### PR TITLE
Add Batch update support for SQLConnector

### DIFF
--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/connectors/data/sql/client/AbstractSQLAction.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/connectors/data/sql/client/AbstractSQLAction.java
@@ -161,6 +161,54 @@ public abstract class AbstractSQLAction extends AbstractNativeAction {
         }
     }
 
+    protected void executeBatchUpdate(Context context, SQLConnector connector, String query, BArray parameters) {
+        BArray parameterstemp = generateTestData(parameters);
+        Connection conn = null;
+        PreparedStatement stmt = null;
+        try {
+            conn = connector.getSQLConnection();
+            stmt = conn.prepareStatement(query);
+            setConnectionAutoCommit(conn, false);
+
+            int paramArrayCount = parameterstemp.size();
+            for (int index = 0; index < paramArrayCount; index++) {
+                BArray params = (BArray) parameterstemp.get(index);
+                createProcessedStatement(conn, stmt, params);
+                stmt.addBatch();
+            }
+            int[] updatedCount = stmt.executeBatch();
+            BArray<BInteger> arrayValue = new BArray<>(BInteger.class);
+            int iSize = updatedCount.length;
+            for (int i = 0; i < iSize; ++i) {
+                arrayValue.add(i, new BInteger(updatedCount[i]));
+            }
+            conn.commit();
+            context.getControlStack().setReturnValue(0, arrayValue);
+        } catch (SQLException e) {
+            throw new BallerinaException("execute update failed: " + e.getMessage(), e);
+        } finally {
+            setConnectionAutoCommit(conn, true);
+            SQLConnectorUtils.cleanupConnection(null, stmt, conn);
+        }
+    }
+
+    private void setConnectionAutoCommit(Connection conn, boolean status) {
+        try {
+            if (conn != null) {
+                conn.setAutoCommit(status);
+            }
+        } catch (SQLException e) {
+            throw new BallerinaException("set connection commit status failed: " + e.getMessage(), e);
+        }
+    }
+
+    private BArray generateTestData(BArray parameters) {
+        BArray<BArray> tempParameters = new BArray<>(BArray.class);
+        tempParameters.add(0, parameters);
+        tempParameters.add(1, parameters);
+        return tempParameters;
+    }
+
     protected void closeConnections(SQLConnector connector) {
         connector.closeConnectionPool();
     }

--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/connectors/data/sql/client/AbstractSQLAction.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/connectors/data/sql/client/AbstractSQLAction.java
@@ -162,27 +162,25 @@ public abstract class AbstractSQLAction extends AbstractNativeAction {
     }
 
     protected void executeBatchUpdate(Context context, SQLConnector connector, String query, BArray parameters) {
-        BArray parameterstemp = generateTestData(parameters);
         Connection conn = null;
         PreparedStatement stmt = null;
         try {
             conn = connector.getSQLConnection();
             stmt = conn.prepareStatement(query);
             setConnectionAutoCommit(conn, false);
-
-            int paramArrayCount = parameterstemp.size();
+            int paramArrayCount = parameters.size();
             for (int index = 0; index < paramArrayCount; index++) {
-                BArray params = (BArray) parameterstemp.get(index);
+                BArray params = (BArray) parameters.get(index);
                 createProcessedStatement(conn, stmt, params);
                 stmt.addBatch();
             }
             int[] updatedCount = stmt.executeBatch();
+            conn.commit();
             BArray<BInteger> arrayValue = new BArray<>(BInteger.class);
             int iSize = updatedCount.length;
             for (int i = 0; i < iSize; ++i) {
                 arrayValue.add(i, new BInteger(updatedCount[i]));
             }
-            conn.commit();
             context.getControlStack().setReturnValue(0, arrayValue);
         } catch (SQLException e) {
             throw new BallerinaException("execute update failed: " + e.getMessage(), e);
@@ -200,13 +198,6 @@ public abstract class AbstractSQLAction extends AbstractNativeAction {
         } catch (SQLException e) {
             throw new BallerinaException("set connection commit status failed: " + e.getMessage(), e);
         }
-    }
-
-    private BArray generateTestData(BArray parameters) {
-        BArray<BArray> tempParameters = new BArray<>(BArray.class);
-        tempParameters.add(0, parameters);
-        tempParameters.add(1, parameters);
-        return tempParameters;
     }
 
     protected void closeConnections(SQLConnector connector) {

--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/connectors/data/sql/client/BatchUpdate.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/connectors/data/sql/client/BatchUpdate.java
@@ -44,6 +44,7 @@ import org.osgi.service.component.annotations.Component;
                 @Argument(name = "parameters",
                           type = TypeEnum.ARRAY,
                           elementType = TypeEnum.STRUCT,
+                          arrayDimensions = 2,
                           structType = "Parameter")
         },
         returnType = { @ReturnType(type = TypeEnum.ARRAY, elementType = TypeEnum.INT) })

--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/connectors/data/sql/client/BatchUpdate.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/connectors/data/sql/client/BatchUpdate.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.ballerinalang.nativeimpl.connectors.data.sql.client;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.Connector;
+import org.ballerinalang.model.types.TypeEnum;
+import org.ballerinalang.model.values.BArray;
+import org.ballerinalang.model.values.BConnector;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.nativeimpl.connectors.data.sql.SQLConnector;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaAction;
+import org.ballerinalang.natives.annotations.ReturnType;
+import org.ballerinalang.natives.connectors.AbstractNativeAction;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * {@code BatchUpdate} is the Batch update action implementation of the SQL Connector.
+ *
+ * @since 0.8.6
+ */
+@BallerinaAction(
+        packageName = "ballerina.data.sql",
+        actionName = "batchUpdate",
+        connectorName = SQLConnector.CONNECTOR_NAME,
+        args = {@Argument(name = "c", type = TypeEnum.CONNECTOR),
+                @Argument(name = "query", type = TypeEnum.STRING),
+                @Argument(name = "parameters",
+                          type = TypeEnum.ARRAY,
+                          elementType = TypeEnum.STRUCT,
+                          structType = "Parameter")
+        },
+        returnType = { @ReturnType(type = TypeEnum.ARRAY, elementType = TypeEnum.INT) })
+@Component(
+        name = "action.data.sql.BatchUpdate",
+        immediate = true,
+        service = AbstractNativeAction.class)
+public class BatchUpdate extends AbstractSQLAction {
+    @Override
+    public BValue execute(Context context) {
+        BConnector bConnector = (BConnector) getArgument(context, 0);
+        String query = getArgument(context, 1).stringValue();
+        BArray parameters = (BArray) getArgument(context, 2);
+        Connector connector = bConnector.value();
+        executeBatchUpdate(context, (SQLConnector) connector, query, parameters);
+        return null;
+    }
+}

--- a/modules/ballerina-native/src/test/java/org/ballerinalang/nativeimpl/connectors/SQLConnectorTest.java
+++ b/modules/ballerina-native/src/test/java/org/ballerinalang/nativeimpl/connectors/SQLConnectorTest.java
@@ -18,6 +18,7 @@
 package org.ballerinalang.nativeimpl.connectors;
 
 import org.ballerinalang.model.BLangProgram;
+import org.ballerinalang.model.values.BArray;
 import org.ballerinalang.model.values.BBoolean;
 import org.ballerinalang.model.values.BDouble;
 import org.ballerinalang.model.values.BFloat;
@@ -244,13 +245,6 @@ public class SQLConnectorTest {
         Assert.assertEquals(retValue.intValue(), 1);
     }
 
-    @Test(dependsOnGroups = "ConnectorTest")
-    public void testCloseConnectionPool() {
-        BValue[] returns = BLangFunctions.invoke(bLangProgram, "testCloseConnectionPool");
-        BInteger retValue = (BInteger) returns[0];
-        Assert.assertEquals(retValue.intValue(), 1);
-    }
-
     @Test(groups = "ConnectorTest")
     public void testArrayInParameters() {
         BValue[] returns = BLangFunctions.invoke(bLangProgram, "testArrayInParameters");
@@ -314,6 +308,22 @@ public class SQLConnectorTest {
         Assert.assertEquals(returns[5].stringValue(), "[true,false,true]");
         Assert.assertEquals(returns[6].stringValue(), "[Hello,Ballerina]");
     }
+
+    @Test(groups = "ConnectorTest")
+    public void testBatchUpdate() {
+        BValue[] returns = BLangFunctions.invoke(bLangProgram, "testBatchUpdate");
+        BArray retValue = (BArray) returns[0];
+        Assert.assertEquals(retValue.get(0).stringValue(), "1");
+        Assert.assertEquals(retValue.get(1).stringValue(), "1");
+    }
+
+    @Test(dependsOnGroups = "ConnectorTest")
+    public void testCloseConnectionPool() {
+        BValue[] returns = BLangFunctions.invoke(bLangProgram, "testCloseConnectionPool");
+        BInteger retValue = (BInteger) returns[0];
+        Assert.assertEquals(retValue.intValue(), 1);
+    }
+
 
     @AfterSuite
     public void cleanup() {

--- a/modules/ballerina-native/src/test/resources/samples/sqlConnectorTest.bal
+++ b/modules/ballerina-native/src/test/resources/samples/sqlConnectorTest.bal
@@ -494,7 +494,7 @@ function testBatchUpdate() (int[]) {
     sql:Parameter para3 = {sqlType:"integer", value:20, direction:0};
     sql:Parameter para4 = {sqlType:"double", value:3400.5, direction:0};
     sql:Parameter para5 = {sqlType:"varchar", value:"Colombo", direction:0};
-    sql:Parameter[] parameters = [para1, para2, para3, para4, para5];
+    sql:Parameter[] parameters1 = [para1, para2, para3, para4, para5];
 
     //Batch 2
     para1 = {sqlType:"varchar", value:"Alex", direction:0};
@@ -503,7 +503,7 @@ function testBatchUpdate() (int[]) {
     para4 = {sqlType:"double", value:3400.5, direction:0};
     para5 = {sqlType:"varchar", value:"Colombo", direction:0};
     sql:Parameter[] parameters2 = [para1, para2, para3, para4, para5];
-    //sql:Parameter[][] parameters = [parameters1, parameters2];
+    sql:Parameter[][] parameters = [parameters1, parameters2];
 
     int[] updateCount;
     updateCount  = sql:ClientConnector.batchUpdate(testDB, "Insert into Customers

--- a/modules/ballerina-native/src/test/resources/samples/sqlConnectorTest.bal
+++ b/modules/ballerina-native/src/test/resources/samples/sqlConnectorTest.bal
@@ -482,3 +482,32 @@ function testArrayInOutParameters() (any, any, any, any, any, any, any) {
     sql:ClientConnector.close(testDB);
     return para2.value, para3.value, para4.value, para5.value, para6.value, para7.value, para8.value;
 }
+
+function testBatchUpdate() (int[]) {
+    map propertiesMap = {"jdbcUrl":"jdbc:hsqldb:file:./target/tempdb/TEST_SQL_CONNECTOR",
+                         "username":"SA", "password":"", "maximumPoolSize":1};
+    sql:ClientConnector testDB = create sql:ClientConnector(propertiesMap);
+
+    //Batch 1
+    sql:Parameter para1 = {sqlType:"varchar", value:"Alex", direction:0};
+    sql:Parameter para2 = {sqlType:"varchar", value:"Smith", direction:0};
+    sql:Parameter para3 = {sqlType:"integer", value:20, direction:0};
+    sql:Parameter para4 = {sqlType:"double", value:3400.5, direction:0};
+    sql:Parameter para5 = {sqlType:"varchar", value:"Colombo", direction:0};
+    sql:Parameter[] parameters = [para1, para2, para3, para4, para5];
+
+    //Batch 2
+    para1 = {sqlType:"varchar", value:"Alex", direction:0};
+    para2 = {sqlType:"varchar", value:"Smith", direction:0};
+    para3 = {sqlType:"integer", value:20, direction:0};
+    para4 = {sqlType:"double", value:3400.5, direction:0};
+    para5 = {sqlType:"varchar", value:"Colombo", direction:0};
+    sql:Parameter[] parameters2 = [para1, para2, para3, para4, para5];
+    //sql:Parameter[][] parameters = [parameters1, parameters2];
+
+    int[] updateCount;
+    updateCount  = sql:ClientConnector.batchUpdate(testDB, "Insert into Customers
+                (firstName,lastName,registrationID,creditLimit,country) values (?,?,?,?,?)", parameters);
+    sql:ClientConnector.close(testDB);
+    return updateCount;
+}


### PR DESCRIPTION
This PR depends on  #2280
This PR adds a new action "batchUpdate" for SQLConnector. It allows to group multiple updates together, and sent to the database in one "batch", rather than sending the updates one by one.  It returns an array of update counts containing one element for each command in the batch. 

```
//Batch 1
sql:Parameter para1 = {sqlType:"varchar", value:"Alex"};
sql:Parameter para2 = {sqlType:"integer", value:20};
sql:Parameter[] parameters1 = [para1, para2];

//Batch 2
para1 = {sqlType:"varchar", value:"Peter";
para3 = {sqlType:"integer", value:30};
sql:Parameter[] parameters2 = [para1, para2];
    
sql:Parameter[][] params = [parameters1, parameters2];
int[] updateCount = sql:ClientConnector.batchUpdate(testDB, "Insert into Customers (name,age) values (?,?)", params);
```
