### PR TITLE
Add Sleep utility method for ballerina

### DIFF
--- a/modules/ballerina-native/src/main/java/org/wso2/ballerina/nativeimpl/lang/system/Sleep.java
+++ b/modules/ballerina-native/src/main/java/org/wso2/ballerina/nativeimpl/lang/system/Sleep.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ * <p>
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.ballerina.nativeimpl.lang.system;
+
+import org.wso2.ballerina.core.exception.BallerinaException;
+import org.wso2.ballerina.core.interpreter.Context;
+import org.wso2.ballerina.core.model.types.TypeEnum;
+import org.wso2.ballerina.core.model.values.BInteger;
+import org.wso2.ballerina.core.model.values.BValue;
+import org.wso2.ballerina.core.nativeimpl.AbstractNativeFunction;
+import org.wso2.ballerina.core.nativeimpl.annotations.Argument;
+import org.wso2.ballerina.core.nativeimpl.annotations.BallerinaFunction;
+
+/**
+ * Native function ballerina.lang.system:sleep.
+ */
+@BallerinaFunction(
+        packageName = "ballerina.lang.system",
+        functionName = "sleep",
+        args = {@Argument(name = "int", type = TypeEnum.INT)},
+        isPublic = true
+)
+public class Sleep extends AbstractNativeFunction {
+
+    public BValue[] execute(Context ctx) {
+        int timeout = ((BInteger) getArgument(ctx, 0)).intValue();
+        try {
+            Thread.sleep(timeout);
+        } catch (InterruptedException e) {
+            throw new BallerinaException("System sleep has been interrupted", e);
+        }
+        return VOID_RETURN;
+    }
+}

--- a/modules/ballerina-native/src/test/java/org/wso2/ballerina/nativeimpl/functions/SystemTest.java
+++ b/modules/ballerina-native/src/test/java/org/wso2/ballerina/nativeimpl/functions/SystemTest.java
@@ -64,6 +64,12 @@ public class SystemTest {
     }
 
     @Test
+    public void testSleep() {
+        BValueType[] args = {new BInteger(10000)};
+        Functions.invoke(bFile, "testSleep", args);
+    }
+
+    @Test
     public void testStringPrintAndPrintln() throws IOException {
         ByteArrayOutputStream outContent = new ByteArrayOutputStream();
         try {

--- a/modules/ballerina-native/src/test/resources/samples/systemTest.bal
+++ b/modules/ballerina-native/src/test/resources/samples/systemTest.bal
@@ -80,3 +80,7 @@ function testTimeFunctions() {
 function printNewline() {
     system:print("hello\n");
 }
+
+function testSleep(int timeoutv) {
+    system:sleep(timeoutv);
+}


### PR DESCRIPTION
Now users can put a sleep on the ballerina script with the following syntax.

```
system:sleep(10000)
```

In the above, timeout should be an integer which is given as milliseconds.