### PR TITLE
normalize breakpoints package path to /

### DIFF
--- a/modules/ballerina-core/src/main/java/org/ballerinalang/util/debugger/dto/CommandDTO.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/util/debugger/dto/CommandDTO.java
@@ -20,7 +20,9 @@ package org.ballerinalang.util.debugger.dto;
 
 import org.ballerinalang.model.NodeLocation;
 
+import java.io.File;
 import java.util.ArrayList;
+import java.util.regex.Matcher;
 
 /**
  * DTO class representing commands send to debugger from the client.
@@ -58,7 +60,11 @@ public class CommandDTO {
     public ArrayList<NodeLocation> getBreakPoints() {
         ArrayList<NodeLocation> breakPoints = new ArrayList<NodeLocation>();
         for (BreakPointDTO bp: points) {
-            breakPoints.add(new NodeLocation(bp.getFileName(), bp.getLineNumber()));
+            // TODO : Change the API for accepting breakpoints
+            // convert "/" into platform's file separator
+            // Server should derive actual file path from path sent from debugger client which is normalized to /
+            String fileName = bp.getFileName().replaceAll("/", Matcher.quoteReplacement(File.separator));
+            breakPoints.add(new NodeLocation(fileName, bp.getLineNumber()));
         }
         return breakPoints;
     }


### PR DESCRIPTION
Debug server and Debugger client can run on different operating systems. Since debug server is encapsulated from debugger client, debugger client doesn't know what OS runs on debug server. So
Debug server should actually derive actual file paths/package paths from paths sent from debugger client.
In this PR debugger server accepts file paths separated with `/` irrespective of the OS and converts to path compatible with debugger server.