### PR TITLE
Add an overloaded constructor to antlr listener

### DIFF
--- a/modules/ballerina-core/src/main/java/org/ballerinalang/util/parser/antlr4/BLangAntlr4Listener.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/util/parser/antlr4/BLangAntlr4Listener.java
@@ -102,6 +102,10 @@ public class BLangAntlr4Listener implements BallerinaListener {
         }
     }
 
+    public BLangAntlr4Listener(BLangModelBuilder modelBuilder) {
+        this.modelBuilder = modelBuilder;
+    }
+
     @Override
     public void enterCompilationUnit(BallerinaParser.CompilationUnitContext ctx) {
     }


### PR DESCRIPTION
There are some use cases with composer where we
want to parse a file which is not persisted to
disk yet. Furthermore, when the cloud based composer
comes into play, we will need parser to just
work for a given string input