### PR TITLE
Handle empty query param values for different types

### DIFF
--- a/modules/ballerina-core/src/main/java/org/ballerinalang/runtime/ServerConnectorMessageHandler.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/runtime/ServerConnectorMessageHandler.java
@@ -182,18 +182,34 @@ public class ServerConnectorMessageHandler {
                 BType btype = bTypes[i];
                 String value = resourceArgumentValues.get(paramNameArray[i]);
 
-                if (value == null) {
+                // Set default values
+                if (value == null || "".equals(value)) {
+                    if (btype == BTypes.typeString) {
+                        stringLocalVars[stringParamCount++] = "";
+                    } else if (btype == BTypes.typeBoolean) {
+                        intLocalVars[intParamCount++] = 0;
+                    } else if (btype == BTypes.typeFloat) {
+                        doubleLocalVars[doubleParamCount++] = 0.0D;
+                    } else if (btype == BTypes.typeInt) {
+                        longLocalVars[longParamCount++] = 0L;
+                    }
                     continue;
                 }
 
                 if (btype == BTypes.typeString) {
                     stringLocalVars[stringParamCount++] = value;
-                } else if (btype == BTypes.typeInt) {
-                    intLocalVars[intParamCount++] = Integer.getInteger(value);
+                } else if (btype == BTypes.typeBoolean) {
+                    if ("true".equalsIgnoreCase(value)) {
+                        intLocalVars[intParamCount++] = 1;
+                    } else if ("false".equalsIgnoreCase(value)) {
+                        intLocalVars[intParamCount++] = 0;
+                    } else {
+                        throw new BallerinaException("Unsupported parameter type for parameter " + value);
+                    }
                 } else if (btype == BTypes.typeFloat) {
                     doubleLocalVars[doubleParamCount++] = new Double(value);
                 } else if (btype == BTypes.typeInt) {
-                    longLocalVars[longParamCount++] = Long.getLong(value);
+                    longLocalVars[longParamCount++] = Long.parseLong(value);
                 } else {
                     throw new BallerinaException("Unsupported parameter type for parameter " + value);
                 }

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/runtime/ServerConnectorMessageHandler.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/runtime/ServerConnectorMessageHandler.java
@@ -185,13 +185,9 @@ public class ServerConnectorMessageHandler {
                 // Set default values
                 if (value == null || "".equals(value)) {
                     if (btype == BTypes.typeString) {
-                        stringLocalVars[stringParamCount++] = "";
-                    } else if (btype == BTypes.typeBoolean) {
-                        intLocalVars[intParamCount++] = 0;
-                    } else if (btype == BTypes.typeFloat) {
-                        doubleLocalVars[doubleParamCount++] = 0.0D;
-                    } else if (btype == BTypes.typeInt) {
-                        longLocalVars[longParamCount++] = 0L;
+                        if (btype == BTypes.typeString) {
+                            stringLocalVars[stringParamCount++] = "";
+                        }
                     }
                     continue;
                 }

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/runtime/ServerConnectorMessageHandler.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/runtime/ServerConnectorMessageHandler.java
@@ -185,9 +185,7 @@ public class ServerConnectorMessageHandler {
                 // Set default values
                 if (value == null || "".equals(value)) {
                     if (btype == BTypes.typeString) {
-                        if (btype == BTypes.typeString) {
-                            stringLocalVars[stringParamCount++] = "";
-                        }
+                        stringLocalVars[stringParamCount++] = "";
                     }
                     continue;
                 }

--- a/modules/ballerina-native/src/test/java/org/ballerinalang/service/UriTemplateBestMatchTest.java
+++ b/modules/ballerina-native/src/test/java/org/ballerinalang/service/UriTemplateBestMatchTest.java
@@ -336,6 +336,24 @@ public class UriTemplateBestMatchTest {
         BJSON bJson = ((BJSON) response.getMessageDataSource());
         Assert.assertEquals(bJson.value().get("echo13").asText(), "1"
                 , "Resource dispatched to wrong template");
+
+        path = "/hello/echo13?foo=";
+        cMsg = MessageUtils.generateHTTPMessage(path, "GET");
+        response = Services.invoke(cMsg);
+
+        Assert.assertNotNull(response, "Response message not found");
+        bJson = ((BJSON) response.getMessageDataSource());
+        Assert.assertEquals(bJson.value().get("echo13").asText(), "0"
+                , "Resource dispatched to wrong template");
+
+        path = "/hello/echo13";
+        cMsg = MessageUtils.generateHTTPMessage(path, "GET");
+        response = Services.invoke(cMsg);
+
+        Assert.assertNotNull(response, "Response message not found");
+        bJson = ((BJSON) response.getMessageDataSource());
+        Assert.assertEquals(bJson.value().get("echo13").asText(), "0"
+                , "Resource dispatched to wrong template");
     }
 
     @Test(description = "Test suitable method with URL. /echo14?foo=1.11 ")
@@ -348,6 +366,24 @@ public class UriTemplateBestMatchTest {
         BJSON bJson = ((BJSON) response.getMessageDataSource());
         Assert.assertEquals(bJson.value().get("echo14").asText(), "1.11"
                 , "Resource dispatched to wrong template");
+
+        path = "/hello/echo14?foo=";
+        cMsg = MessageUtils.generateHTTPMessage(path, "GET");
+        response = Services.invoke(cMsg);
+
+        Assert.assertNotNull(response, "Response message not found");
+        bJson = ((BJSON) response.getMessageDataSource());
+        Assert.assertEquals(bJson.value().get("echo14").asText(), "0.0"
+                , "Resource dispatched to wrong template");
+
+        path = "/hello/echo14";
+        cMsg = MessageUtils.generateHTTPMessage(path, "GET");
+        response = Services.invoke(cMsg);
+
+        Assert.assertNotNull(response, "Response message not found");
+        bJson = ((BJSON) response.getMessageDataSource());
+        Assert.assertEquals(bJson.value().get("echo14").asText(), "0.0"
+                , "Resource dispatched to wrong template");
     }
 
     @Test(description = "Test suitable method with URL. /echo15?foo=1.11 ")
@@ -359,6 +395,24 @@ public class UriTemplateBestMatchTest {
         Assert.assertNotNull(response, "Response message not found");
         BJSON bJson = ((BJSON) response.getMessageDataSource());
         Assert.assertEquals(bJson.value().get("echo15").asText(), "true"
+                , "Resource dispatched to wrong template");
+
+        path = "/hello/echo15?foo=";
+        cMsg = MessageUtils.generateHTTPMessage(path, "GET");
+        response = Services.invoke(cMsg);
+
+        Assert.assertNotNull(response, "Response message not found");
+        bJson = ((BJSON) response.getMessageDataSource());
+        Assert.assertEquals(bJson.value().get("echo15").asText(), "false"
+                , "Resource dispatched to wrong template");
+
+        path = "/hello/echo15";
+        cMsg = MessageUtils.generateHTTPMessage(path, "GET");
+        response = Services.invoke(cMsg);
+
+        Assert.assertNotNull(response, "Response message not found");
+        bJson = ((BJSON) response.getMessageDataSource());
+        Assert.assertEquals(bJson.value().get("echo15").asText(), "false"
                 , "Resource dispatched to wrong template");
     }
 

--- a/modules/ballerina-native/src/test/java/org/ballerinalang/service/UriTemplateBestMatchTest.java
+++ b/modules/ballerina-native/src/test/java/org/ballerinalang/service/UriTemplateBestMatchTest.java
@@ -326,6 +326,42 @@ public class UriTemplateBestMatchTest {
                 , "Resource dispatched to wrong template");
     }
 
+    @Test(description = "Test suitable method with URL. /echo13?foo=1 ")
+    public void testIntegerQueryParam() {
+        String path = "/hello/echo13?foo=1";
+        CarbonMessage cMsg = MessageUtils.generateHTTPMessage(path, "GET");
+        CarbonMessage response = Services.invoke(cMsg);
+
+        Assert.assertNotNull(response, "Response message not found");
+        BJSON bJson = ((BJSON) response.getMessageDataSource());
+        Assert.assertEquals(bJson.value().get("echo13").asText(), "1"
+                , "Resource dispatched to wrong template");
+    }
+
+    @Test(description = "Test suitable method with URL. /echo14?foo=1.11 ")
+    public void testFloatQueryParam() {
+        String path = "/hello/echo14?foo=1.11";
+        CarbonMessage cMsg = MessageUtils.generateHTTPMessage(path, "GET");
+        CarbonMessage response = Services.invoke(cMsg);
+
+        Assert.assertNotNull(response, "Response message not found");
+        BJSON bJson = ((BJSON) response.getMessageDataSource());
+        Assert.assertEquals(bJson.value().get("echo14").asText(), "1.11"
+                , "Resource dispatched to wrong template");
+    }
+
+    @Test(description = "Test suitable method with URL. /echo15?foo=1.11 ")
+    public void testBooleanQueryParam() {
+        String path = "/hello/echo15?foo=true";
+        CarbonMessage cMsg = MessageUtils.generateHTTPMessage(path, "GET");
+        CarbonMessage response = Services.invoke(cMsg);
+
+        Assert.assertNotNull(response, "Response message not found");
+        BJSON bJson = ((BJSON) response.getMessageDataSource());
+        Assert.assertEquals(bJson.value().get("echo15").asText(), "true"
+                , "Resource dispatched to wrong template");
+    }
+
     @AfterClass
     public void tearDown() {
         EnvironmentInitializer.cleanup(application);

--- a/modules/ballerina-native/src/test/resources/lang/service/uritemplate/uri-template-matching.bal
+++ b/modules/ballerina-native/src/test/resources/lang/service/uritemplate/uri-template-matching.bal
@@ -111,6 +111,38 @@ service<http> echo11 {
         reply response;
     }
 
+    @http:GET{}
+    @http:Path {value:"/echo13"}
+    resource echo13 (message m, int foo) {
+        message response = {};
+        string bar;
+        bar, _ = <string> foo;
+        json responseJson = {"echo13": bar};
+        messages:setJsonPayload(response, responseJson);
+        reply response;
+    }
+
+    @http:GET{}
+    @http:Path {value:"/echo14"}
+    resource echo14 (message m, float foo) {
+        message response = {};
+        string bar;
+        bar, _ = <string> foo;
+        json responseJson = {"echo14": bar};
+        messages:setJsonPayload(response, responseJson);
+        reply response;
+    }
+
+    @http:GET{}
+    @http:Path {value:"/echo15"}
+    resource echo15 (message m, boolean foo) {
+        message response = {};
+        string bar;
+        bar, _ = <string> foo;
+        json responseJson = {"echo15": bar};
+        messages:setJsonPayload(response, responseJson);
+        reply response;
+    }
 
     @http:POST{}
     @http:Path {value:"/so2"}


### PR DESCRIPTION
- At the moment if query param is not available in the URI, it does not set a default value. This has been fixed with this PR.
- Added test-cases for each type.
- Fix the issue of integer type query params.