### PR TITLE
Fix sql select action issue with MYSQL DB

### DIFF
--- a/modules/ballerina-core/src/main/java/org/ballerinalang/model/DataTableJSONDataSource.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/model/DataTableJSONDataSource.java
@@ -55,7 +55,7 @@ public class DataTableJSONDataSource implements JSONDataSource {
     @Override
     public void serialize(JsonGenerator gen, SerializerProvider serializerProvider) throws IOException {
         gen.writeStartArray();
-        while (this.df.hasNext()) {
+        while (this.df.hasNext(this.isInTransaction)) {
             this.objGen.transform(this.df).serialize(gen, serializerProvider);
         }
         gen.writeEndArray();

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/model/DataTableOMDataSource.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/model/DataTableOMDataSource.java
@@ -53,7 +53,7 @@ public class DataTableOMDataSource extends AbstractPushOMDataSource {
     @Override
     public void serialize(XMLStreamWriter xmlStreamWriter) throws XMLStreamException {
         xmlStreamWriter.writeStartElement(this.rootWrapper);
-        while (dataTable.hasNext()) {
+        while (dataTable.hasNext(this.isInTransaction)) {
             xmlStreamWriter.writeStartElement(this.rowWrapper);
             for (BDataTable.ColumnDefinition col : dataTable.getColumnDefs()) {
                 boolean isArray = false;

--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/lang/datatables/HasNext.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/lang/datatables/HasNext.java
@@ -52,6 +52,6 @@ public class HasNext extends AbstractNativeFunction {
 
     public BValue[] execute(Context ctx) {
         BDataTable dataTable = (BDataTable) getRefArgument(ctx, 0);
-        return getBValues(new BBoolean(dataTable.hasNext()));
+        return getBValues(new BBoolean(dataTable.hasNext(ctx.isInTransaction())));
     }
 }

--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/lang/datatables/Next.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/lang/datatables/Next.java
@@ -51,6 +51,6 @@ public class Next extends AbstractNativeFunction {
 
     public BValue[] execute(Context ctx) {
         BDataTable dataTable = (BDataTable) getRefArgument(ctx, 0);
-        return getBValues(dataTable.getNext(ctx.isInTransaction()));
+        return getBValues(dataTable.getNext());
     }
 }


### PR DESCRIPTION
Since mysql result set is initialized with TYPE_FORWARD_ONLY , isLast method cannot be invoked on that result set.  It will cause the select action error. So auto close logic is changed not to use isLast() method.