### PR TITLE
Improve json-arrays sample

### DIFF
--- a/samples/ballerina-by-example/examples/json-arrays/json-arrays.bal
+++ b/samples/ballerina-by-example/examples/json-arrays/json-arrays.bal
@@ -1,9 +1,9 @@
 import ballerina.lang.system;
 import ballerina.lang.errors;
-import ballerina.lang.strings;
+import ballerina.lang.jsons;
 
 function main (string[] args) {
-    //JSON Arrays. They are arrays of any JSON value.
+    // JSON Arrays. They are arrays of any JSON value.
     json j1 = [1, false, null, "foo",
                {first:"John", last:"Pala"}];
     system:println(j1);
@@ -28,19 +28,13 @@ function main (string[] args) {
     int i = 0;
     try {
         json family = p.family;
-        while (true) {
+        int length = jsons:getInt(family, "$.length()");
+        while (i < length) {
             json e = family[i];
             system:println(e);
             i = i + 1;
         }
     } catch (errors:Error e) {
-        string msg = e.msg;
-        if (!strings:contains(msg, "array index out of range")) {
-            system:println(msg);
-            throw e;
-        } else {
-            system:println("length of array: " + i);
-            // Ignore the error.
-        }
+        system:println("error: " + e.msg);
     }
 }

--- a/samples/ballerina-by-example/examples/json-arrays/json-arrays.bal
+++ b/samples/ballerina-by-example/examples/json-arrays/json-arrays.bal
@@ -30,8 +30,8 @@ function main (string[] args) {
         json family = p.family;
         int length = jsons:getInt(family, "$.length()");
         while (i < length) {
-            json e = family[i];
-            system:println(e);
+            json f = family[i];
+            system:println(f);
             i = i + 1;
         }
     } catch (errors:Error e) {


### PR DESCRIPTION
This pull request improves json-arrays sample in ballerina-by-example by using json array length instead of handling array index out of bound exception.