### PR TITLE
Generate jacoco aggregated test coverage report

### DIFF
--- a/modules/ballerina-core/pom.xml
+++ b/modules/ballerina-core/pom.xml
@@ -173,13 +173,13 @@
                                     </limits> -->
                                     <excludes>
                                         <exclude>*Test</exclude>
-                                        <exclude>org/wso2/ballerina/core/parser/
+                                        <exclude>org/ballerinalang/util/parser/
                                             BallerinaBaseListener*</exclude>
-                                        <exclude>org/wso2/ballerina/core/parser/
+                                        <exclude>org/ballerinalang/util/parser/
                                             BallerinaLexer*</exclude>
-                                        <exclude>org/wso2/ballerina/core/parser/
+                                        <exclude>org/ballerinalang/util/parser/
                                             BallerinaListener*</exclude>
-                                        <exclude>org/wso2/ballerina/core/parser/
+                                        <exclude>org/ballerinalang/util/parser/
                                             BallerinaParser*</exclude>
                                     </excludes>
                                 </rule>

--- a/modules/launcher/pom.xml
+++ b/modules/launcher/pom.xml
@@ -78,6 +78,62 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <taskdef name="report" classname="org.jacoco.ant.ReportTask">
+                                    <classpath path="${basedir}/target/jacoco-jars/org.jacoco.ant.jar" />
+                                </taskdef>
+                                <mkdir dir="${basedir}/../../target/coverage-report" />
+                                <report>
+                                    <executiondata>
+                                        <fileset dir="${project.build.directory}/../../ballerina-core/target/coverage-reports">
+                                            <include name="jacoco-unit.exec" />
+                                        </fileset>
+                                        <fileset dir="${project.build.directory}/../../ballerina-native/target/coverage-reports">
+                                            <include name="jacoco-unit.exec" />
+                                        </fileset>
+                                    </executiondata>
+                                    <structure name="Ballerina Coverage Report">
+                                        <group name="ballerina">
+                                            <classfiles>
+                                                <fileset dir="${project.build.directory}/../../ballerina-core/target/classes">
+                                                    <exclude name="org/ballerinalang/util/parser/BallerinaBaseListener*" />
+                                                    <exclude name="org/ballerinalang/util/parser/BallerinaLexer*" />
+                                                    <exclude name="org/ballerinalang/util/parser/BallerinaListener*" />
+                                                    <exclude name="org/ballerinalang/util/parser/BallerinaParser*" />
+                                                </fileset>
+                                                <fileset dir="${project.build.directory}/../../ballerina-native/target/classes" />
+                                            </classfiles>
+                                            <sourcefiles encoding="UTF-8">
+                                                <fileset dir="${project.build.directory}/../../ballerina-core/src/main/java" />
+                                                <fileset dir="${project.build.directory}/../../ballerina-native/src/main/java" />
+                                            </sourcefiles>
+                                        </group>
+                                    </structure>
+                                    <html
+                                        destdir="${basedir}/../../target/coverage-report/site" />
+                                </report>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>org.jacoco.ant</artifactId>
+                        <version>${jacoco.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Aggregated test coverage report will be generated in <ballerina>/target/coverage-report directory.