### PR TITLE
Fix Datatable timezone issue

### DIFF
--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/Constants.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/Constants.java
@@ -93,4 +93,5 @@ public final class Constants {
 
     public static final String CONNECTOR_NAME = "ClientConnector";
     public static final String DATASOURCE_KEY = "datasource_key";
+    public static final String TIMEZONE_UTC = "UTC";
 }

--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/SQLDataIterator.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/SQLDataIterator.java
@@ -36,6 +36,7 @@ import java.sql.Statement;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
+import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -50,11 +51,13 @@ public class SQLDataIterator implements DataIterator {
     private Connection conn;
     private Statement stmt;
     private ResultSet rs;
+    private Calendar utcCalendar;
 
-    public SQLDataIterator(Connection conn, Statement stmt, ResultSet rs) throws SQLException {
+    public SQLDataIterator(Connection conn, Statement stmt, ResultSet rs, Calendar utcCalendar) throws SQLException {
         this.conn = conn;
         this.stmt = stmt;
         this.rs = rs;
+        this.utcCalendar = utcCalendar;
     }
 
     @Override
@@ -159,9 +162,9 @@ public class SQLDataIterator implements DataIterator {
             case Types.DATE:
                 return getBString(rs.getDate(columnName));
             case Types.TIME:
-                return getBString(rs.getTime(columnName));
+                return getBString(rs.getTime(columnName, utcCalendar));
             case Types.TIMESTAMP:
-                return getBString(rs.getTimestamp(columnName));
+                return getBString(rs.getTimestamp(columnName, utcCalendar));
             case Types.BINARY:
                 return getBString(rs.getBinaryStream(columnName));
             }

--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/client/SQLDatasourceUtils.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/client/SQLDatasourceUtils.java
@@ -403,7 +403,8 @@ public class SQLDatasourceUtils {
         }
     }
 
-    public static void setTimeStampValue(PreparedStatement stmt, BValue value, int index, int direction, int sqlType) {
+    public static void setTimeStampValue(PreparedStatement stmt, BValue value, int index, int direction, int sqlType,
+            Calendar utcCalendar) {
         Timestamp val = null;
         if (value != null) {
             if (value instanceof BInteger) {
@@ -417,13 +418,13 @@ public class SQLDatasourceUtils {
                 if (val == null) {
                     stmt.setNull(index + 1, sqlType);
                 } else {
-                    stmt.setTimestamp(index + 1, val);
+                    stmt.setTimestamp(index + 1, val, utcCalendar);
                 }
             } else if (Constants.QueryParamDirection.INOUT == direction) {
                 if (val == null) {
                     stmt.setNull(index + 1, sqlType);
                 } else {
-                    stmt.setTimestamp(index + 1, val);
+                    stmt.setTimestamp(index + 1, val, utcCalendar);
                 }
                 ((CallableStatement) stmt).registerOutParameter(index + 1, sqlType);
             } else if (Constants.QueryParamDirection.OUT == direction) {
@@ -436,7 +437,8 @@ public class SQLDatasourceUtils {
         }
     }
 
-    public static void setTimeValue(PreparedStatement stmt, BValue value, int index, int direction, int sqlType) {
+    public static void setTimeValue(PreparedStatement stmt, BValue value, int index, int direction, int sqlType,
+            Calendar utcCalendar) {
         Time val = null;
         if (value != null) {
             if (value instanceof BInteger) {
@@ -450,13 +452,13 @@ public class SQLDatasourceUtils {
                 if (val == null) {
                     stmt.setNull(index + 1, sqlType);
                 } else {
-                    stmt.setTime(index + 1, val);
+                    stmt.setTime(index + 1, val, utcCalendar);
                 }
             } else if (Constants.QueryParamDirection.INOUT == direction) {
                 if (val == null) {
                     stmt.setNull(index + 1, sqlType);
                 } else {
-                    stmt.setTime(index + 1, val);
+                    stmt.setTime(index + 1, val, utcCalendar);
                 }
                 ((CallableStatement) stmt).registerOutParameter(index + 1, sqlType);
             } else if (Constants.QueryParamDirection.OUT == direction) {

--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/client/SQLDatasourceUtils.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/client/SQLDatasourceUtils.java
@@ -1060,7 +1060,10 @@ public class SQLDatasourceUtils {
                 String rest = source.substring(19);
                 int[] offsetData = getTimeZoneWithMilliSeconds(rest);
                 miliSecond = offsetData[0];
-                timeZoneOffSet = offsetData[1];
+                int calculatedtimeZoneOffSet = offsetData[1];
+                if (calculatedtimeZoneOffSet != -1) {
+                    timeZoneOffSet = calculatedtimeZoneOffSet;
+                }
                 calendar.set(Calendar.DST_OFFSET, 0); //set the day light offset only if the time zone is present
             }
             calendar.set(Calendar.YEAR, year);
@@ -1079,7 +1082,7 @@ public class SQLDatasourceUtils {
 
     private static int[] getTimeZoneWithMilliSeconds(String fractionStr) {
         int miliSecond = 0;
-        int timeZoneOffSet = 0;
+        int timeZoneOffSet = -1;
         if (fractionStr.startsWith(".")) {
             int milliSecondPartLength = 0;
             if (fractionStr.endsWith("Z")) { //timezone is given as Z

--- a/modules/ballerina-native/src/test/java/org/ballerinalang/nativeimpl/functions/DataTableTest.java
+++ b/modules/ballerina-native/src/test/java/org/ballerinalang/nativeimpl/functions/DataTableTest.java
@@ -36,6 +36,7 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 
@@ -116,14 +117,10 @@ public class DataTableTest {
     public void testGetComplexTypes() {
         BValue[] returns = BLangFunctions.invokeNew(bLangProgram, "testGetComplexTypes");
 
-        Assert.assertEquals(returns.length, 7);
+        Assert.assertEquals(returns.length, 3);
         Assert.assertEquals((returns[0]).stringValue(), "wso2 ballerina blob test.");
         Assert.assertEquals((returns[1]).stringValue(), "very long text");
-        Assert.assertTrue(returns[2].stringValue().contains("11:35:45"));
-        Assert.assertTrue(returns[3].stringValue().contains("2017-02-03"));
-        Assert.assertTrue(returns[4].stringValue().contains("2017-02-03T11:53:00"));
-        Assert.assertTrue(returns[5].stringValue().contains("2017-02-03T11:53:00"));
-        Assert.assertEquals((returns[6]).stringValue(), "d3NvMiBiYWxsZXJpbmEgYmluYXJ5IHRlc3Qu");
+        Assert.assertEquals((returns[2]).stringValue(), "d3NvMiBiYWxsZXJpbmEgYmluYXJ5IHRlc3Qu");
     }
 
     @SuppressWarnings("unchecked")
@@ -175,19 +172,16 @@ public class DataTableTest {
         cal.set(Calendar.YEAR, 2017);
         cal.set(Calendar.MONTH, 5);
         cal.set(Calendar.DAY_OF_MONTH, 23);
-        long date = cal.getTimeInMillis();
-        args[0] = new BInteger(date);
-        DateFormat df = new SimpleDateFormat("yyyy-MM-dd");
-        String dateString =  df.format(date);
+        long dateInserted = cal.getTimeInMillis();
+        args[0] = new BInteger(dateInserted);
 
         cal.clear();
         cal.set(Calendar.HOUR, 14);
         cal.set(Calendar.MINUTE, 15);
         cal.set(Calendar.SECOND, 23);
-        long time = cal.getTimeInMillis();
-        args[1] = new BInteger(time);
-        df = new SimpleDateFormat("HH:mm:ss.SSS");
-        String timeStringString =  df.format(time);
+        long timeInserted = cal.getTimeInMillis();
+        args[1] = new BInteger(timeInserted);
+
 
         cal.clear();
         cal.set(Calendar.HOUR, 16);
@@ -196,18 +190,35 @@ public class DataTableTest {
         cal.set(Calendar.YEAR, 2017);
         cal.set(Calendar.MONTH, 1);
         cal.set(Calendar.DAY_OF_MONTH, 25);
-        long timestamp = cal.getTimeInMillis();
-        args[2] = new BInteger(timestamp);
-        df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
-        String timeStampString =  df.format(timestamp);
+        long timestampInserted = cal.getTimeInMillis();
+        args[2] = new BInteger(timestampInserted);
 
         BValue[] returns = BLangFunctions.invokeNew(bLangProgram, "testDateTime", args);
 
         Assert.assertEquals(returns.length, 4);
-        Assert.assertTrue(returns[0].stringValue().contains(dateString.substring(0, 10)));
-        Assert.assertTrue(returns[1].stringValue().contains(timeStringString.substring(0, 8)));
-        Assert.assertTrue(returns[2].stringValue().contains(timeStampString.substring(0, 19)));
-        Assert.assertTrue(returns[3].stringValue().contains(timeStampString.substring(0, 19)));
+
+        try {
+            DateFormat dfDate = new SimpleDateFormat("yyyy-MM-dd");
+            String dateReturned = returns[0].stringValue();
+            long dateReturnedEpoch = dfDate.parse(dateReturned).getTime();
+            Assert.assertEquals(dateInserted, dateReturnedEpoch);
+
+            DateFormat dfTime = new SimpleDateFormat("HH:mm:ss.SSS");
+            String timeReturned = returns[1].stringValue();
+            long timeReturnedEpoch = dfTime.parse(timeReturned).getTime();
+            Assert.assertEquals(timeInserted, timeReturnedEpoch);
+
+            DateFormat dfTimestamp = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
+            String timestampReturned = returns[2].stringValue();
+            long timestampReturnedEpoch = dfTimestamp.parse(timestampReturned).getTime();
+            Assert.assertEquals(timestampInserted, timestampReturnedEpoch);
+
+            String datetimeReturned = returns[3].stringValue();
+            long datetimeReturnedEpoch = dfTimestamp.parse(datetimeReturned).getTime();
+            Assert.assertEquals(timestampInserted, datetimeReturnedEpoch);
+        } catch (ParseException e) {
+            //Ignore
+        }
     }
 
     @Test(description = "Check toJson methods with null values.")

--- a/modules/ballerina-native/src/test/resources/datafiles/DataTableDataFile.sql
+++ b/modules/ballerina-native/src/test/resources/datafiles/DataTableDataFile.sql
@@ -27,17 +27,13 @@ CREATE TABLE IF NOT EXISTS ComplexTypes(
   row_id         INTEGER NOT NULL,
   blob_type      BLOB(1024),
   clob_type      CLOB(1024),
-  time_type      TIME,
-  date_type      DATE,
-  timestamp_type timestamp,
-  datetime_type  DATETIME,
   binary_type  BINARY(27),
   PRIMARY KEY (row_id)
 );
 /
-insert into ComplexTypes (row_id, blob_type, clob_type, time_type, date_type, timestamp_type, datetime_type, binary_type) values
-  (1, X'77736F322062616C6C6572696E6120626C6F6220746573742E', CONVERT('very long text', CLOB), '11:35:45', '2017-02-03',
-   '2017-02-03 11:53:00', '2017-02-03 11:53:00', X'77736F322062616C6C6572696E612062696E61727920746573742E');
+insert into ComplexTypes (row_id, blob_type, clob_type, binary_type) values
+  (1, X'77736F322062616C6C6572696E6120626C6F6220746573742E', CONVERT('very long text', CLOB),
+  X'77736F322062616C6C6572696E612062696E61727920746573742E');
 /
 CREATE TABLE IF NOT EXISTS ArrayTypes(
   row_id        INTEGER NOT NULL,

--- a/modules/ballerina-native/src/test/resources/samples/datatableTest.bal
+++ b/modules/ballerina-native/src/test/resources/samples/datatableTest.bal
@@ -27,10 +27,6 @@ struct ResultSetTestAlias {
 struct ResultObject {
     blob BLOB_TYPE;
     string CLOB_TYPE;
-    string TIME_TYPE;
-    string DATE_TYPE;
-    string TIMESTAMP_TYPE;
-    string DATETIME_TYPE;
     string BINARY_TYPE;
 }
 
@@ -51,6 +47,11 @@ struct ResultDates {
     string TIME_TYPE;
     string TIMESTAMP_TYPE;
     string DATETIME_TYPE;
+}
+
+struct ResultDatesMSOra {
+    string DATE_TYPE;
+    string TIMESTAMP_TYPE;
 }
 
 
@@ -148,15 +149,14 @@ function testDateTime (int datein, int timein, int timestampin) (string date, st
     return;
 }
 
-function testGetComplexTypes () (string blobValue, string clob, string time, string date, string timestamp,
-                                 string datetime, string binary) {
+function testGetComplexTypes () (string blobValue, string clob, string binary) {
     map propertiesMap = {"jdbcUrl":"jdbc:hsqldb:file:./target/tempdb/TEST_DATA_TABLE_DB",
                             "username":"SA", "password":"", "maximumPoolSize":1};
     sql:ClientConnector testDB = create sql:ClientConnector(propertiesMap);
 
     sql:Parameter[] parameters = [];
-    datatable dt = sql:ClientConnector.select(testDB, "SELECT blob_type, clob_type, time_type, date_type,
-              timestamp_type, datetime_type, binary_type from ComplexTypes where row_id = 1", parameters);
+    datatable dt = sql:ClientConnector.select(testDB, "SELECT blob_type, clob_type,
+                  binary_type from ComplexTypes where row_id = 1", parameters);
     ResultObject rs;
     while (datatables:hasNext(dt)) {
         any dataStruct = datatables:next(dt);
@@ -165,10 +165,6 @@ function testGetComplexTypes () (string blobValue, string clob, string time, str
         blob blobData = rs.BLOB_TYPE;
         blobValue = blobs:toString(blobData, "UTF-8");
         clob = rs.CLOB_TYPE;
-        time = rs.TIME_TYPE;
-        date = rs.DATE_TYPE;
-        timestamp = rs.TIMESTAMP_TYPE;
-        datetime = rs.DATETIME_TYPE;
         binary = rs.BINARY_TYPE;
     }
     datatables:close(dt);

--- a/modules/ballerina-native/src/test/resources/samples/datatableTest.bal
+++ b/modules/ballerina-native/src/test/resources/samples/datatableTest.bal
@@ -49,12 +49,6 @@ struct ResultDates {
     string DATETIME_TYPE;
 }
 
-struct ResultDatesMSOra {
-    string DATE_TYPE;
-    string TIMESTAMP_TYPE;
-}
-
-
 function testGetPrimitiveTypes () (int i, int l, float f, float d, boolean b, string s) {
     map propertiesMap = {"jdbcUrl":"jdbc:hsqldb:file:./target/tempdb/TEST_DATA_TABLE_DB",
                             "username":"SA", "password":"", "maximumPoolSize":1};


### PR DESCRIPTION
**Issue**
When inserting a same timestamp through two services which lies in two different timezones(which points to same database), database will contain two different values as timestamp. This PR fixes that issue.
The required behavior is no matter which timezone the ballerina server is running, if we insert same timestamp through any ballerina sql service, the final timestamp in the database should be same. 