### PR TITLE
Fix JMS message headers and property issues

### DIFF
--- a/modules/ballerina-core/src/main/java/org/ballerinalang/model/values/BMap.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/model/values/BMap.java
@@ -20,7 +20,11 @@ package org.ballerinalang.model.values;
 import org.ballerinalang.model.types.BType;
 import org.ballerinalang.model.types.BTypes;
 import org.ballerinalang.runtime.message.BallerinaMessageDataSource;
+import org.ballerinalang.util.exceptions.BallerinaException;
 
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -39,6 +43,11 @@ public class BMap<K, V extends BValue> extends BallerinaMessageDataSource implem
     private static final int MAX_CAPACITY = 1 << 16;
     @SuppressWarnings("unchecked")
     private MapEntry<K, V>[] values = new MapEntry[INITIAL_CAPACITY];
+
+    /**
+     * Output stream to write message out to the socket
+     */
+     private OutputStream outputStream;
 
     /**
      * Retrieve the value for the given key from map.
@@ -195,5 +204,23 @@ public class BMap<K, V extends BValue> extends BallerinaMessageDataSource implem
         }
     }
 
+    @Override
+    public String getMessageAsString() {
+        return stringValue();
+    }
+
+    @Override
+    public void serializeData() {
+        try {
+            outputStream.write(stringValue().getBytes(Charset.defaultCharset()));
+        } catch (IOException e) {
+            throw new BallerinaException("Error occurred while serializing data", e);
+        }
+    }
+
+    @Override
+    public void setOutputStream(OutputStream outputStream) {
+        this.outputStream = outputStream;
+    }
 }
 

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/runtime/message/BallerinaMessageDataSource.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/runtime/message/BallerinaMessageDataSource.java
@@ -62,11 +62,6 @@ public class BallerinaMessageDataSource implements MessageDataSource {
         // This is where we write to output stream
     }
 
-//    @Override
-//    public String getMessageAsString() {
-//        return null;
-//    }
-
     public void setOutputStream(OutputStream outputStream) {
     }
 

--- a/modules/ballerina-native/src/main/ballerina/ballerina/net/jms/natives.bal
+++ b/modules/ballerina-native/src/main/ballerina/ballerina/net/jms/natives.bal
@@ -15,13 +15,54 @@ native function rollback (message m);
 @doc:Param { value:"message: message" }
 native function commit (message m);
 
+@doc:Description { value:"JMS client connector to send messages to the JMS provider."}
+@doc:Param { value:"connection and optional properties for the connector"}
 connector ClientConnector (map properties) {
 
-	@doc:Description { value:"SEND action implementation of the JMS Connector"}
-	@doc:Param { value:"connector: Connector" }
-	@doc:Param { value:"destinationName: Destination Name" }
-	@doc:Param { value:"msgType: Message Type" }
-	@doc:Param { value:"message: Message" }
-	native action send (ClientConnector jmsClientConnector, string destinationName, string msgType, message m) (boolean);
+    @doc:Description {value:"SEND action implementation of the JMS Connector"}
+    @doc:Param {value:"connector: Connector"}
+    @doc:Param {value:"destinationName: Destination Name"}
+    @doc:Param {value:"message: Message"}
+    native action send (ClientConnector jmsClientConnector, string destinationName, message m) (boolean);
 
 }
+
+@doc:Description { value:"Header key for message ID. This is not a required header and jms client application might set the value when sending the message to the JMS broker."}
+const string HEADER_MESSAGE_ID = "JMS_MESSAGE_ID";
+
+@doc:Description { value:"JMS priority value header for the message. Priority value can range from 0 to 9. 0 is the lowest priority. 9 is the highest priority"}
+const string HEADER_PRIORITY = "JMS_PRIORITY";
+
+@doc:Description { value:"Header for JMS message expiry. "}
+const string HEADER_EXPIRATION = "JMS_EXPIRATION";
+
+@doc:Description { value:"Header to check the message delivery status. Whether the message is being redelivered from the JMS broker. This cannot be used to set the redilvered header for the message"}
+const string HEADER_REDELIVERED = "JMS_REDELIVERED";
+
+@doc:Description { value:"JMS correlation id message header"}
+const string HEADER_CORRELATION_ID = "JMS_CORRELATION_ID";
+
+@doc:Description { value:"JMS destination message header"}
+const string HEADER_DESTINATION = "JMS_DESTINATION";
+
+@doc:Description { value:"JMS timestamp message header"}
+const string HEADER_TIMESTAMP = "JMS_TIMESTAMP";
+
+@doc:Description { value:"JMS reply to message header"}
+const string HEADER_REPLY_TO = "JMS_REPLY_TO";
+
+@doc:Description { value:"Header to set the jms message type. The JMS API does not define a standard message definition repository and it is upto the user to set this header. Some JMS providers may have restricted set of message type values."}
+const string HEADER_MESSAGE_TYPE = "JMS_TYPE";
+
+@doc:Description { value:"JMS delivery mode message header. Can select either persistent or non persitent message delivery for the message"}
+const string HEADER_DELIVERY_MODE = "JMS_DELIVERY_MODE";
+
+@doc:Description { value:"Value for persistent JMS message delivery mode"}
+const string PERSISTENT_DELIVERY_MODE = "2";
+
+@doc:Description { value:"Value for non persistent JMS message delivery mode"}
+const string NON_PERSISTENT_DELIVERY_MODE = "1";
+
+const string DELIVERY_SUCCESS = "Success";
+
+const string DELIVERY_ERROR = "Error";

--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/lang/utils/Constants.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/lang/utils/Constants.java
@@ -42,6 +42,11 @@ public class Constants {
     public static final String TEXT_PLAIN = "text/plain";
 
     /**
+     * HTTP content-type application/octet-stream
+     */
+    public static final String OCTET_STREAM = "application/octet-stream";
+
+    /**
      * HTTP content-type application/x-www-form-urlencoded.
      */
     public static final String APPLICATION_FORM = "application/x-www-form-urlencoded";

--- a/samples/getting_started/jms/jmsSender.bal
+++ b/samples/getting_started/jms/jmsSender.bal
@@ -16,6 +16,7 @@ function jmsSender() (boolean) {
     message queueMessage = {};
     messages:setStringPayload(queueMessage, "Hello from JMS");
 
-    jms:ClientConnector.send(jmsEP, "MyQueue", "TextMessage", queueMessage);
+    jms:ClientConnector.send(jmsEP, "MyQueue", queueMessage);
     return true;
 }
+


### PR DESCRIPTION
- Add support for all the JMS Message headers

- Fix JMS message property not properly getting set issue

- Remove JMS message type argument from JMS send function. Use the CarbonMessage content-type header value to infer the underlying JMS message type
    
    |JMS Message Type | Content Type|
    | ----------------------------|--------------------|
    | TextMessage  | text/plain, application/json, application/xml|
    |MapMessage   | application/x-www-form-urlencoded|
    |BytesMessage | any other type|

Fixed Issues:
 https://github.com/ballerinalang/ballerina/issues/2529
 https://github.com/ballerinalang/ballerina/issues/2585
 https://github.com/ballerinalang/ballerina/issues/2596