### PR TITLE
Fix #3018 #3020 #3065-Set proper error message for connector init

### DIFF
--- a/modules/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BLangVM.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BLangVM.java
@@ -105,6 +105,7 @@ import org.ballerinalang.util.exceptions.BallerinaException;
 import org.ballerinalang.util.exceptions.RuntimeErrors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.wso2.carbon.messaging.CarbonMessage;
 import org.wso2.carbon.messaging.ServerConnectorErrorHandler;
 
 import java.io.PrintStream;
@@ -3327,17 +3328,18 @@ public class BLangVM {
             ip = -1;
             if (context.getServiceInfo() != null) {
                 // Invoke ServiceConnector error handler.
-                Object protocol = context.getCarbonMessage().getProperty("PROTOCOL");
-                Optional<ServerConnectorErrorHandler> optionalErrorHandler =
-                        BallerinaConnectorManager.getInstance().getServerConnectorErrorHandler((String) protocol);
-                try {
-                    optionalErrorHandler
-                            .orElseGet(DefaultServerConnectorErrorHandler::getInstance)
-                            .handleError(new BallerinaException(
-                                            BLangVMErrors.getPrintableStackTrace(context.getError())),
-                                    context.getCarbonMessage(), context.getBalCallback());
-                } catch (Exception e) {
-                    logger.error("cannot handle error using the error handler for: " + protocol, e);
+                CarbonMessage carbonMessage = context.getCarbonMessage();
+                if (carbonMessage != null) {
+                    Object protocol = carbonMessage.getProperty("PROTOCOL");
+                    Optional<ServerConnectorErrorHandler> optionalErrorHandler = BallerinaConnectorManager.getInstance()
+                            .getServerConnectorErrorHandler((String) protocol);
+                    try {
+                        optionalErrorHandler.orElseGet(DefaultServerConnectorErrorHandler::getInstance).handleError(
+                                new BallerinaException(BLangVMErrors.getPrintableStackTrace(context.getError())),
+                                context.getCarbonMessage(), context.getBalCallback());
+                    } catch (Exception e) {
+                        logger.error("cannot handle error using the error handler for: " + protocol, e);
+                    }
                 }
             }
             return;


### PR DESCRIPTION
When the connector is created in service level and if there is an error with the initialization, instead of the correct error message below error is displayed.

`ballerina: internal error occurred`