### PR TITLE
Fix the issue with white spaces for namespace declaration statement. 

### DIFF
--- a/modules/ballerina-core/src/main/java/org/ballerinalang/util/parser/antlr4/WhiteSpaceUtil.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/util/parser/antlr4/WhiteSpaceUtil.java
@@ -1165,25 +1165,26 @@ public class WhiteSpaceUtil {
                 getWhitespaceToRight(tokenStream, ctx.stop.getTokenIndex()));
         return ws;
     }
-    
+
     public static WhiteSpaceDescriptor getNamespaceDeclarationWS(CommonTokenStream tokenStream,
-        BallerinaParser.NamespaceDeclarationContext ctx) {
+                                                                 BallerinaParser.NamespaceDeclarationContext ctx) {
         WhiteSpaceDescriptor ws = new WhiteSpaceDescriptor();
         ws.addWhitespaceRegion(WhiteSpaceRegions.NAMESPACE_DEC_IMPORT_KEYWORD_TO_PKG_NAME_START,
-            getWhitespaceToRight(tokenStream, ctx.start.getTokenIndex()));
+                getWhitespaceToRight(tokenStream, ctx.start.getTokenIndex()));
         ws.addWhitespaceRegion(WhiteSpaceRegions.NAMESPACE_DEC_PKG_NAME_END_TO_NEXT,
-            getWhitespaceToRight(tokenStream, ctx.QuotedStringLiteral().getText().length()));
+                getWhitespaceToRight(tokenStream, ctx.QuotedStringLiteral().getSymbol().getTokenIndex()));
 
         // if (as Identifier) is present, there can be five whitespace regions
         if (ctx.Identifier() != null) {
             ws.addWhitespaceRegion(WhiteSpaceRegions.NAMESPACE_DEC_AS_KEYWORD_TO_IDENTIFIER,
-                getWhitespaceToRight(tokenStream, getFirstTokenWithText(ctx.children, KEYWORD_AS).getTokenIndex()));
+                    getWhitespaceToRight(tokenStream,
+                            getFirstTokenWithText(ctx.children, KEYWORD_AS).getTokenIndex()));
             ws.addWhitespaceRegion(WhiteSpaceRegions.NAMESPACE_DEC_IDENTIFIER_TO_IMPORT_DEC_END,
-                getWhitespaceToRight(tokenStream, ctx.Identifier().getSymbol().getTokenIndex()));
+                    getWhitespaceToRight(tokenStream, ctx.Identifier().getSymbol().getTokenIndex()));
         }
 
         ws.addWhitespaceRegion(WhiteSpaceRegions.NAMESPACE_DEC_END_TO_NEXT_TOKEN,
-            getWhitespaceToRight(tokenStream, ctx.stop.getTokenIndex()));
+                getWhitespaceToRight(tokenStream, ctx.stop.getTokenIndex()));
         return ws;
     }
 


### PR DESCRIPTION
This is to fix the issue cause by using 
<code>ctx.QuotedStringLiteral().getText().length()</code>
instead of 
<code>ctx.QuotedStringLiteral().getSymbol().getTokenIndex()</code>
to get the white space region for package name end.