### PR TITLE
Add struct/map/array stringValue() implementation

### DIFF
--- a/modules/ballerina-core/src/main/java/org/ballerinalang/model/values/BBooleanArray.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/model/values/BBooleanArray.java
@@ -22,6 +22,7 @@ import org.ballerinalang.model.types.BType;
 import org.ballerinalang.model.types.BTypes;
 
 import java.util.Arrays;
+import java.util.StringJoiner;
 
 /**
  * @since 0.87
@@ -66,5 +67,14 @@ public class BBooleanArray extends BNewArray {
         BBooleanArray booleanArray = new BBooleanArray(Arrays.copyOf(values, values.length));
         booleanArray.size = this.size;
         return booleanArray;
+    }
+    
+    @Override
+    public String stringValue() {
+        StringJoiner sj = new StringJoiner(",", "[", "]");
+        for (int i = 0; i < size; i++) {
+            sj.add(Boolean.toString(values[i] == 1));
+        }
+        return sj.toString();
     }
 }

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/model/values/BFloatArray.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/model/values/BFloatArray.java
@@ -22,6 +22,7 @@ import org.ballerinalang.model.types.BType;
 import org.ballerinalang.model.types.BTypes;
 
 import java.util.Arrays;
+import java.util.StringJoiner;
 
 /**
  * @since 0.87
@@ -66,5 +67,14 @@ public class BFloatArray extends BNewArray {
         BFloatArray floatArray = new BFloatArray(Arrays.copyOf(values, values.length));
         floatArray.size = size;
         return floatArray;
+    }
+    
+    @Override
+    public String stringValue() {
+        StringJoiner sj = new StringJoiner(",", "[", "]");
+        for (int i = 0; i < size; i++) {
+            sj.add(Double.toString(values[i]));
+        }
+        return sj.toString();
     }
 }

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/model/values/BIntArray.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/model/values/BIntArray.java
@@ -22,6 +22,7 @@ import org.ballerinalang.model.types.BType;
 import org.ballerinalang.model.types.BTypes;
 
 import java.util.Arrays;
+import java.util.StringJoiner;
 
 /**
  * @since 0.87
@@ -66,5 +67,14 @@ public class BIntArray extends BNewArray {
         BIntArray intArray = new BIntArray(Arrays.copyOf(values, values.length));
         intArray.size = this.size;
         return intArray;
+    }
+    
+    @Override
+    public String stringValue() {
+        StringJoiner sj = new StringJoiner(",", "[", "]");
+        for (int i = 0; i < size; i++) {
+            sj.add(Long.toString(values[i]));
+        }
+        return sj.toString();
     }
 }

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/model/values/BMap.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/model/values/BMap.java
@@ -24,6 +24,7 @@ import org.ballerinalang.runtime.message.BallerinaMessageDataSource;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.StringJoiner;
 
 /**
  * {@code MapType} represents a map.
@@ -138,7 +139,23 @@ public class BMap<K, V extends BValue> extends BallerinaMessageDataSource implem
 
     @Override
     public String stringValue() {
-        return null;
+        StringJoiner sj = new StringJoiner(",", "{", "}");
+        String key;
+        BValue value;
+        String stringValue;
+        for (int i = 0; i < size; i++) {
+            key = "\"" + (String) values[i].getKey() + "\"";
+            value = values[i].getValue();
+            if (value == null) {
+                stringValue = null;
+            } else if (value instanceof BString) {
+                stringValue = "\"" + value.stringValue() + "\"";
+            } else {
+                stringValue = value.stringValue();
+            }
+            sj.add(key + ":" + stringValue);
+        }
+        return sj.toString();
     }
 
     @Override

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/model/values/BRefValueArray.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/model/values/BRefValueArray.java
@@ -20,6 +20,7 @@ package org.ballerinalang.model.values;
 import org.ballerinalang.model.types.BType;
 
 import java.util.Arrays;
+import java.util.StringJoiner;
 
 /**
  * @since 0.87
@@ -69,5 +70,14 @@ public class BRefValueArray extends BNewArray {
         BRefValueArray refValueArray = new BRefValueArray(Arrays.copyOf(values, values.length));
         refValueArray.size = this.size;
         return refValueArray;
+    }
+    
+    @Override
+    public String stringValue() {
+        StringJoiner sj = new StringJoiner(",", "[", "]");
+        for (int i = 0; i < size; i++) {
+            sj.add(values[i] == null ? "null" : values[i].stringValue());
+        }
+        return sj.toString();
     }
 }

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/model/values/BStringArray.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/model/values/BStringArray.java
@@ -22,6 +22,7 @@ import org.ballerinalang.model.types.BType;
 import org.ballerinalang.model.types.BTypes;
 
 import java.util.Arrays;
+import java.util.StringJoiner;
 
 /**
  * @since 0.87
@@ -66,5 +67,14 @@ public class BStringArray extends BNewArray {
         BStringArray stringArray = new BStringArray(Arrays.copyOf(values, values.length));
         stringArray.size = this.size;
         return stringArray;
+    }
+
+    @Override
+    public String stringValue() {
+        StringJoiner sj = new StringJoiner(",", "[", "]");
+        for (int i = 0; i < size; i++) {
+            sj.add("\"" + values[i] + "\"");
+        }
+        return sj.toString();
     }
 }

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/model/values/BStruct.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/model/values/BStruct.java
@@ -17,11 +17,15 @@
 package org.ballerinalang.model.values;
 
 import org.ballerinalang.model.StructDef;
+import org.ballerinalang.model.types.BStructType;
+import org.ballerinalang.model.types.BStructType.StructField;
 import org.ballerinalang.model.types.BType;
+import org.ballerinalang.model.types.BTypes;
 
 import java.util.Arrays;
 
 import java.util.HashMap;
+import java.util.StringJoiner;
 
 /**
  * The {@code BStruct} represents the value of a user defined struct in Ballerina.
@@ -119,7 +123,35 @@ public final class BStruct implements BRefType<StructDef>, StructureType {
      */
     @Override
     public String stringValue() {
-        return null;
+        int stringIndex = 0,
+                intIndex = 0,
+                longIndex = 0,
+                doubleIndex = 0,
+                byteIndex = 0,
+                refValIndex = 0;
+        
+        StringJoiner sj = new StringJoiner(",", "{", "}");
+        for (StructField field : ((BStructType) structType).getStructFields()) {
+            String fieldName = field.getFieldName();
+            Object fieldVal;
+            BType fieldType = field.getFieldType();
+            if (fieldType == BTypes.typeString) {
+                fieldVal = "\"" + stringFields[stringIndex++] + "\"";
+            } else if (fieldType == BTypes.typeInt) {
+                fieldVal = longFields[longIndex++];
+            } else if (fieldType == BTypes.typeFloat) {
+                fieldVal = doubleFields[doubleIndex++];
+            }  else if (fieldType == BTypes.typeBoolean) {
+                fieldVal = intFields[intIndex++];
+            } else if (fieldType == BTypes.typeBlob) {
+                fieldVal = byteFields[byteIndex++].toString();
+            } else {
+                BValue val = refFields[refValIndex++];
+                fieldVal = val == null ? null : val.stringValue();
+            }
+            sj.add(fieldName + ":" + fieldVal);
+        }
+        return sj.toString();
     }
 
     @Override

--- a/modules/ballerina-core/src/test/java/org/ballerinalang/model/structs/StructTest.java
+++ b/modules/ballerina-core/src/test/java/org/ballerinalang/model/structs/StructTest.java
@@ -157,8 +157,14 @@ public class StructTest {
         Assert.assertEquals(((BFloat) returns[2]).floatValue(), -88.234);
         Assert.assertEquals(((BFloat) returns[3]).floatValue(), -24.99);
     }
-
     
+    @Test(description = "Test negative default values in struct")
+    public void testStructToString() {
+        BValue[] returns = BLangFunctions.invokeNew(programFile, "getStruct");
+        Assert.assertEquals(returns[0].stringValue(), "{name:\"aaa\",lname:\"\",adrs:null,age:25,family:null,parent:" +
+                "{name:\"bbb\",lname:\"ccc\",adrs:null,age:50,family:null,parent:null}}");
+    }
+
     /*
      *  Negative tests
      */

--- a/modules/ballerina-core/src/test/java/org/ballerinalang/model/values/BMapValueTest.java
+++ b/modules/ballerina-core/src/test/java/org/ballerinalang/model/values/BMapValueTest.java
@@ -165,4 +165,14 @@ public class BMapValueTest   {
     void testInvalidGrammar3() {
         BTestUtils.getProgramFile("lang/values/map-value-invalid3.bal");
     }
+    
+    @Test
+    public void testBMapToString() {
+        BMap<String, BRefType> map = new BMap<>();
+        map.put(new String("key1"), new BInteger(1));
+        map.put(new String("key2"), new BString("foo"));
+        map.put(new String("key3"), new BXMLItem("<bar>hello</bar>"));
+        
+        Assert.assertEquals(map.stringValue(), "{\"key1\":1,\"key2\":\"foo\",\"key3\":<bar>hello</bar>}");
+    }
 }

--- a/modules/ballerina-core/src/test/resources/lang/structs/struct.bal
+++ b/modules/ballerina-core/src/test/resources/lang/structs/struct.bal
@@ -106,3 +106,8 @@ function getStructNegativeValues()(int, int, float, float) {
     NegativeValTest tmp = {};
     return tmp.negativeInt, tmp.negativeSpaceInt, tmp.negativeFloat, tmp.negativeSpaceFloat;
 }
+
+function getStruct() (Person) {
+    Person p1 = {name:"aaa", age:25, parent:{name:"bbb", lname:"ccc", age:50}};
+    return p1;
+}

--- a/modules/ballerina-native/src/test/java/org/ballerinalang/nativeimpl/functions/ArrayTest.java
+++ b/modules/ballerina-native/src/test/java/org/ballerinalang/nativeimpl/functions/ArrayTest.java
@@ -17,6 +17,7 @@
 */
 package org.ballerinalang.nativeimpl.functions;
 
+import org.ballerinalang.model.values.BBooleanArray;
 import org.ballerinalang.model.values.BFloatArray;
 import org.ballerinalang.model.values.BIntArray;
 import org.ballerinalang.model.values.BInteger;
@@ -522,5 +523,28 @@ public class ArrayTest {
         Assert.assertEquals(((BStringArray) returnVals[0]).get(0), "country");
         Assert.assertEquals(((BStringArray) returnVals[0]).get(1), "currency");
         Assert.assertEquals(((BStringArray) returnVals[0]).get(2), "states");
+    }
+    
+    @Test
+    public void testArrayToString() {
+        String[] strArray = { "aaa", "bbb", "ccc" };
+        BStringArray bStringArray = new BStringArray(strArray);
+        Assert.assertEquals(bStringArray.stringValue(), "[\"aaa\",\"bbb\",\"ccc\"]");
+
+        long[] longArray = { 6, 3, 8, 4 };
+        BIntArray bIntArray = new BIntArray(longArray);
+        Assert.assertEquals(bIntArray.stringValue(), "[6,3,8,4]");
+
+        double[] doubleArray = { 6.4, 3.7, 8.8, 7.4 };
+        BFloatArray bFloatArray = new BFloatArray(doubleArray);
+        Assert.assertEquals(bFloatArray.stringValue(), "[6.4,3.7,8.8,7.4]");
+
+        int[] boolArray = { 1, 1, 0 };
+        BBooleanArray bBooleanArray = new BBooleanArray(boolArray);
+        Assert.assertEquals(bBooleanArray.stringValue(), "[true,true,false]");
+
+        BXMLItem[] xmlArray = { new BXMLItem("<foo/>"), new BXMLItem("<bar>hello</bar>") };
+        BRefValueArray bXmlArray = new BRefValueArray(xmlArray);
+        Assert.assertEquals(bXmlArray.stringValue(), "[<foo/>,<bar>hello</bar>]");
     }
 }


### PR DESCRIPTION
Currently `stringValue()` method returns null for structs, maps and arrays. As a result, if we pass any of those three to a `println()` function, it will print null. This PR fixes this issue.

With this fix, the outputs will be as follows:

Struct:
```
{name:"Jack",age:20,siblings:null}
```

Map:
```
{"key1":123,"key2":"foo","key3":<bar>hello</bar>}
```

Array:
```
[45,86,64]

["foo","bar"]

[<foo>hello</foo>,<bar>hello</bar>]

[true,true,false]
```