### PR TITLE
Add support for --version flag

### DIFF
--- a/modules/ballerina-core/src/main/java/org/ballerinalang/runtime/Constants.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/runtime/Constants.java
@@ -34,10 +34,12 @@ public class Constants {
     // Ballerina version system property name
     public static final String BALLERINA_VERSION = "ballerina.version";
 
+    // Ballerina home system property name
+    public static final String BALLERINA_HOME = "ballerina.home";
+
     // logger names.
     public static final String BAL_LINKED_INTERPRETER_LOGGER = "BLinkedInterpreter";
 
     // Name of the system property to hold the debug port
     public static final String SYSTEM_PROP_BAL_DEBUG = "ballerina.debug";
-
 }

--- a/modules/launcher/src/main/java/org/ballerinalang/launcher/Main.java
+++ b/modules/launcher/src/main/java/org/ballerinalang/launcher/Main.java
@@ -8,6 +8,7 @@ import com.beust.jcommander.Parameters;
 import org.ballerinalang.BLangProgramArchiveBuilder;
 import org.ballerinalang.BLangProgramLoader;
 import org.ballerinalang.model.BLangProgram;
+import org.ballerinalang.runtime.Constants;
 import org.ballerinalang.util.exceptions.BLangRuntimeException;
 import org.ballerinalang.util.exceptions.ParserException;
 import org.ballerinalang.util.exceptions.SemanticException;
@@ -694,11 +695,31 @@ public class Main {
         @Parameter(names = "--debug", hidden = true)
         private String debugPort;
 
+        @Parameter(names = {"--version", "-v"}, description = "display Ballerina version information")
+        private boolean version;
+
         private JCommander parentCmdParser;
 
         @Override
         public void execute() {
-            printUsageInfo(parentCmdParser);
+            if (version) {
+                outStream.println("Ballerina " + "\"" + System.getProperty(Constants.BALLERINA_VERSION) + "\"");
+                outStream.println("home: " + System.getProperty(Constants.BALLERINA_HOME));
+
+                outStream.println();
+                outStream.println(System.getProperty("java.runtime.name"));
+                outStream.println("vm: " + System.getProperty("java.vm.name"));
+                outStream.print("version: " + "\"" + System.getProperty("java.version") + "\", ");
+                outStream.println("vendor: " + "\"" + System.getProperty("java.vendor") + "\"");
+                outStream.println("home: " + System.getProperty("java.home"));
+
+                outStream.println();
+                outStream.print("OS name: " + "\"" + System.getProperty("os.name") + "\", ");
+                outStream.print("version: " + "\"" + System.getProperty("os.version") + "\", ");
+                outStream.println("arch: " + "\"" + System.getProperty("os.arch") + "\"");
+            } else {
+                printUsageInfo(parentCmdParser);
+            }
         }
 
         @Override


### PR DESCRIPTION
This PR adds support for the --version flag to display Ballerina version information. The user can use the following commands to view Ballerina version and other, related environment information. 

- ballerina --version

- ballerina -v