### PR TITLE
Add white space descriptor to transaction statement

### DIFF
--- a/modules/ballerina-core/src/main/java/org/ballerinalang/model/builder/BLangModelBuilder.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/model/builder/BLangModelBuilder.java
@@ -1620,8 +1620,9 @@ public class BLangModelBuilder {
         transactionStmtBuilder.setCommittedBlockStmt(committedBlock);
     }
 
-    public void addTransactionStmt() {
+    public void addTransactionStmt(WhiteSpaceDescriptor whiteSpaceDescriptor) {
         TransactionStmt.TransactionStmtBuilder transactionStmtBuilder = transactionStmtBuilderStack.pop();
+        transactionStmtBuilder.setWhiteSpaceDescriptor(whiteSpaceDescriptor);
         TransactionStmt transactionStmt = transactionStmtBuilder.build();
         addToBlockStmt(transactionStmt);
     }

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/model/statements/TransactionStmt.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/model/statements/TransactionStmt.java
@@ -17,11 +17,13 @@
 */
 package org.ballerinalang.model.statements;
 
+
 import org.ballerinalang.model.NodeExecutor;
 import org.ballerinalang.model.NodeLocation;
 import org.ballerinalang.model.NodeVisitor;
 import org.ballerinalang.model.SymbolName;
 import org.ballerinalang.model.SymbolScope;
+import org.ballerinalang.model.WhiteSpaceDescriptor;
 import org.ballerinalang.model.symbols.BLangSymbol;
 
 import java.util.Collections;
@@ -39,7 +41,7 @@ public class TransactionStmt extends AbstractStatement {
     private CommittedBlock committedBlock;
 
     private TransactionStmt(NodeLocation location, Statement transactionBlock, AbortedBlock abortedBlock,
-            CommittedBlock committedBlock) {
+                            CommittedBlock committedBlock) {
         super(location);
         this.transactionBlock = transactionBlock;
         this.abortedBlock = abortedBlock;
@@ -174,6 +176,7 @@ public class TransactionStmt extends AbstractStatement {
         private AbortedBlock abortedBlock;
         private CommittedBlock committedBlock;
         private NodeLocation location;
+        private WhiteSpaceDescriptor whiteSpaceDescriptor;
 
         public void setTransactionBlock(Statement transactionBlock) {
             this.transactionBlock = transactionBlock;
@@ -203,8 +206,19 @@ public class TransactionStmt extends AbstractStatement {
             this.location = location;
         }
 
+        public WhiteSpaceDescriptor getWhiteSpaceDescriptor() {
+            return whiteSpaceDescriptor;
+        }
+
+        public void setWhiteSpaceDescriptor(WhiteSpaceDescriptor whiteSpaceDescriptor) {
+            this.whiteSpaceDescriptor = whiteSpaceDescriptor;
+        }
+
         public TransactionStmt build() {
-            return new TransactionStmt(location, transactionBlock, abortedBlock, committedBlock);
+            TransactionStmt transactionStmt = new TransactionStmt(location, transactionBlock,
+                    abortedBlock, committedBlock);
+            transactionStmt.setWhiteSpaceDescriptor(whiteSpaceDescriptor);
+            return transactionStmt;
         }
     }
 }

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/util/parser/antlr4/BLangAntlr4Listener.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/util/parser/antlr4/BLangAntlr4Listener.java
@@ -1543,7 +1543,11 @@ public class BLangAntlr4Listener implements BallerinaListener {
     @Override
     public void exitTransactionStatement(BallerinaParser.TransactionStatementContext ctx) {
         if (ctx.exception == null) {
-            modelBuilder.addTransactionStmt();
+            WhiteSpaceDescriptor whiteSpaceDescriptor = null;
+            if (isVerboseMode) {
+                whiteSpaceDescriptor = WhiteSpaceUtil.getTransactionWS(tokenStream, ctx);
+            }
+            modelBuilder.addTransactionStmt(whiteSpaceDescriptor);
         }
     }
 

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/util/parser/antlr4/WhiteSpaceRegions.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/util/parser/antlr4/WhiteSpaceRegions.java
@@ -326,7 +326,7 @@ public class WhiteSpaceRegions {
     public static final int TYPE_CAST_EXP_TYPE_CAST_START_TO_TYPE_NAME = 1;
     public static final int TYPE_CAST_EXP_TYPE_CAST_END_TO_EXP = 2;
     public static final int TYPE_CAST_EXP_FOLLOWING_WHITESPACE = 3;
-    
+
     // white space regions in a type-conversion expr
     public static final int TYPE_CONVERSION_EXP_PRECEDING_WHITESPACE = 0;
     public static final int TYPE_CONVERSION_EXP_TYPE_CAST_START_TO_TYPE_NAME = 1;
@@ -350,4 +350,22 @@ public class WhiteSpaceRegions {
     public static final int TRANSFORM_STMT_PRECEDING_WHITESPACE = 0;
     public static final int TRANSFORM_STMT_TO_BODY_START = 2;
     public static final int TRANSFORM_STMT_END_TO_NEXT_TOKEN = 3;
+
+    // whitespace regions in a transaction statement
+    public static final int TRANSACTION_STMT_PRECEDING_WHITESPACE = 0;
+    public static final int TRANSACTION_STMT_TRANSACTION_KEYWORD_TO_BODY_START = 1;
+    public static final int TRANSACTION_STMT_BODY_START_TO_FIRST_TOKEN = 2;
+    public static final int TRANSACTION_STMT_BODY_END_TO_NEXT_TOKEN = 3;
+
+    // whitespace regions in a committed clause
+    public static final int COMMITTED_STMT_PRECEDING_WHITESPACE = 0;
+    public static final int COMMITTED_STMT_TRANSACTION_KEYWORD_TO_BODY_START = 1;
+    public static final int COMMITTED_STMT_BODY_START_TO_FIRST_TOKEN = 2;
+    public static final int COMMITTED_STMT_BODY_END_TO_NEXT_TOKEN = 3;
+
+    // whitespace regions in a aborted clause
+    public static final int ABORTED_STMT_PRECEDING_WHITESPACE = 0;
+    public static final int ABORTED_STMT_TRANSACTION_KEYWORD_TO_BODY_START = 1;
+    public static final int ABORTED_STMT_BODY_START_TO_FIRST_TOKEN = 2;
+    public static final int ABORTED_STMT_BODY_END_TO_NEXT_TOKEN = 3;
 }

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/util/parser/antlr4/WhiteSpaceUtil.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/util/parser/antlr4/WhiteSpaceUtil.java
@@ -41,12 +41,15 @@ public class WhiteSpaceUtil {
     public static final String CLOSING_PAREN = ")";
     public static final String KEYWORD_AS = "as";
     public static final String OPENING_CURLY_BRACE = "{";
+    public static final String CLOSING_CURLY_BRACE = "}";
     public static final String SYMBOL_COLON = ":";
     public static final String NATIVE_KEYWORD = "native";
     public static final String KEYWORD_THROWS = "throws";
     public static final String EQUAL_OPERATOR = "=";
     public static final String IF_KEYWORD = "if";
     public static final String DOT_OPERATOR = ".";
+    public static final String COMMITTED_CLAUSE = "CommittedClause";
+    public static final String ABORTED_CLAUSE = "AbortedClause";
 
     public static String getFileStartingWhiteSpace(CommonTokenStream tokenStream) {
         // find first non-whitespace token
@@ -941,7 +944,7 @@ public class WhiteSpaceUtil {
                 getWhitespaceToRight(tokenStream, ctx.stop.getTokenIndex()));
         return ws;
     }
-    
+
     public static WhiteSpaceDescriptor getTypeConversionExpWS(CommonTokenStream tokenStream,
         BallerinaParser.TypeConversionExpressionContext ctx) {
     WhiteSpaceDescriptor ws = new WhiteSpaceDescriptor();
@@ -1050,6 +1053,62 @@ public class WhiteSpaceUtil {
                 getWhitespaceToLeft(tokenStream, ctx.start.getTokenIndex()));
         ws.addWhitespaceRegion(WhiteSpaceRegions.ACTION_INVOCATION_STMT_END_TO_NEXT_TOKEN,
                 getWhitespaceToRight(tokenStream, ctx.stop.getTokenIndex()));
+        return ws;
+    }
+
+    public static WhiteSpaceDescriptor getTransactionWS(CommonTokenStream tokenStream,
+                                                        BallerinaParser.TransactionStatementContext ctx) {
+        WhiteSpaceDescriptor ws = new WhiteSpaceDescriptor();
+        ws.addWhitespaceRegion(WhiteSpaceRegions.TRANSACTION_STMT_PRECEDING_WHITESPACE,
+                getWhitespaceToLeft(tokenStream, ctx.start.getTokenIndex()));
+        ws.addWhitespaceRegion(WhiteSpaceRegions.TRANSACTION_STMT_TRANSACTION_KEYWORD_TO_BODY_START,
+                getWhitespaceToRight(tokenStream, ctx.start.getTokenIndex()));
+        ws.addWhitespaceRegion(WhiteSpaceRegions.TRANSACTION_STMT_BODY_START_TO_FIRST_TOKEN,
+                getWhitespaceToRight(tokenStream,
+                        getFirstTokenWithText(ctx.children, OPENING_CURLY_BRACE).getTokenIndex()));
+        ws.addWhitespaceRegion(WhiteSpaceRegions.TRANSACTION_STMT_BODY_END_TO_NEXT_TOKEN,
+                getWhitespaceToRight(tokenStream,
+                        getFirstTokenWithText(ctx.children, CLOSING_CURLY_BRACE).getTokenIndex()));
+        if (ctx.transactionHandlers().committedClause() != null) {
+            ws.addChildDescriptor(COMMITTED_CLAUSE, getCommittedClauseWS(tokenStream,
+                    ctx.transactionHandlers().committedClause()));
+        }
+        if (ctx.transactionHandlers().abortedClause() != null) {
+            ws.addChildDescriptor(ABORTED_CLAUSE, getAbortedClauseWS(tokenStream,
+                    ctx.transactionHandlers().abortedClause()));
+        }
+        return ws;
+    }
+
+    public static WhiteSpaceDescriptor getCommittedClauseWS(CommonTokenStream tokenStream,
+                                                            BallerinaParser.CommittedClauseContext ctx) {
+        WhiteSpaceDescriptor ws = new WhiteSpaceDescriptor();
+        ws.addWhitespaceRegion(WhiteSpaceRegions.COMMITTED_STMT_PRECEDING_WHITESPACE,
+                getWhitespaceToLeft(tokenStream, ctx.start.getTokenIndex()));
+        ws.addWhitespaceRegion(WhiteSpaceRegions.COMMITTED_STMT_TRANSACTION_KEYWORD_TO_BODY_START,
+                getWhitespaceToRight(tokenStream, ctx.start.getTokenIndex()));
+        ws.addWhitespaceRegion(WhiteSpaceRegions.COMMITTED_STMT_BODY_START_TO_FIRST_TOKEN,
+                getWhitespaceToRight(tokenStream,
+                        getFirstTokenWithText(ctx.children, OPENING_CURLY_BRACE).getTokenIndex()));
+        ws.addWhitespaceRegion(WhiteSpaceRegions.COMMITTED_STMT_BODY_END_TO_NEXT_TOKEN,
+                getWhitespaceToRight(tokenStream,
+                        getFirstTokenWithText(ctx.children, CLOSING_CURLY_BRACE).getTokenIndex()));
+        return ws;
+    }
+
+    public static WhiteSpaceDescriptor getAbortedClauseWS(CommonTokenStream tokenStream,
+                                                          BallerinaParser.AbortedClauseContext ctx) {
+        WhiteSpaceDescriptor ws = new WhiteSpaceDescriptor();
+        ws.addWhitespaceRegion(WhiteSpaceRegions.ABORTED_STMT_PRECEDING_WHITESPACE,
+                getWhitespaceToLeft(tokenStream, ctx.start.getTokenIndex()));
+        ws.addWhitespaceRegion(WhiteSpaceRegions.ABORTED_STMT_TRANSACTION_KEYWORD_TO_BODY_START,
+                getWhitespaceToRight(tokenStream, ctx.start.getTokenIndex()));
+        ws.addWhitespaceRegion(WhiteSpaceRegions.ABORTED_STMT_BODY_START_TO_FIRST_TOKEN,
+                getWhitespaceToRight(tokenStream,
+                        getFirstTokenWithText(ctx.children, OPENING_CURLY_BRACE).getTokenIndex()));
+        ws.addWhitespaceRegion(WhiteSpaceRegions.ABORTED_STMT_BODY_END_TO_NEXT_TOKEN,
+                getWhitespaceToRight(tokenStream,
+                        getFirstTokenWithText(ctx.children, CLOSING_CURLY_BRACE).getTokenIndex()));
         return ws;
     }
 }


### PR DESCRIPTION
This pull request is to save and retrieve whitespaces added by user to the transaction statement in source file. 

Previously transaction statement looks like below:

> transaction {} aborted {} committed {}

After Adding whitespaces descriptor transaction statement looks like below:

> transaction {
> } aborted {
> } committed {
> }
