### PR TITLE
Allow sequential access for same sql Parameter array in multiple actions

### DIFF
--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/Constants.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/Constants.java
@@ -93,4 +93,7 @@ public final class Constants {
 
     public static final String CONNECTOR_NAME = "ClientConnector";
     public static final String DATASOURCE_KEY = "datasource_key";
+
+    public static final String MYSQL = "mysql";
+    public static final char QUESTION_MARK = '?';
 }

--- a/modules/ballerina-native/src/test/java/org/ballerinalang/nativeimpl/actions/SQLActionsTest.java
+++ b/modules/ballerina-native/src/test/java/org/ballerinalang/nativeimpl/actions/SQLActionsTest.java
@@ -444,6 +444,14 @@ public class SQLActionsTest {
         Assert.assertEquals(((BInteger) returns[0]).intValue(), 1);
     }
 
+    @Test(groups = "ConnectorTest")
+    public void testInsertTableDataWithOneParametersArray() {
+        BValue[] returns = BLangFunctions.invokeNew(bLangProgram, "testInsertTableDataWithOneParametersArray");
+        BInteger retValue = (BInteger) returns[0];
+        Assert.assertEquals(retValue.intValue(), 1);
+        Assert.assertEquals(retValue.intValue(), 1);
+    }
+
     @AfterSuite
     public void cleanup() {
         SQLDBUtils.deleteDirectory(new File(SQLDBUtils.DB_DIRECTORY));

--- a/modules/ballerina-native/src/test/resources/samples/sqlConnectorTest.bal
+++ b/modules/ballerina-native/src/test/resources/samples/sqlConnectorTest.bal
@@ -921,3 +921,24 @@ function testDateTimeOutParams (int time, int date, int timestamp) (int count) {
     sql:ClientConnector.close(testDB);
     return;
 }
+
+function testInsertTableDataWithOneParametersArray () (int, int) {
+    map propertiesMap = {"jdbcUrl":"jdbc:hsqldb:file:./target/tempdb/TEST_SQL_CONNECTOR",
+                            "username":"SA", "password":"", "maximumPoolSize":1};
+    sql:ClientConnector testDB = create sql:ClientConnector(propertiesMap);
+    sql:Parameter para1 = {sqlType:"varchar", value:"Anne", direction:0};
+    sql:Parameter para2 = {sqlType:"varchar", value:"James", direction:0};
+    sql:Parameter para3 = {sqlType:"integer", value: 333, direction:0};
+    sql:Parameter para4 = {sqlType:"double", value:5000.75, direction:0};
+    sql:Parameter para5 = {sqlType:"varchar", value:"UK", direction:0};
+    sql:Parameter[] parameters = [para1, para2, para3, para4, para5];
+
+    int insertCount1 = sql:ClientConnector.update (testDB, "Insert into Customers
+        (firstName,lastName,registrationID,creditLimit,country) values (?,?,?,?,?)", parameters);
+
+    int insertCount2 = sql:ClientConnector.update (testDB, "Insert into Customers
+        (firstName,lastName,registrationID) values (?,?,?)", parameters);
+
+    sql:ClientConnector.close (testDB);
+    return insertCount1, insertCount2;
+}


### PR DESCRIPTION
This resolves #2624. This allows to reuse the same sql parameter array for multiple actions irrespective of the array size. Parameters are used by the action sequentially based on the number of parameter locations (i.e. "?") in the given sql query.

```ruby
    sql:Parameter para1 = {sqlType:"varchar", value:"Anne", direction:0};
    sql:Parameter para2 = {sqlType:"varchar", value:"James", direction:0};
    sql:Parameter para3 = {sqlType:"integer", value: 333, direction:0};
    sql:Parameter para4 = {sqlType:"double", value:5000.75, direction:0};
    sql:Parameter para5 = {sqlType:"varchar", value:"UK", direction:0};
    sql:Parameter[] parameters = [para1, para2, para3, para4, para5];

    int insertCount1 = sql:ClientConnector.update (testDB, "Insert into Customers
        (firstName,lastName,registrationID,creditLimit,country) values (?,?,?,?,?)", parameters);

    int insertCount2 = sql:ClientConnector.update (testDB, "Insert into Customers
        (firstName,lastName,registrationID) values (?,?,?)", parameters);
```
