### PR TITLE
Null check for Value type name

### DIFF
--- a/modules/ballerina-core/src/main/java/org/ballerinalang/util/parser/antlr4/BLangAntlr4Listener.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/util/parser/antlr4/BLangAntlr4Listener.java
@@ -662,14 +662,16 @@ public class BLangAntlr4Listener implements BallerinaListener {
             return;
         }
 
-        String valueTypeName = ctx.getChild(0).getText();
-        SimpleTypeName simpleTypeName = new SimpleTypeName(valueTypeName);
-        simpleTypeName.setNodeLocation(getCurrentLocation(ctx));
-        if (isVerboseMode) {
-            WhiteSpaceDescriptor ws = WhiteSpaceUtil.getValueTypeNameWS(tokenStream, ctx);
-            simpleTypeName.setWhiteSpaceDescriptor(ws);
+        if (ctx.getChild(0) != null) {
+            String valueTypeName = ctx.getChild(0).getText();
+            SimpleTypeName simpleTypeName = new SimpleTypeName(valueTypeName);
+            simpleTypeName.setNodeLocation(getCurrentLocation(ctx));
+            if (isVerboseMode) {
+                WhiteSpaceDescriptor ws = WhiteSpaceUtil.getValueTypeNameWS(tokenStream, ctx);
+                simpleTypeName.setWhiteSpaceDescriptor(ws);
+            }
+            typeNameStack.push(simpleTypeName);
         }
-        typeNameStack.push(simpleTypeName);
     }
 
     @Override


### PR DESCRIPTION
This Pr is to resolve the empty stack exception occurred when try with a source as bellow,

**const i**

We use such incomplete sources when resolving the content for content assist functionality. Due to the null pointer exception, process skips the steps after the ballerina source parsing.