### PR TITLE
Change the init location of client-connectors

### DIFF
--- a/modules/ballerina-core/src/main/java/org/ballerinalang/natives/connectors/BallerinaConnectorManager.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/natives/connectors/BallerinaConnectorManager.java
@@ -23,6 +23,7 @@ import org.ballerinalang.services.dispatchers.ResourceDispatcher;
 import org.ballerinalang.services.dispatchers.ServiceDispatcher;
 import org.ballerinalang.util.exceptions.BallerinaException;
 import org.wso2.carbon.connector.framework.ConnectorManager;
+import org.wso2.carbon.messaging.CarbonMessageProcessor;
 import org.wso2.carbon.messaging.ClientConnector;
 import org.wso2.carbon.messaging.ServerConnector;
 import org.wso2.carbon.messaging.ServerConnectorErrorHandler;
@@ -49,6 +50,8 @@ public class BallerinaConnectorManager {
     
     /* ServerConnectors which startup is delayed at the service deployment time */
     private List<ServerConnector> startupDelayedServerConnectors = new ArrayList<>();
+
+    CarbonMessageProcessor messageProcessor;
 
     private BallerinaConnectorManager() {
     }
@@ -194,4 +197,15 @@ public class BallerinaConnectorManager {
                 DispatcherRegistry.getInstance().registerServiceDispatcher(serviceDispatcher));
     }
 
+    public void setMessageProcessor(CarbonMessageProcessor messageProcessor) {
+        this.messageProcessor = messageProcessor;
+    }
+
+    public CarbonMessageProcessor getMessageProcessor() {
+        return this.messageProcessor;
+    }
+
+    public void registerClientConnector(ClientConnector clientConnector) {
+        this.connectorManager.registerClientConnector(clientConnector);
+    }
 }

--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/actions/http/Init.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/actions/http/Init.java
@@ -37,6 +37,7 @@ import java.util.ServiceLoader;
         immediate = true,
         service = AbstractNativeAction.class)
 public class Init extends AbstractHTTPAction {
+
     @Override
     public BValue execute(Context context) {
         if (BallerinaConnectorManager.getInstance().
@@ -50,5 +51,10 @@ public class Init extends AbstractHTTPAction {
             });
         }
         return null;
+    }
+
+    @Override
+    public boolean isNonBlockingAction() {
+        return false;
     }
 }

--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/actions/http/Init.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/actions/http/Init.java
@@ -1,0 +1,54 @@
+package org.ballerinalang.nativeimpl.actions.http;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeEnum;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.Attribute;
+import org.ballerinalang.natives.annotations.BallerinaAction;
+import org.ballerinalang.natives.annotations.BallerinaAnnotation;
+import org.ballerinalang.natives.connectors.AbstractNativeAction;
+import org.ballerinalang.natives.connectors.BallerinaConnectorManager;
+import org.osgi.service.component.annotations.Component;
+import org.wso2.carbon.messaging.CarbonMessageProcessor;
+import org.wso2.carbon.messaging.ClientConnector;
+
+import java.util.ServiceLoader;
+
+/**
+ * {@code Init} is the Init action implementation of the HTTP Connector.
+ *
+ * @since 0.9
+ */
+@BallerinaAction(
+        packageName = "ballerina.net.http",
+        actionName = "init",
+        connectorName = Constants.CONNECTOR_NAME,
+        args = {@Argument(name = "c", type = TypeEnum.CONNECTOR)
+        },
+        connectorArgs = {
+                @Argument(name = "serviceUri", type = TypeEnum.STRING)
+        }
+)
+@BallerinaAnnotation(annotationName = "Description", attributes = { @Attribute(name = "value",
+                                                       value = "The init action implementation for HTTP connector.") })
+@Component(
+        name = "action.net.http.init",
+        immediate = true,
+        service = AbstractNativeAction.class)
+public class Init extends AbstractHTTPAction {
+    @Override
+    public BValue execute(Context context) {
+        if (BallerinaConnectorManager.getInstance().
+                getClientConnector(Constants.PROTOCOL_HTTP) == null) {
+            CarbonMessageProcessor carbonMessageProcessor = BallerinaConnectorManager.getInstance()
+                    .getMessageProcessor();
+            ServiceLoader<ClientConnector> clientConnectorLoader = ServiceLoader.load(ClientConnector.class);
+            clientConnectorLoader.forEach((clientConnector) -> {
+                clientConnector.setMessageProcessor(carbonMessageProcessor);
+                BallerinaConnectorManager.getInstance().registerClientConnector(clientConnector);
+            });
+        }
+        return null;
+    }
+}

--- a/modules/launcher/src/main/java/org/ballerinalang/launcher/BProgramRunner.java
+++ b/modules/launcher/src/main/java/org/ballerinalang/launcher/BProgramRunner.java
@@ -44,7 +44,7 @@ class BProgramRunner {
         ProgramFile programFile = new BLangProgramLoader().loadMainProgramFile(programDirPath, sourceFilePath);
 
         // Load Client Connectors
-        BallerinaConnectorManager.getInstance().initializeClientConnectors(new MessageProcessor());
+        BallerinaConnectorManager.getInstance().setMessageProcessor(new MessageProcessor());
 
         // Check whether there is a main function
         new BLangProgramRunner().runMain(programFile, args.toArray(new String[0]));


### PR DESCRIPTION
At the moment, we initialize all the client connectors even when we run a main program.

With this change we only initialize the connectors in a main program only if the main program has connectors. 