### PR TITLE
Change Mac OS logic for getting JAVA_HOME

### DIFF
--- a/modules/distribution/ballerina-home/bin/ballerina
+++ b/modules/distribution/ballerina-home/bin/ballerina
@@ -41,15 +41,15 @@ CYGWIN*) cygwin=true;;
 MINGW*) mingw=true;;
 OS400*) os400=true;;
 Darwin*) darwin=true
-        if [ -z "$JAVA_VERSION" ] ; then
-             JAVA_VERSION="CurrentJDK"
+        if [ -z "$JAVA_HOME" ] ; then
+		   if [ -z "$JAVA_VERSION" ] ; then
+			 JAVA_HOME=$(/usr/libexec/java_home)
            else
              echo "Using Java version: $JAVA_VERSION"
-           fi
-           if [ -z "$JAVA_HOME" ] ; then
-             JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
-           fi
-           ;;
+			 JAVA_HOME=$(/usr/libexec/java_home -v $JAVA_VERSION)
+		   fi
+	    fi
+        ;;
 esac
 
 # resolve links - $0 may be a softlink


### PR DESCRIPTION
The previous logic only worked for java installs done through homebrew
cask. Installs done by Oracles official installer do not update the
/System/.../CurrentJDK/ link. The /usr/libexec/java_home command is
updated by both the Oracle installer and the Cask installer, and is a
more reliable way of getting the JAVA_HOME for the current jdk as well
as JDKs of other versions.