### PR TITLE
Websocket close functions

### DIFF
--- a/docs/server-connectors/websocket-server.md
+++ b/docs/server-connectors/websocket-server.md
@@ -93,6 +93,14 @@ This function push text all the clients who have been connected to the currently
 |---------|--------------|-----------|---------------|
 |text|string|The text message to send|This can be any string|
 
+### Closing the connection of the current client from server side
+#### ws:closeConnection(text)
+This function close the connection of the current client from a given WebSocket resource.
+
+|Parameter|Parameter Type|Description|Expected Values|
+|---------|--------------|-----------|---------------|
+|none|-|-|-|
+
 ### Storing and grouping WebSocket connections globally
 In Ballerina you can store the WebSocket connections and use them in other services too.
 There are 2 ways of using this feature.
@@ -130,6 +138,14 @@ store.
 |---------|--------------|-----------|---------------|
 |connectionName|string|Represent the name of the connection given by the user|Unique string of the connection|
 
+#### ws:closeStoredConnection(connectionName);
+This function is used to close a stored connection. Note that removeStoredConnection will only remove connection from
+connection store. This will close the connection and remove it from the store.
+
+|Parameter|Parameter Type|Description|Expected Values|
+|---------|--------------|-----------|---------------|
+|connectionName|string|Represent the name of the connection given by the user|Unique string of the connection|
+
 ### Grouping WebSocket Connections
 #### ws:addConnectionToGroup(groupName)
 This will add the current WebSocket connection to group with the given group name.
@@ -158,6 +174,14 @@ This function removes the current connection from the given group if that connec
 This removes the whole connection group globally. So if the connection group is removed it cannot be used again.
 But it does not mean that individual connections are removed globally. Because same connection can be added to one or
 more groups. 
+
+|Parameter|Parameter Type|Description|Expected Values|
+|---------|--------------|-----------|---------------|
+|groupName|string|Represent the name of the group|String name represents the group|
+
+#### ws:closeConnectionGroup(groupName)
+This close all the connections in a connection group. Note that removeConnectionGroup will only remove only the connection
+group. But the connection status will not affect. But here the connections will be closed and removed the connection group
 
 |Parameter|Parameter Type|Description|Expected Values|
 |---------|--------------|-----------|---------------|

--- a/modules/ballerina-native/src/main/ballerina/ballerina/net/ws/natives.bal
+++ b/modules/ballerina-native/src/main/ballerina/ballerina/net/ws/natives.bal
@@ -23,6 +23,10 @@ native function removeStoredConnection (string connectionName);
 @doc:Param { value:"text: Text which should be sent" }
 native function pushTextToConnection (string connectionName, string text);
 
+@doc:Description { value:"Close stored connection."}
+@doc:Param { value:"connectionName: Name of the connection" }
+native function closeStoredConnection (string connectionName);
+
 @doc:Description { value:"This pushes text from server to all the connected clients of the service."}
 @doc:Param { value:"connectionGroupName: Name of the connection group" }
 native function addConnectionToGroup (string connectionGroupName);

--- a/modules/ballerina-native/src/main/ballerina/ballerina/net/ws/natives.bal
+++ b/modules/ballerina-native/src/main/ballerina/ballerina/net/ws/natives.bal
@@ -47,7 +47,7 @@ native function removeConnectionGroup (string connectionGroupName);
 @doc:Param { value:"text: Text which should be sent" }
 native function pushTextToGroup (string connectionGroupName, string text);
 
-@doc:Description { value:"Close all the connections in connection group"}
+@doc:Description { value:"Close all the connections in connection group."}
 @doc:Param { value:"connectionGroupName: Name of the connection group" }
 native function closeConnectionGroup(string connectionGroupName);
 

--- a/modules/ballerina-native/src/main/ballerina/ballerina/net/ws/natives.bal
+++ b/modules/ballerina-native/src/main/ballerina/ballerina/net/ws/natives.bal
@@ -40,5 +40,9 @@ native function removeConnectionGroup (string connectionGroupName);
 @doc:Param { value:"text: Text which should be sent" }
 native function pushTextToGroup (string connectionGroupName, string text);
 
+@doc:Description { value:"Close all the connections in connection group"}
+@doc:Param { value:"connectionGroupName: Name of the connection group" }
+native function closeConnectionGroup(string connectionGroupName);
+
 
 

--- a/modules/ballerina-native/src/main/ballerina/ballerina/net/ws/natives.bal
+++ b/modules/ballerina-native/src/main/ballerina/ballerina/net/ws/natives.bal
@@ -10,6 +10,9 @@ native function pushText (string text);
 @doc:Param { value:"text: Text which should be sent" }
 native function broadcastText (string text);
 
+@doc:Description { value:"Close the current client connection"}
+native function closeConnection ();
+
 @doc:Description { value:"Store the connection globally for the use of other services."}
 @doc:Param { value:"connectionName: Name of the connection" }
 native function storeConnection (string connectionName);

--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/net/ws/CloseConnection.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/net/ws/CloseConnection.java
@@ -19,10 +19,8 @@
 package org.ballerinalang.nativeimpl.net.ws;
 
 import org.ballerinalang.bre.Context;
-import org.ballerinalang.model.types.TypeEnum;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.natives.AbstractNativeFunction;
-import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.Attribute;
 import org.ballerinalang.natives.annotations.BallerinaAnnotation;
 import org.ballerinalang.natives.annotations.BallerinaFunction;

--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/net/ws/CloseConnection.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/net/ws/CloseConnection.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.nativeimpl.net.ws;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.services.dispatchers.http.Constants;
+import org.ballerinalang.services.dispatchers.ws.WebSocketConnectionManager;
+import org.ballerinalang.util.exceptions.BallerinaException;
+import org.wso2.carbon.messaging.CarbonMessage;
+
+import javax.websocket.CloseReason;
+import javax.websocket.Session;
+
+/**
+ * Close the current connection inside the resource.
+ */
+public class CloseConnection extends AbstractNativeFunction {
+
+    @Override
+    public BValue[] execute(Context context) {
+
+        if (context.getServiceInfo() == null) {
+            throw new BallerinaException("This function is only working with services");
+        }
+
+        try {
+            CarbonMessage carbonMessage = context.getCarbonMessage();
+            Session session = (Session) carbonMessage.getProperty(Constants.WEBSOCKET_SESSION);
+            session.close(new CloseReason(
+                    () -> 1000,
+                    "Normal closure"
+            ));
+            WebSocketConnectionManager.getInstance().removeConnectionFromAll(session);
+        } catch (Throwable e) {
+            throw new BallerinaException("Error occurred in removing the connection");
+        }
+        return VOID_RETURN;
+    }
+}

--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/net/ws/CloseConnection.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/net/ws/CloseConnection.java
@@ -54,10 +54,7 @@ public class CloseConnection extends AbstractNativeFunction {
         try {
             CarbonMessage carbonMessage = context.getCarbonMessage();
             Session session = (Session) carbonMessage.getProperty(Constants.WEBSOCKET_SESSION);
-            session.close(new CloseReason(
-                    () -> 1000,
-                    "Normal closure"
-            ));
+            session.close(new CloseReason(() -> 1000, "Normal closure"));
             WebSocketConnectionManager.getInstance().removeConnectionFromAll(session);
         } catch (Throwable e) {
             throw new BallerinaException("Error occurred in removing the connection");

--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/net/ws/CloseConnection.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/net/ws/CloseConnection.java
@@ -19,8 +19,13 @@
 package org.ballerinalang.nativeimpl.net.ws;
 
 import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeEnum;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.Attribute;
+import org.ballerinalang.natives.annotations.BallerinaAnnotation;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.services.dispatchers.http.Constants;
 import org.ballerinalang.services.dispatchers.ws.WebSocketConnectionManager;
 import org.ballerinalang.util.exceptions.BallerinaException;
@@ -32,6 +37,13 @@ import javax.websocket.Session;
 /**
  * Close the current connection inside the resource.
  */
+@BallerinaFunction(
+        packageName = "ballerina.net.ws",
+        functionName = "closeConnection",
+        isPublic = true
+)
+@BallerinaAnnotation(annotationName = "Description",
+                     attributes = { @Attribute(name = "value", value = "This close the current connection") })
 public class CloseConnection extends AbstractNativeFunction {
 
     @Override

--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/net/ws/connectiongroup/CloseConnectionGroup.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/net/ws/connectiongroup/CloseConnectionGroup.java
@@ -70,10 +70,7 @@ public class CloseConnectionGroup extends AbstractNativeFunction {
                 session -> {
                     if (session.isOpen()) {
                         try {
-                            session.close(new CloseReason(
-                                    () -> 1000,
-                                    "Normal closure"
-                            ));
+                            session.close(new CloseReason(() -> 1000, "Normal closure"));
                             connectionManager.removeConnectionFromAll(session);
                         } catch (IOException e) {
                             throw new BallerinaException("Error occurred in closing connection group: "

--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/net/ws/connectiongroup/CloseConnectionGroup.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/net/ws/connectiongroup/CloseConnectionGroup.java
@@ -47,7 +47,8 @@ import javax.websocket.Session;
         isPublic = true
 )
 @BallerinaAnnotation(annotationName = "Description",
-                     attributes = { @Attribute(name = "value", value = "Removes connection group.")})
+                     attributes = { @Attribute(name = "value",
+                                               value = "Close all the connections in connection group.")})
 @BallerinaAnnotation(annotationName = "Param",
                      attributes = { @Attribute(name = "connectionGroupName", value = "Name of the connection group")})
 public class CloseConnectionGroup extends AbstractNativeFunction {

--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/net/ws/connectiongroup/CloseConnectionGroup.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/net/ws/connectiongroup/CloseConnectionGroup.java
@@ -82,6 +82,7 @@ public class CloseConnectionGroup extends AbstractNativeFunction {
                     }
                 }
         );
+        connectionManager.removeConnectionGroup(connectionGroupName);
         return VOID_RETURN;
     }
 }

--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/net/ws/connectiongroup/CloseConnectionGroup.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/net/ws/connectiongroup/CloseConnectionGroup.java
@@ -59,7 +59,7 @@ public class CloseConnectionGroup extends AbstractNativeFunction {
             throw new BallerinaException("This function is only working with services");
         }
 
-        String connectionGroupName = getArgument(context, 0).stringValue();
+        String connectionGroupName = getStringArgument(context, 0);
         WebSocketConnectionManager connectionManager = WebSocketConnectionManager.getInstance();
         List<Session> sessions = connectionManager.getInstance().getConnectionGroup(connectionGroupName);
         if (sessions == null) {

--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/net/ws/connectiongroup/CloseConnectionGroup.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/net/ws/connectiongroup/CloseConnectionGroup.java
@@ -1,0 +1,80 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.nativeimpl.net.ws.connectiongroup;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeEnum;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.Attribute;
+import org.ballerinalang.natives.annotations.BallerinaAnnotation;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.services.dispatchers.ws.WebSocketConnectionManager;
+import org.ballerinalang.util.exceptions.BallerinaException;
+
+import java.io.IOException;
+import java.util.List;
+import javax.websocket.CloseReason;
+import javax.websocket.Session;
+
+/**
+ * Close all the connections from connection group.
+ * This will remove all the connections in a connection group and close all the connections.
+ */
+@BallerinaFunction(
+        packageName = "ballerina.net.ws",
+        functionName = "closeConnectionGroup",
+        args = {
+                @Argument(name = "connectionGroupName", type = TypeEnum.STRING)
+        },
+        isPublic = true
+)
+@BallerinaAnnotation(annotationName = "Description",
+                     attributes = { @Attribute(name = "value", value = "Removes connection group.")})
+@BallerinaAnnotation(annotationName = "Param",
+                     attributes = { @Attribute(name = "connectionGroupName", value = "Name of the connection group")})
+public class CloseConnectionGroup extends AbstractNativeFunction {
+    @Override
+    public BValue[] execute(Context context) {
+
+        if (context.getServiceInfo() == null) {
+            throw new BallerinaException("This function is only working with services");
+        }
+
+        String connectionGroupName = getArgument(context, 0).stringValue();
+        WebSocketConnectionManager connectionManager = WebSocketConnectionManager.getInstance();
+        List<Session> sessions = connectionManager.getInstance().getConnectionGroup(connectionGroupName);
+        sessions.forEach(
+                session -> {
+                    try {
+                        session.close(new CloseReason(
+                                () -> 1000,
+                                "Normal closure"
+                        ));
+                        connectionManager.removeConnectionFromAll(session);
+                    } catch (IOException e) {
+                        throw new BallerinaException("Error occurred in closing connection group: "
+                                                             + connectionGroupName);
+                    }
+                }
+        );
+        return VOID_RETURN;
+    }
+}

--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/net/ws/connectionstore/CloseStoredConnection.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/net/ws/connectionstore/CloseStoredConnection.java
@@ -23,6 +23,8 @@ import org.ballerinalang.model.types.TypeEnum;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.natives.AbstractNativeFunction;
 import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.Attribute;
+import org.ballerinalang.natives.annotations.BallerinaAnnotation;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.services.dispatchers.ws.WebSocketConnectionManager;
 import org.ballerinalang.util.exceptions.BallerinaException;
@@ -43,6 +45,11 @@ import javax.websocket.Session;
         },
         isPublic = true
 )
+@BallerinaAnnotation(annotationName = "Description",
+                     attributes = { @Attribute(name = "value",
+                                               value = "Close stored connection")})
+@BallerinaAnnotation(annotationName = "Param",
+                     attributes = { @Attribute(name = "connectionName", value = "Name of the stored connection")})
 public class CloseStoredConnection extends AbstractNativeFunction {
 
     @Override

--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/net/ws/connectionstore/CloseStoredConnection.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/net/ws/connectionstore/CloseStoredConnection.java
@@ -59,7 +59,7 @@ public class CloseStoredConnection extends AbstractNativeFunction {
             throw new BallerinaException("This function is only working with services");
         }
 
-        String connectionName = getArgument(context, 0).stringValue();
+        String connectionName = getStringArgument(context, 0);
         WebSocketConnectionManager connectionManager = WebSocketConnectionManager.getInstance();
 
         Session session = connectionManager.getStoredConnection(connectionName);

--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/net/ws/connectionstore/CloseStoredConnection.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/net/ws/connectionstore/CloseStoredConnection.java
@@ -68,10 +68,7 @@ public class CloseStoredConnection extends AbstractNativeFunction {
         }
         if (session.isOpen()) {
             try {
-                session.close(new CloseReason(
-                        () -> 1000,
-                        "Normal closure"
-                ));
+                session.close(new CloseReason(() -> 1000, "Normal closure"));
             } catch (IOException e) {
                 throw new BallerinaException("Error occurred in closing the connection for connection name: "
                                                      + connectionName);

--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/net/ws/connectionstore/CloseStoredConnection.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/net/ws/connectionstore/CloseStoredConnection.java
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.nativeimpl.net.ws.connectionstore;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeEnum;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.services.dispatchers.ws.WebSocketConnectionManager;
+import org.ballerinalang.util.exceptions.BallerinaException;
+
+import java.io.IOException;
+import javax.websocket.CloseReason;
+import javax.websocket.Session;
+
+/**
+ * Close the stored connection.
+ * This will remove the connection from the connection store and close the connection.
+ */
+@BallerinaFunction(
+        packageName = "ballerina.net.ws",
+        functionName = "closeStoredConnection",
+        args = {
+                @Argument(name = "connectionName", type = TypeEnum.STRING)
+        },
+        isPublic = true
+)
+public class CloseStoredConnection extends AbstractNativeFunction {
+
+    @Override
+    public BValue[] execute(Context context) {
+
+        if (context.getServiceInfo() == null) {
+            throw new BallerinaException("This function is only working with services");
+        }
+
+        String connectionName = getArgument(context, 0).stringValue();
+        WebSocketConnectionManager connectionManager = WebSocketConnectionManager.getInstance();
+
+        Session session = connectionManager.getStoredConnection(connectionName);
+        if (session == null) {
+            throw new BallerinaException("No connection found under connection name: " + connectionName + " to close");
+        }
+        if (session.isOpen()) {
+            try {
+                session.close(new CloseReason(
+                        () -> 1000,
+                        "Normal closure"
+                ));
+            } catch (IOException e) {
+                throw new BallerinaException("Error occurred in closing the connection for connection name: "
+                                                     + connectionName);
+            }
+        }
+        connectionManager.removeConnectionFromAll(session);
+
+        return VOID_RETURN;
+    }
+}

--- a/modules/ballerina-native/src/test/java/org/ballerinalang/nativeimpl/functions/ws/ConnectionStoreTest.java
+++ b/modules/ballerina-native/src/test/java/org/ballerinalang/nativeimpl/functions/ws/ConnectionStoreTest.java
@@ -114,6 +114,23 @@ public class ConnectionStoreTest {
         Assert.assertEquals(session4.getTextReceived(), null);
     }
 
+    @Test(priority = 2)
+    public void testCloseConnection() {
+        // Check pre conditions
+        Assert.assertTrue(session1.isOpen());
+        Assert.assertTrue(session2.isOpen());
+        Assert.assertTrue(session3.isOpen());
+        Assert.assertTrue(session4.isOpen());
+
+        Services.invoke(MessageUtils.generateHTTPMessage(httpBasePath + "/close/2", "GET"));
+
+        // Check post conditions
+        Assert.assertTrue(session1.isOpen());
+        Assert.assertFalse(session2.isOpen());
+        Assert.assertTrue(session3.isOpen());
+        Assert.assertTrue(session4.isOpen());
+    }
+
     @AfterClass
     public void cleanUp() {
         EnvironmentInitializer.cleanup(wsApp);

--- a/modules/ballerina-native/src/test/java/org/ballerinalang/testutils/ws/MockWebSocketSession.java
+++ b/modules/ballerina-native/src/test/java/org/ballerinalang/testutils/ws/MockWebSocketSession.java
@@ -39,8 +39,8 @@ public class MockWebSocketSession implements Session {
 
     private final String id;
     private final MockBasicRemoteEndpoint remoteEndpoint;
-    private CloseReason closeReason = null;
-    private boolean isConnectionClose = false;
+    private CloseReason closeReason;
+    private boolean isOpen = true;
 
     public MockWebSocketSession(String id) {
         this.id = id;
@@ -53,14 +53,6 @@ public class MockWebSocketSession implements Session {
 
     public ByteBuffer getBufferReceived() {
         return remoteEndpoint.getBufferReceived();
-    }
-
-    public boolean isConnectionClose() {
-        return isConnectionClose;
-    }
-
-    public CloseReason getCloseReason() {
-        return closeReason;
     }
 
     @Override
@@ -115,7 +107,7 @@ public class MockWebSocketSession implements Session {
 
     @Override
     public boolean isOpen() {
-        return false;
+        return isOpen;
     }
 
     @Override
@@ -165,13 +157,13 @@ public class MockWebSocketSession implements Session {
 
     @Override
     public void close() throws IOException {
-        this.isConnectionClose = true;
+        this.isOpen = false;
     }
 
     @Override
     public void close(CloseReason closeReason) throws IOException {
-        this.isConnectionClose = true;
         this.closeReason = closeReason;
+        this.isOpen = false;
     }
 
     @Override

--- a/modules/ballerina-native/src/test/resources/samples/websocket/connection_group_sample/connectionGroupTest.bal
+++ b/modules/ballerina-native/src/test/resources/samples/websocket/connection_group_sample/connectionGroupTest.bal
@@ -29,6 +29,10 @@ service<ws> oddEvenWebSocketConnector {
             ws:removeConnectionFromGroup("oddGroup");
         } else if ("removeEvenConnection" == text) {
             ws:removeConnectionFromGroup("evenGroup");
+        } else if ("closeEvenGroup" == text) {
+            ws:closeConnectionGroup("evenGroup");
+        } else if ("closeOddGroup" == text) {
+            ws:closeConnectionGroup("oddGroup");
         } else {
             ws:pushTextToGroup("oddGroup", "oddGroup: " + messages:getStringPayload(m));
             ws:pushTextToGroup("evenGroup", "evenGroup: " + messages:getStringPayload(m));

--- a/modules/ballerina-native/src/test/resources/samples/websocket/connection_store_sample/httpService.bal
+++ b/modules/ballerina-native/src/test/resources/samples/websocket/connection_store_sample/httpService.bal
@@ -20,4 +20,12 @@ service<http> dataService {
         message res = {};
         reply res;
     }
+
+    @http:GET {}
+    @http:Path {value:"/close/{id}"}
+    resource closeConnection (message m, @http:PathParam {value:"id"} string id) {
+        ws:closeStoredConnection(id);
+        message res = {};
+        reply res;
+    }
 }

--- a/modules/ballerina-native/src/test/resources/samples/websocket/endpointTest.bal
+++ b/modules/ballerina-native/src/test/resources/samples/websocket/endpointTest.bal
@@ -13,6 +13,10 @@ service<ws> testEndpoint {
 
     @ws:OnTextMessage {}
     resource onTextMessage(message m) {
+        string  text = messages:getStringPayload(m);
+        if ("closeMe" == text) {
+            ws:closeConnection();
+        }
         ws:pushText(messages:getStringPayload(m));
     }
 

--- a/modules/ballerina-native/src/test/resources/testng.xml
+++ b/modules/ballerina-native/src/test/resources/testng.xml
@@ -107,8 +107,8 @@ under the License.
     <!-- WebSocket Test Cases -->
     <test name="websocket-test-cases" parallel="false">
         <classes>
-            <!--<class name="org.ballerinalang.nativeimpl.functions.ws.WebSocketEndpointTest"/>-->
-            <!--<class name="org.ballerinalang.nativeimpl.functions.ws.ConnectionGroupTest"/>-->
+            <class name="org.ballerinalang.nativeimpl.functions.ws.WebSocketEndpointTest"/>
+            <class name="org.ballerinalang.nativeimpl.functions.ws.ConnectionGroupTest"/>
             <class name="org.ballerinalang.nativeimpl.functions.ws.ConnectionStoreTest"/>
         </classes>
     </test>

--- a/modules/ballerina-native/src/test/resources/testng.xml
+++ b/modules/ballerina-native/src/test/resources/testng.xml
@@ -107,8 +107,8 @@ under the License.
     <!-- WebSocket Test Cases -->
     <test name="websocket-test-cases" parallel="false">
         <classes>
-            <class name="org.ballerinalang.nativeimpl.functions.ws.WebSocketEndpointTest"/>
-            <class name="org.ballerinalang.nativeimpl.functions.ws.ConnectionGroupTest"/>
+            <!--<class name="org.ballerinalang.nativeimpl.functions.ws.WebSocketEndpointTest"/>-->
+            <!--<class name="org.ballerinalang.nativeimpl.functions.ws.ConnectionGroupTest"/>-->
             <class name="org.ballerinalang.nativeimpl.functions.ws.ConnectionStoreTest"/>
         </classes>
     </test>

--- a/samples/getting_started/websocket/connectionGroupSample/README.txt
+++ b/samples/getting_started/websocket/connectionGroupSample/README.txt
@@ -13,14 +13,18 @@ groups as separate messages.
 oddEvenHttpService
 ------------------
 This is a http service which has several endpoints
-* /data/even
+* /groupInfo/even
  The message will be delivered to the evenGroup which is created in oddEvenWebSocketService.
-* /data/odd
+* /groupInfo/odd
  The message will be delivered to the oddGroup which is created in oddEvenWebSocketService.
-* /data/rm-even
+* /groupInfo/rm-even
  This will delete the evenGroup which is created in oddEvenWebSocketService.
-* /data/rm-odd
+* /groupInfo/rm-odd
  This will delete the oddGroup which is created in oddEvenWebSocketService.
+* /groupInfo/close-even
+ This will close the evenGroup which is created in oddEvenWebSocketService.
+* /groupInfo/close-odd
+ This will close the oddGroup which is created in oddEvenWebSocketService.
 
 Pre-requisites
 ==============

--- a/samples/getting_started/websocket/connectionGroupSample/oddEvenHttpService.bal
+++ b/samples/getting_started/websocket/connectionGroupSample/oddEvenHttpService.bal
@@ -43,4 +43,22 @@ service<http> oddEvenHttpService {
         messages:setStringPayload(res, "done");
         reply res;
     }
+
+    @http:GET {}
+    @http:Path {value:"/close-even"}
+    resource closeEven (message m) {
+        ws:closeConnectionGroup(oddWebSocketConnectionGroupName);
+        message res = {};
+        messages:setStringPayload(res, "done");
+        reply res;
+    }
+
+    @http:GET {}
+    @http:Path {value:"/close-odd"}
+    resource closeOdd (message m) {
+        ws:closeConnectionGroup(oddWebSocketConnectionGroupName);
+        message res = {};
+        messages:setStringPayload(res, "done");
+        reply res;
+    }
 }

--- a/samples/getting_started/websocket/connectionGroupSample/oddEvenHttpService.bal
+++ b/samples/getting_started/websocket/connectionGroupSample/oddEvenHttpService.bal
@@ -47,7 +47,7 @@ service<http> oddEvenHttpService {
     @http:GET {}
     @http:Path {value:"/close-even"}
     resource closeEven (message m) {
-        ws:closeConnectionGroup(oddWebSocketConnectionGroupName);
+        ws:closeConnectionGroup(evenWebSocketConnectionGroupName);
         message res = {};
         messages:setStringPayload(res, "done");
         reply res;

--- a/samples/getting_started/websocket/connectionStoreSample/httpService.bal
+++ b/samples/getting_started/websocket/connectionStoreSample/httpService.bal
@@ -16,7 +16,7 @@ service<http> dataService {
 
     @http:GET {}
     @http:Path {value:"/rm/{id}"}
-    resource deleteConnection (message m, @http:PathParam {value:"id"} string id) {
+    resource removeConnection (message m, @http:PathParam {value:"id"} string id) {
         ws:removeStoredConnection(id);
         message res = {};
         messages:setStringPayload(res, "done");
@@ -25,7 +25,7 @@ service<http> dataService {
 
     @http:GET {}
     @http:Path {value:"/close/{id}"}
-    resource deleteConnection (message m, @http:PathParam {value:"id"} string id) {
+    resource closeConnection (message m, @http:PathParam {value:"id"} string id) {
         ws:closeStoredConnection(id);
         message res = {};
         messages:setStringPayload(res, "done");

--- a/samples/getting_started/websocket/connectionStoreSample/httpService.bal
+++ b/samples/getting_started/websocket/connectionStoreSample/httpService.bal
@@ -22,4 +22,13 @@ service<http> dataService {
         messages:setStringPayload(res, "done");
         reply res;
     }
+
+    @http:GET {}
+    @http:Path {value:"/close/{id}"}
+    resource deleteConnection (message m, @http:PathParam {value:"id"} string id) {
+        ws:closeStoredConnection(id);
+        message res = {};
+        messages:setStringPayload(res, "done");
+        reply res;
+    }
 }

--- a/samples/getting_started/websocket/echoServer/README.txt
+++ b/samples/getting_started/websocket/echoServer/README.txt
@@ -1,7 +1,8 @@
 Description
 ===========
 This is a simple sample of WebSocket Server Connector of Ballerina.
-This will send you back "You said : " + text that you sent.
+This will send you back the same text that you sent.
+If you send "closeMe" then server will close the connection from the server side for the given connection.
 
 How to run the sample
 =====================

--- a/samples/getting_started/websocket/echoServer/server/websocketEchoServer.bal
+++ b/samples/getting_started/websocket/echoServer/server/websocketEchoServer.bal
@@ -14,7 +14,11 @@ service<ws> websocketEchoServer {
 
     @ws:OnTextMessage {}
     resource onTextMessage(message m) {
-        ws:pushText(messages:getStringPayload(m));
+        string stringPayload = messages:getStringPayload(m);
+        if ("closeMe" == stringPayload) {
+            ws:closeConnection(); // Close connection from server side
+        }
+        ws:pushText();
         system:println("client: " + messages:getStringPayload(m));
     }
 

--- a/samples/getting_started/websocket/echoServer/server/websocketEchoServer.bal
+++ b/samples/getting_started/websocket/echoServer/server/websocketEchoServer.bal
@@ -17,9 +17,10 @@ service<ws> websocketEchoServer {
         string stringPayload = messages:getStringPayload(m);
         if ("closeMe" == stringPayload) {
             ws:closeConnection(); // Close connection from server side
+        } else {
+            ws:pushText(stringPayload);
+            system:println("client: " + messages:getStringPayload(m));
         }
-        ws:pushText();
-        system:println("client: " + messages:getStringPayload(m));
     }
 
     @ws:OnClose {}


### PR DESCRIPTION
This PR includes new functions to close the client WebSocket connections easily.

- ws:closeConnection()
This function is used to close the current connection which is connected to a given resource. 

- ws:closeStoredConnection("connectionName")
This function is used to close a stored connection in a connection store.

- ws:closeConnectionGroup("connectionGroupName")
This function close all the client who are in the connection group.
