### PR TITLE
Server connector error handling improvements

### DIFF
--- a/modules/ballerina-core/src/main/java/org/ballerinalang/runtime/ServerConnectorMessageHandler.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/runtime/ServerConnectorMessageHandler.java
@@ -68,7 +68,7 @@ public class ServerConnectorMessageHandler {
             // Find the Service
             Service service = dispatcher.findService(cMsg, callback, balContext);
             if (service == null) {
-                throw new BallerinaException("no Service found to handle the service request", balContext);
+                throw new BallerinaException("no service found to handle the service request", balContext);
                 // Finer details of the errors are thrown from the dispatcher itself, Ideally we shouldn't get here.
             }
 
@@ -80,13 +80,7 @@ public class ServerConnectorMessageHandler {
             }
 
             // Find the Resource
-            Resource resource = null;
-            try {
-                resource = resourceDispatcher.findResource(service, cMsg, callback, balContext);
-            } catch (BallerinaException ex) {
-                throw new BallerinaException("no resource found to handle the request to Service : " +
-                        service.getSymbolName().getName() + " : " + ex.getMessage());
-            }
+            Resource resource = resourceDispatcher.findResource(service, cMsg, callback, balContext);
             if (resource == null) {
                 throw new BallerinaException("no resource found to handle the request to Service : " +
                         service.getSymbolName().getName());
@@ -130,7 +124,7 @@ public class ServerConnectorMessageHandler {
         try {
             optionalErrorHandler
                     .orElseGet(DefaultServerConnectorErrorHandler::getInstance)
-                    .handleError(new BallerinaException(errorMsg, throwable.getCause(), balContext), cMsg, callback);
+                    .handleError(new BallerinaException(errorMsg, throwable, balContext), cMsg, callback);
         } catch (Exception e) {
             throw new BallerinaException("Cannot handle error using the error handler for : " + protocol, e);
         }

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/ResourceDispatcher.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/ResourceDispatcher.java
@@ -20,7 +20,7 @@ package org.ballerinalang.services.dispatchers;
 import org.ballerinalang.bre.Context;
 import org.ballerinalang.model.Resource;
 import org.ballerinalang.model.Service;
-import org.ballerinalang.util.exceptions.BallerinaException;
+import org.ballerinalang.util.exceptions.ResourceNotFoundException;
 import org.wso2.carbon.messaging.CarbonCallback;
 import org.wso2.carbon.messaging.CarbonMessage;
 
@@ -38,9 +38,10 @@ public interface ResourceDispatcher {
      * @param cMsg     Carbon Message
      * @param callback Carbon Messaging Callback
      * @return resource which can handle a given cMsg
+     * @throws ResourceNotFoundException on error if the resource cannot be found.
      */
-    Resource findResource(
-            Service service, CarbonMessage cMsg, CarbonCallback callback, Context balContext) throws BallerinaException;
+    Resource findResource(Service service, CarbonMessage cMsg, CarbonCallback callback, Context balContext)
+            throws ResourceNotFoundException;
 
     String getProtocol();
 

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/ServiceDispatcher.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/ServiceDispatcher.java
@@ -19,6 +19,7 @@ package org.ballerinalang.services.dispatchers;
 
 import org.ballerinalang.bre.Context;
 import org.ballerinalang.model.Service;
+import org.ballerinalang.util.exceptions.ServiceNotFoundException;
 import org.wso2.carbon.messaging.CarbonCallback;
 import org.wso2.carbon.messaging.CarbonMessage;
 
@@ -36,8 +37,10 @@ public interface ServiceDispatcher {
      * @param cMsg Carbon Message
      * @param callback callback
      * @return service which can handle a given cMsg
+     * @throws ServiceNotFoundException on error if the service cannot be found.
      */
-    Service findService(CarbonMessage cMsg, CarbonCallback callback, Context balContext);
+    Service findService(CarbonMessage cMsg, CarbonCallback callback, Context balContext)
+            throws ServiceNotFoundException;
 
     /**
      * Get the protocol of the dispatcher.

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/file/FileResourceDispatcher.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/file/FileResourceDispatcher.java
@@ -23,6 +23,7 @@ import org.ballerinalang.model.Resource;
 import org.ballerinalang.model.Service;
 import org.ballerinalang.services.dispatchers.ResourceDispatcher;
 import org.ballerinalang.util.exceptions.BallerinaException;
+import org.ballerinalang.util.exceptions.ResourceNotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.messaging.CarbonCallback;
@@ -36,7 +37,7 @@ public class FileResourceDispatcher implements ResourceDispatcher {
 
     @Override
     public Resource findResource(Service service, CarbonMessage cMsg, CarbonCallback callback,
-            Context balContext) throws BallerinaException {
+            Context balContext) throws ResourceNotFoundException {
         if (log.isDebugEnabled()) {
             log.debug("Starting to find resource in the file service " + service.getSymbolName().toString() + " to "
                     + "deliver the message");

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/file/FileServiceDispatcher.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/file/FileServiceDispatcher.java
@@ -25,6 +25,7 @@ import org.ballerinalang.model.SymbolName;
 import org.ballerinalang.natives.connectors.BallerinaConnectorManager;
 import org.ballerinalang.services.dispatchers.ServiceDispatcher;
 import org.ballerinalang.util.exceptions.BallerinaException;
+import org.ballerinalang.util.exceptions.ServiceNotFoundException;
 import org.wso2.carbon.messaging.CarbonCallback;
 import org.wso2.carbon.messaging.CarbonMessage;
 import org.wso2.carbon.messaging.ServerConnector;
@@ -42,15 +43,16 @@ public class FileServiceDispatcher implements ServiceDispatcher {
     Map<String, Service> servicesMap = new HashMap<>();
 
     @Override
-    public Service findService(CarbonMessage cMsg, CarbonCallback callback, Context balContext) {
+    public Service findService(CarbonMessage cMsg, CarbonCallback callback, Context balContext)
+            throws ServiceNotFoundException {
         Object serviceNameProperty = cMsg.getProperty(Constants.TRANSPORT_PROPERTY_SERVICE_NAME);
         String serviceName = (serviceNameProperty != null) ? serviceNameProperty.toString() : null;
         if (serviceName == null) {
-            throw new BallerinaException("Service name is not found with the file input stream.", balContext);
+            throw new ServiceNotFoundException("Service name is not found with the file input stream.", balContext);
         }
         Service service = servicesMap.get(serviceName);
         if (service == null) {
-            throw new BallerinaException("No file service is registered with the service name " + serviceName,
+            throw new ServiceNotFoundException("No file service is registered with the service name " + serviceName,
                     balContext);
         }
         return service;

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/file/FileServiceDispatcher.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/file/FileServiceDispatcher.java
@@ -48,11 +48,11 @@ public class FileServiceDispatcher implements ServiceDispatcher {
         Object serviceNameProperty = cMsg.getProperty(Constants.TRANSPORT_PROPERTY_SERVICE_NAME);
         String serviceName = (serviceNameProperty != null) ? serviceNameProperty.toString() : null;
         if (serviceName == null) {
-            throw new ServiceNotFoundException("Service name is not found with the file input stream.", balContext);
+            throw new ServiceNotFoundException("service name is not found with the file input stream.", balContext);
         }
         Service service = servicesMap.get(serviceName);
         if (service == null) {
-            throw new ServiceNotFoundException("No file service is registered with the service name " + serviceName,
+            throw new ServiceNotFoundException("no file service is registered with the service name " + serviceName,
                     balContext);
         }
         return service;

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/http/HTTPErrorHandler.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/http/HTTPErrorHandler.java
@@ -17,9 +17,9 @@
  */
 package org.ballerinalang.services.dispatchers.http;
 
+import org.ballerinalang.util.exceptions.ResourceNotFoundException;
+import org.ballerinalang.util.exceptions.ServiceNotFoundException;
 import org.osgi.service.component.annotations.Component;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.wso2.carbon.messaging.CarbonCallback;
 import org.wso2.carbon.messaging.CarbonMessage;
 import org.wso2.carbon.messaging.DefaultCarbonMessage;
@@ -38,11 +38,14 @@ import java.util.Map;
         service = ServerConnectorErrorHandler.class)
 public class HTTPErrorHandler implements ServerConnectorErrorHandler {
 
-    private static final Logger log = LoggerFactory.getLogger(HTTPErrorHandler.class);
-
     @Override
-    public void handleError(Exception e, CarbonMessage carbonMessage, CarbonCallback callback) {
-        callback.done(createErrorMessage(e.getMessage(), 500));
+    public void handleError(Exception exception, CarbonMessage carbonMessage, CarbonCallback callback) {
+        if (exception.getCause() instanceof ServiceNotFoundException ||
+                exception.getCause() instanceof ResourceNotFoundException) {
+            callback.done(createErrorMessage(exception.getMessage(), 404));
+        } else {
+            callback.done(createErrorMessage(exception.getMessage(), 500));
+        }
     }
 
     @Override

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/jms/JMSResourceDispatcher.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/jms/JMSResourceDispatcher.java
@@ -44,12 +44,12 @@ public class JMSResourceDispatcher implements ResourceDispatcher {
         }
         Resource[] resources = service.getResources();
         if (resources.length == 0) {
-            throw new BallerinaException("No resources found to handle the JMS message in " + service.getSymbolName()
-                    .toString(), balContext);
+            throw new ResourceNotFoundException("no resources found to handle the jms message in " +
+                    service.getSymbolName().toString(), balContext);
         }
         if (resources.length > 1) {
-            throw new BallerinaException("More than one resources found in JMS service " + service.getSymbolName()
-                    .toString() + ".JMS Service should only have one resource", balContext);
+            throw new BallerinaException("more than one resources found in jms service " + service.getSymbolName()
+                    .toString() + ". jms service should only have one resource", balContext);
         }
         return resources[0];
     }

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/jms/JMSResourceDispatcher.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/jms/JMSResourceDispatcher.java
@@ -23,6 +23,7 @@ import org.ballerinalang.model.Resource;
 import org.ballerinalang.model.Service;
 import org.ballerinalang.services.dispatchers.ResourceDispatcher;
 import org.ballerinalang.util.exceptions.BallerinaException;
+import org.ballerinalang.util.exceptions.ResourceNotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.messaging.CarbonCallback;
@@ -36,7 +37,7 @@ public class JMSResourceDispatcher implements ResourceDispatcher {
 
     @Override
     public Resource findResource(Service service, CarbonMessage cMsg, CarbonCallback callback, Context balContext)
-            throws BallerinaException {
+            throws ResourceNotFoundException {
         if (log.isDebugEnabled()) {
             log.debug("Starting to find resource in the jms service " + service.getSymbolName().toString() + " to "
                             + "deliver the message");

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/jms/JMSServiceDispatcher.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/jms/JMSServiceDispatcher.java
@@ -25,6 +25,7 @@ import org.ballerinalang.model.SymbolName;
 import org.ballerinalang.natives.connectors.BallerinaConnectorManager;
 import org.ballerinalang.services.dispatchers.ServiceDispatcher;
 import org.ballerinalang.util.exceptions.BallerinaException;
+import org.ballerinalang.util.exceptions.ServiceNotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.messaging.CarbonCallback;
@@ -46,15 +47,16 @@ public class JMSServiceDispatcher implements ServiceDispatcher {
     private Map<String, Service> serviceMap = new HashMap<>();
 
     @Override
-    public Service findService(CarbonMessage cMsg, CarbonCallback callback, Context balContext) {
+    public Service findService(CarbonMessage cMsg, CarbonCallback callback, Context balContext)
+            throws ServiceNotFoundException {
         Object serviceIdProperty = cMsg.getProperty(Constants.JMS_SERVICE_ID);
         String serviceId = (serviceIdProperty != null) ? serviceIdProperty.toString() : null;
         if (serviceId == null) {
-            throw new BallerinaException("Service Id is not found in JMS Message", balContext);
+            throw new ServiceNotFoundException("Service Id is not found in JMS Message", balContext);
         }
         Service service = serviceMap.get(serviceId);
         if (service == null) {
-            throw new BallerinaException("No jms service is registered with the service id " + serviceId,
+            throw new ServiceNotFoundException("No jms service is registered with the service id " + serviceId,
                     balContext);
         }
         return service;

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/jms/JMSServiceDispatcher.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/jms/JMSServiceDispatcher.java
@@ -52,11 +52,11 @@ public class JMSServiceDispatcher implements ServiceDispatcher {
         Object serviceIdProperty = cMsg.getProperty(Constants.JMS_SERVICE_ID);
         String serviceId = (serviceIdProperty != null) ? serviceIdProperty.toString() : null;
         if (serviceId == null) {
-            throw new ServiceNotFoundException("Service Id is not found in JMS Message", balContext);
+            throw new ServiceNotFoundException("service id is not found in jms message", balContext);
         }
         Service service = serviceMap.get(serviceId);
         if (service == null) {
-            throw new ServiceNotFoundException("No jms service is registered with the service id " + serviceId,
+            throw new ServiceNotFoundException("no jms service is registered with the service id " + serviceId,
                     balContext);
         }
         return service;

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/websocket/WebSocketResourceDispatcher.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/websocket/WebSocketResourceDispatcher.java
@@ -25,6 +25,7 @@ import org.ballerinalang.model.Service;
 import org.ballerinalang.services.dispatchers.ResourceDispatcher;
 import org.ballerinalang.services.dispatchers.http.Constants;
 import org.ballerinalang.util.exceptions.BallerinaException;
+import org.ballerinalang.util.exceptions.ResourceNotFoundException;
 import org.wso2.carbon.messaging.BinaryCarbonMessage;
 import org.wso2.carbon.messaging.CarbonCallback;
 import org.wso2.carbon.messaging.CarbonMessage;
@@ -41,7 +42,7 @@ public class WebSocketResourceDispatcher implements ResourceDispatcher {
 
     @Override
     public Resource findResource(Service service, CarbonMessage cMsg, CarbonCallback callback, Context balContext)
-            throws BallerinaException {
+            throws ResourceNotFoundException {
 
         try {
             if (cMsg instanceof TextCarbonMessage) {
@@ -69,7 +70,7 @@ public class WebSocketResourceDispatcher implements ResourceDispatcher {
             throw new BallerinaException("Error occurred in WebSocket resource dispatchers : " + e.getMessage(),
                                          balContext);
         }
-        throw new BallerinaException("No matching Resource found for dispatchers.");
+        throw new ResourceNotFoundException("No matching Resource found for dispatchers.");
     }
 
     @Override

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/websocket/WebSocketResourceDispatcher.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/websocket/WebSocketResourceDispatcher.java
@@ -67,10 +67,10 @@ public class WebSocketResourceDispatcher implements ResourceDispatcher {
                 }
             }
         } catch (Throwable e) {
-            throw new BallerinaException("Error occurred in WebSocket resource dispatchers : " + e.getMessage(),
+            throw new BallerinaException("error occurred in web-socket resource dispatchers : " + e.getMessage(),
                                          balContext);
         }
-        throw new ResourceNotFoundException("No matching Resource found for dispatchers.");
+        throw new ResourceNotFoundException("no matching resource found for dispatchers.");
     }
 
     @Override

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/websocket/WebSocketServiceDispatcher.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/websocket/WebSocketServiceDispatcher.java
@@ -51,27 +51,27 @@ public class WebSocketServiceDispatcher extends HTTPServiceDispatcher {
         String serviceUri = (String) cMsg.getProperty(Constants.TO);
         serviceUri = refactorUri(serviceUri);
         if (serviceUri == null) {
-            throw new ServiceNotFoundException("No service found to dispatch");
+            throw new ServiceNotFoundException("no service found to dispatch");
         }
         String basePath = URIUtil.getFirstPathSegment(serviceUri);
         Service service = HTTPServicesRegistry.getInstance().
                 getService(interfaceId, Constants.DEFAULT_BASE_PATH + basePath);
 
         if (service == null) {
-            throw new ServiceNotFoundException("No service found to handle message for " + serviceUri);
+            throw new ServiceNotFoundException("no service found to handle message for " + serviceUri);
         }
 
 
         String webSocketUpgradePath = findWebSocketUpgradePath(service);
         if (webSocketUpgradePath == null) {
-            throw new ServiceNotFoundException("No service found to handle message for " + serviceUri);
+            throw new ServiceNotFoundException("no service found to handle message for " + serviceUri);
         }
 
         if (webSocketUpgradePath.equals(serviceUri)) {
             return service;
         }
 
-        throw new ServiceNotFoundException("No service found to handle message for " + serviceUri);
+        throw new ServiceNotFoundException("no service found to handle message for " + serviceUri);
     }
 
     @Override
@@ -101,7 +101,7 @@ public class WebSocketServiceDispatcher extends HTTPServiceDispatcher {
         }
         if (websocketUpgradePathAnnotation != null && websocketUpgradePathAnnotation.getValue() != null) {
             if (basePathAnnotation == null) {
-                throw new BallerinaException("Cannot define @WebSocketPathUpgrade without @BasePath");
+                throw new BallerinaException("cannot define @WebSocketPathUpgrade without @BasePath");
             }
 
             String basePath = refactorUri(basePathAnnotation.getValue());

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/websocket/WebSocketServiceDispatcher.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/websocket/WebSocketServiceDispatcher.java
@@ -27,6 +27,7 @@ import org.ballerinalang.services.dispatchers.http.HTTPServiceDispatcher;
 import org.ballerinalang.services.dispatchers.http.HTTPServicesRegistry;
 import org.ballerinalang.services.dispatchers.uri.URIUtil;
 import org.ballerinalang.util.exceptions.BallerinaException;
+import org.ballerinalang.util.exceptions.ServiceNotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.messaging.CarbonCallback;
@@ -43,33 +44,34 @@ public class WebSocketServiceDispatcher extends HTTPServiceDispatcher {
     private static final Logger logger = LoggerFactory.getLogger(WebSocketServiceDispatcher.class);
 
     @Override
-    public Service findService(CarbonMessage cMsg, CarbonCallback callback, Context balContext) {
+    public Service findService(CarbonMessage cMsg, CarbonCallback callback, Context balContext)
+            throws ServiceNotFoundException {
         String interfaceId = getInterface(cMsg);
 
         String serviceUri = (String) cMsg.getProperty(Constants.TO);
         serviceUri = refactorUri(serviceUri);
         if (serviceUri == null) {
-            throw new BallerinaException("No service found to dispatch");
+            throw new ServiceNotFoundException("No service found to dispatch");
         }
         String basePath = URIUtil.getFirstPathSegment(serviceUri);
         Service service = HTTPServicesRegistry.getInstance().
                 getService(interfaceId, Constants.DEFAULT_BASE_PATH + basePath);
 
         if (service == null) {
-            throw new BallerinaException("No service found to handle message for " + serviceUri);
+            throw new ServiceNotFoundException("No service found to handle message for " + serviceUri);
         }
 
 
         String webSocketUpgradePath = findWebSocketUpgradePath(service);
         if (webSocketUpgradePath == null) {
-            throw new BallerinaException("No service found to handle message for " + serviceUri);
+            throw new ServiceNotFoundException("No service found to handle message for " + serviceUri);
         }
 
         if (webSocketUpgradePath.equals(serviceUri)) {
             return service;
         }
 
-        throw new BallerinaException("No service found to handle message for " + serviceUri);
+        throw new ServiceNotFoundException("No service found to handle message for " + serviceUri);
     }
 
     @Override

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/util/exceptions/ResourceNotFoundException.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/util/exceptions/ResourceNotFoundException.java
@@ -17,6 +17,8 @@
  */
 package org.ballerinalang.util.exceptions;
 
+import org.ballerinalang.bre.Context;
+
 /**
  * {@code ResourceNotFoundException} is thrown when resource not found related errors occur with resource dispatching
  * during ballerina runtime execution.
@@ -25,6 +27,10 @@ package org.ballerinalang.util.exceptions;
 public class ResourceNotFoundException extends BallerinaException {
     public ResourceNotFoundException(String message) {
         super(message);
+    }
+
+    public ResourceNotFoundException(String message, Context context) {
+        super(message, context);
     }
 
     public ResourceNotFoundException(String message, Throwable cause) {

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/util/exceptions/ResourceNotFoundException.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/util/exceptions/ResourceNotFoundException.java
@@ -22,7 +22,7 @@ package org.ballerinalang.util.exceptions;
  *
  * @since 0.8.1
  */
-public class ResourceNotFoundException extends Exception {
+public class ResourceNotFoundException extends BallerinaException {
     public ResourceNotFoundException(String message) {
         super(message);
     }

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/util/exceptions/ResourceNotFoundException.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/util/exceptions/ResourceNotFoundException.java
@@ -18,9 +18,9 @@
 package org.ballerinalang.util.exceptions;
 
 /**
- * {@code ResourceNotFoundException} is used to handle resource not found related errors with resource dispatching.
+ * {@code ResourceNotFoundException} is thrown when resource not found related errors occur with resource dispatching
+ * during ballerina runtime execution.
  *
- * @since 0.8.1
  */
 public class ResourceNotFoundException extends BallerinaException {
     public ResourceNotFoundException(String message) {

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/util/exceptions/ResourceNotFoundException.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/util/exceptions/ResourceNotFoundException.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.util.exceptions;
+
+/**
+ * {@code ResourceNotFoundException} is used to handle resource not found related errors with resource dispatching.
+ *
+ * @since 0.8.1
+ */
+public class ResourceNotFoundException extends Exception {
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+
+    public ResourceNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/util/exceptions/ResourceNotFoundException.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/util/exceptions/ResourceNotFoundException.java
@@ -25,15 +25,23 @@ import org.ballerinalang.bre.Context;
  *
  */
 public class ResourceNotFoundException extends BallerinaException {
+
+    /**
+     * Constructs a new {@link ResourceNotFoundException} with the specified detail message.
+     *
+     * @param message Error Message
+     */
     public ResourceNotFoundException(String message) {
         super(message);
     }
 
+    /**
+     * Constructs a new {@link ResourceNotFoundException} with ballerina context.
+     *
+     * @param message Error message
+     * @param context Ballerina context
+     */
     public ResourceNotFoundException(String message, Context context) {
         super(message, context);
-    }
-
-    public ResourceNotFoundException(String message, Throwable cause) {
-        super(message, cause);
     }
 }

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/util/exceptions/ServiceNotFoundException.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/util/exceptions/ServiceNotFoundException.java
@@ -26,19 +26,23 @@ import org.ballerinalang.bre.Context;
  */
 public class ServiceNotFoundException extends BallerinaException {
 
-    public ServiceNotFoundException(String message, Context context) {
-        super(message, context);
-    }
-
-    public ServiceNotFoundException(String message, Throwable cause, Context context) {
-        super(message, cause, context);
-    }
-
+    /**
+     * Constructs a new {@link ServiceNotFoundException} with the specified detail message.
+     *
+     * @param message Error Message
+     */
     public ServiceNotFoundException(String message) {
         super(message);
     }
 
-    public ServiceNotFoundException(String message, Throwable cause) {
-        super(message, cause);
+    /**
+     * Constructs a new {@link ServiceNotFoundException} with ballerina context.
+     *
+     * @param message Error message
+     * @param context Ballerina context
+     */
+    public ServiceNotFoundException(String message, Context context) {
+        super(message, context);
     }
+
 }

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/util/exceptions/ServiceNotFoundException.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/util/exceptions/ServiceNotFoundException.java
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.util.exceptions;
+
+import org.ballerinalang.bre.Context;
+
+/**
+ * {@code ServiceNotFoundException} is used to handle service not found related errors with service dispatching.
+ *
+ * @since 0.8.1
+ */
+public class ServiceNotFoundException extends Exception {
+    private transient Context context;
+
+    public ServiceNotFoundException(String message, Context context) {
+        super(message);
+        this.context = context;
+    }
+
+    public ServiceNotFoundException(String message, Throwable cause, Context context) {
+        super(message, cause);
+        this.context = context;
+    }
+
+    public ServiceNotFoundException(String message) {
+        super(message);
+    }
+
+    public ServiceNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public Context getContext() {
+        return this.context;
+    }
+}

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/util/exceptions/ServiceNotFoundException.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/util/exceptions/ServiceNotFoundException.java
@@ -24,17 +24,14 @@ import org.ballerinalang.bre.Context;
  *
  * @since 0.8.1
  */
-public class ServiceNotFoundException extends Exception {
-    private transient Context context;
+public class ServiceNotFoundException extends BallerinaException {
 
     public ServiceNotFoundException(String message, Context context) {
-        super(message);
-        this.context = context;
+        super(message, context);
     }
 
     public ServiceNotFoundException(String message, Throwable cause, Context context) {
-        super(message, cause);
-        this.context = context;
+        super(message, cause, context);
     }
 
     public ServiceNotFoundException(String message) {
@@ -43,9 +40,5 @@ public class ServiceNotFoundException extends Exception {
 
     public ServiceNotFoundException(String message, Throwable cause) {
         super(message, cause);
-    }
-
-    public Context getContext() {
-        return this.context;
     }
 }

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/util/exceptions/ServiceNotFoundException.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/util/exceptions/ServiceNotFoundException.java
@@ -20,9 +20,9 @@ package org.ballerinalang.util.exceptions;
 import org.ballerinalang.bre.Context;
 
 /**
- * {@code ServiceNotFoundException} is used to handle service not found related errors with service dispatching.
+ * {@code ServiceNotFoundException} is thrown when service not found related errors occur with service dispatching
+ * during ballerina runtime execution.
  *
- * @since 0.8.1
  */
 public class ServiceNotFoundException extends BallerinaException {
 

--- a/pom.xml
+++ b/pom.xml
@@ -458,7 +458,7 @@
         <carbon.kernel.package.import.version.range>[5.0.0, 6.0.0)</carbon.kernel.package.import.version.range>
         <carbon.kernel.pax.version>5.2.0-m2</carbon.kernel.pax.version>
 
-        <carbon.transport.version>4.2.5</carbon.transport.version>
+        <carbon.transport.version>4.2.6-SNAPSHOT</carbon.transport.version>
         <carbon.transport.package.import.version.range>[4.0.0, 5.0.0)</carbon.transport.package.import.version.range>
 
         <carbon.messaging.version>2.2.3</carbon.messaging.version>


### PR DESCRIPTION
- This PR depends on https://github.com/wso2/carbon-transports/pull/220 and the release of carbon-transports 4.2.6

- This PR uses a similar approach proposed in https://github.com/ballerinalang/ballerina/pull/1865 to handle 404 status code, but since the error handler is now at bellerina level, creating http status code specific messages can be done within the error handler.