### PR TITLE
Fixing Built in struct type loading issue in Windows #2185

### DIFF
--- a/modules/ballerina-core/src/main/java/org/ballerinalang/util/repository/BuiltinPackageRepository.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/util/repository/BuiltinPackageRepository.java
@@ -42,7 +42,7 @@ import java.util.zip.ZipInputStream;
 public class BuiltinPackageRepository extends PackageRepository {
 
     private Class<?> nativePackageProvider;
-    private static final String BASE_DIR = "META-INF" + File.separator + "natives" + File.separator;
+    private static final String BASE_DIR = "META-INF/natives/";
     private static final String BAL_FILE_EXT = ".bal";
     private static final String NATIVE_BAL_FILE = "natives.bal";
     private static final String FALSE = "false";
@@ -63,7 +63,7 @@ public class BuiltinPackageRepository extends PackageRepository {
             skipNatives = false;
         }
         
-        this.packageDirPath = packageDirPath.toString();
+        this.packageDirPath = packageDirPath.toString().replace("\\", "/");
         Map<String, InputStream> sourceFileStreamMap = new HashMap<String, InputStream>();
         ClassLoader classLoader = nativePackageProvider.getClassLoader();
 
@@ -72,8 +72,8 @@ public class BuiltinPackageRepository extends PackageRepository {
 
         // Read all resources as input streams and create the package source 
         for (String fileName : fileNames) {
-            InputStream balSourceStream = classLoader.getResourceAsStream(BASE_DIR + packageDirPath.toString()
-                    + File.separator + fileName);
+            InputStream balSourceStream = classLoader.getResourceAsStream(BASE_DIR + this.packageDirPath
+                    + "/" + fileName);
             sourceFileStreamMap.put(fileName, balSourceStream);
         }
         return new PackageSource(packageDirPath, sourceFileStreamMap, this);


### PR DESCRIPTION
Fixing #2185
Path separator in ZIP files should always a forward slash (/) [1] , even on other platforms such as Windows, where the normal path separator is something different such as a backslash. 

[1] https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT