### PR TITLE
Add clone functionality to messages

### DIFF
--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/lang/messages/Clone.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/lang/messages/Clone.java
@@ -58,33 +58,6 @@ public class Clone  extends AbstractNativeFunction {
             LOG.debug("Invoke message clone.");
         }
         BMessage msg = (BMessage) getArgument(context, 0);
-        return getBValues(getCopyOfMessage(msg));
-    }
-
-    private BMessage getCopyOfMessage(BMessage originalMessage) {
-
-        // Fix this
-        throw new RuntimeException("Not supported yet");
-//        MessageValue newMessageObj = new MessageValue(new DefaultCarbonMessage());
-//        try {
-//            // Clone headers
-//            List<Header> allHeaders = originalMessage.getHeaders();
-//            newMessageObj.setHeaderList(allHeaders);
-//
-//            // Clone payload
-//            if (originalMessage.isAlreadyRead()) {
-//                newMessageObj.setBuiltPayload(MessageUtils.getBValueCopy(originalMessage.getBuiltPayload()));
-//            } else {
-//                String payload = MessageUtils.getStringFromInputStream(originalMessage.value().getInputStream());
-//                BString result = new BString(payload);
-//                newMessageObj.setBuiltPayload(result);
-//                originalMessage.setBuiltPayload(result);
-//            }
-//            newMessageObj.setAlreadyRead(true);
-//        } catch (Throwable e) {
-//            throw new BallerinaException("Error while cloning message: " + e.getMessage());
-//        }
-        
-//        return newMessageObj;
+        return getBValues(msg.clone());
     }
 }

--- a/modules/ballerina-native/src/test/java/org/ballerinalang/nativeimpl/functions/MessageTest.java
+++ b/modules/ballerina-native/src/test/java/org/ballerinalang/nativeimpl/functions/MessageTest.java
@@ -181,16 +181,13 @@ public class MessageTest {
 
     @Test
     public void testClone() {
-        /*final String payload1 = "Hello World...!!! I am the Original Copy.";
+        final String payload1 = "Hello World...!!! I am the Original Copy.";
         final String payload2 = "Hello World...!!! I am the Cloned Copy.";
         DefaultCarbonMessage carbonMsg = new DefaultCarbonMessage();
         carbonMsg.setStringMessageBody(payload1);
         BValue[] args = {new BMessage(carbonMsg), new BString(payload2)};
-        FunctionInvocationExpr funcIExpr = FunctionUtils.createInvocationExpr(bLangProgram, "testClone", args.length);
-        Context bContext = FunctionUtils.createInvocationContext(args, 1);
-        BLangInterpreter bLangInterpreter = new BLangInterpreter(bContext);
-        funcIExpr.accept(bLangInterpreter);
-        Assert.assertEquals(FunctionUtils.getReturnBValue(bContext).intValue(), 1);*/
+        BValue[] returns = BLangFunctions.invoke(bLangProgram, "testClone", args);
+        Assert.assertEquals(returns[0].stringValue(), "1");
     }
 
     @Test

--- a/modules/ballerina-native/src/test/resources/samples/messageTest.bal
+++ b/modules/ballerina-native/src/test/resources/samples/messageTest.bal
@@ -1,5 +1,4 @@
 import ballerina.lang.messages;
-import ballerina.lang.system;
 
 function testGetJSONPayload(message msg) (json){
     return messages:getJsonPayload(msg);
@@ -63,8 +62,7 @@ function testClone(message msg, string payload2) (int) {
 
     v1 = messages:getStringPayload(msg);
     v2 = messages:getStringPayload(clone);
-    system:log(3, v1);
-    system:log(3, v2);
+
     if( v1 != payload2 ) {
         state = 1;
     } else {


### PR DESCRIPTION
This PR will add the support for message clone function. Here is a test function to verify the clone functionality.
```
function testClone(message msg, string payload2) (int) {
    message clone;
    string v1;
    string v2;
    int state;

    state = 0;
    clone = messages:clone(msg);
    messages:setStringPayload(clone, payload2);

    v1 = messages:getStringPayload(msg);
    v2 = messages:getStringPayload(clone);

    if( v1 != payload2 ) {
        state = 1;
    } else {
        state = 2;
    }
    return state;
}
```