### PR TITLE
Fixing MD5 and SHA1 Hashing

### DIFF
--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/utils/GetHash.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/utils/GetHash.java
@@ -69,8 +69,10 @@ public class GetHash extends AbstractNativeFunction {
 
         //todo document the supported algorithm
         switch (algorithm) {
-            case "SHA1":
-            case "SHA256":
+            case "SHA1": algorithm = "SHA-1";
+                break;
+            case "SHA256": algorithm = "SHA-256";
+                break;
             case "MD5":
                 break;
             default:
@@ -82,7 +84,7 @@ public class GetHash extends AbstractNativeFunction {
         try {
             baseString = baseString.replace("\\n", "\n");
             MessageDigest messageDigest = null;
-            messageDigest = MessageDigest.getInstance("SHA-256");
+            messageDigest = MessageDigest.getInstance(algorithm);
             messageDigest.update(baseString.getBytes("UTF-8"));
             byte[] bytes = messageDigest.digest();
 


### PR DESCRIPTION
Before the fix, for MD5 and SHA1, it always returned the SHA256 hash value. With this PR, MD5 and SHA1 hashing is corrected.