### PR TITLE
Remove dependency on jndi.properties file

### DIFF
--- a/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/jms/JMSServiceDispatcher.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/jms/JMSServiceDispatcher.java
@@ -161,8 +161,6 @@ public class JMSServiceDispatcher implements ServiceDispatcher {
 
         List<AnnotationAttachmentInfo> connectionProperties = new ArrayList<>();
 
-        AnnotationAttachmentInfo jmsSource = service.getAnnotationAttachmentInfo(Constants.JMS_PACKAGE,
-                Constants.ANNOTATION_JMS_SOURCE);
         AnnotationAttributeInfo attributeInfo = (AnnotationAttributeInfo) service.getAttributeInfo(
                 AttributeInfo.ANNOTATIONS_ATTRIBUTE);
         if (attributeInfo != null) {
@@ -174,33 +172,25 @@ public class JMSServiceDispatcher implements ServiceDispatcher {
             }
         }
 
-        if (jmsSource != null) {
-            Map<String, String> annotationKeyValuePairs = connectionProperties.stream()
-                    .collect(Collectors.toMap(
-                            entry -> entry.getAnnotationAttributeValue
-                                    (Constants.CONNECTION_PROPERTY_KEY).getStringValue(),
-                            entry -> entry.getAnnotationAttributeValue
-                                    (Constants.CONNECTION_PROPERTY_VALUE).getStringValue()
-                    ));
+        Map<String, String> annotationKeyValuePairs = connectionProperties.stream()
+                .collect(Collectors.toMap(
+                        entry -> entry.getAnnotationAttributeValue
+                                (Constants.CONNECTION_PROPERTY_KEY).getStringValue(),
+                        entry -> entry.getAnnotationAttributeValue
+                                (Constants.CONNECTION_PROPERTY_VALUE).getStringValue()
+                ));
 
-            annotationKeyValuePairs.put(Constants.CONNECTION_PROPERTY_FACTORY_INITIAL,
-                    jmsSource.getAnnotationAttributeValue
-                            (Constants.CONNECTION_PROPERTY_FACTORY_INITIAL).getStringValue());
-            annotationKeyValuePairs.put(Constants.CONNECTION_PROPERTY_PROVIDE_URL,
-                    jmsSource.getAnnotationAttributeValue
-                            (Constants.CONNECTION_PROPERTY_PROVIDE_URL).getStringValue());
 
-            String serviceId = service.getName();
-            serviceInfoMap.put(serviceId, service);
-            annotationKeyValuePairs.putIfAbsent(Constants.JMS_DESTINATION, serviceId);
-            ServerConnector serverConnector = BallerinaConnectorManager.getInstance()
-                    .createServerConnector(Constants.PROTOCOL_JMS, serviceId, annotationKeyValuePairs);
-            try {
-                serverConnector.start();
-            } catch (ServerConnectorException e) {
-                throw new BallerinaException("Error when starting to listen to the queue/topic while " + serviceId +
-                        " deployment", e);
-            }
+        String serviceId = service.getName();
+        serviceInfoMap.put(serviceId, service);
+        annotationKeyValuePairs.putIfAbsent(Constants.JMS_DESTINATION, serviceId);
+        ServerConnector serverConnector = BallerinaConnectorManager.getInstance()
+                .createServerConnector(Constants.PROTOCOL_JMS, serviceId, annotationKeyValuePairs);
+        try {
+            serverConnector.start();
+        } catch (ServerConnectorException e) {
+            throw new BallerinaException("Error when starting to listen to the queue/topic while " + serviceId +
+                    " deployment", e);
         }
     }
 


### PR DESCRIPTION
- With this fix, we can connect to WSO2 MB without using a jndi.properties file

- Remove @jms:JMSSource annotation. Only the @jms:ConnectionProperty annotations will be required when connecting as a message consumer

```java
  @jms:ConnectionProperty {
      key:"factoryInitial",
      value:"org.wso2.andes.jndi.PropertiesFileInitialContextFactory"}
  @jms:ConnectionProperty {key:"connectionFactoryType", value:"queue"}
  @jms:ConnectionProperty {
      key:"connectionfactory.QueueConnectionFactory",
      value:"amqp://admin:admin@carbon/carbon?brokerlist='localhost:5672'"}
  @jms:ConnectionProperty {key:"connectionFactoryJNDIName",
                           value:"QueueConnectionFactory"}
  @jms:ConnectionProperty {key:"destination", value:"myQueue"}
```