### PR TITLE
Add an optional parameter to pass program directory to main and service commands.

### DIFF
--- a/modules/launcher/src/main/java/org/ballerinalang/launcher/BProgramRunner.java
+++ b/modules/launcher/src/main/java/org/ballerinalang/launcher/BProgramRunner.java
@@ -72,4 +72,8 @@ class BProgramRunner {
         }
 
     }
+
+    public static void setProgramDirPath(Path programDirPath) {
+        BProgramRunner.programDirPath = programDirPath;
+    }
 }

--- a/modules/launcher/src/main/java/org/ballerinalang/launcher/Main.java
+++ b/modules/launcher/src/main/java/org/ballerinalang/launcher/Main.java
@@ -259,8 +259,11 @@ public class Main {
         @Parameter(names = "--debug", hidden = true)
         private String debugPort;
 
-        @Parameter(names = "--ballerina.debug", hidden = true, description = "remote debugging port")
+        @Parameter(names = {"--ballerina-debug", "-bd" }, description = "remote debugging port")
         private String ballerinaDebugPort;
+
+        @Parameter(names = {"--program-directory", "-pd"}, description = "program directory path")
+        private String programDir;
 
         public void execute() {
             if (helpFlag) {
@@ -283,6 +286,11 @@ public class Main {
             if (null != ballerinaDebugPort) {
                 System.setProperty(SYSTEM_PROP_BAL_DEBUG, ballerinaDebugPort);
             }
+
+            if (null != programDir) {
+                BProgramRunner.setProgramDirPath(Paths.get(programDir));
+            }
+
             Path sourcePath = Paths.get(argList.get(0));
             BProgramRunner.runMain(sourcePath, programArgs);
         }
@@ -329,8 +337,11 @@ public class Main {
         @Parameter(names = {"--service-root", "-sr"}, description = "directory which contains ballerina services")
         private String serviceRootPath;
 
-        @Parameter(names = "--ballerina.debug", hidden = true, description = "remote debugging port")
+        @Parameter(names = {"--ballerina-debug", "-bd"}, description = "remote debugging port")
         private String ballerinaDebugPort;
+
+        @Parameter(names = {"--program-directory", "-pd"}, description = "program directory path")
+        private String programDir;
 
         public void execute() {
             if (helpFlag) {
@@ -378,6 +389,11 @@ public class Main {
             if (null != ballerinaDebugPort) {
                 System.setProperty(SYSTEM_PROP_BAL_DEBUG, ballerinaDebugPort);
             }
+
+            if (null != programDir) {
+                BProgramRunner.setProgramDirPath(Paths.get(programDir));
+            }
+
             BProgramRunner.runServices(paths);
         }
 


### PR DESCRIPTION
Also did some modifications for ballerina-debug command to make it uniform with other parameters. 

Currently you need to 'cd' to ballerina program directory to run a ballerina program ( with package name ). This optional parameter will allow you to run a program from any location without 'cd' to program directory.