### PR TITLE
Add FormParam/HeaderParam + getFormParams built-in function support in ballerina

### DIFF
--- a/modules/ballerina-core/pom.xml
+++ b/modules/ballerina-core/pom.xml
@@ -139,6 +139,10 @@
             <groupId>org.atomikos.wso2</groupId>
             <artifactId>atomikos</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.ballerinalang</groupId>
+            <artifactId>ballerina-logging</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/runtime/ServerConnectorMessageHandler.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/runtime/ServerConnectorMessageHandler.java
@@ -190,22 +190,26 @@ public class ServerConnectorMessageHandler {
                     continue;
                 }
 
-                if (btype == BTypes.typeString) {
-                    stringLocalVars[stringParamCount++] = value;
-                } else if (btype == BTypes.typeBoolean) {
-                    if ("true".equalsIgnoreCase(value)) {
-                        intLocalVars[intParamCount++] = 1;
-                    } else if ("false".equalsIgnoreCase(value)) {
-                        intLocalVars[intParamCount++] = 0;
+                try {
+                    if (btype == BTypes.typeString) {
+                        stringLocalVars[stringParamCount++] = value;
+                    } else if (btype == BTypes.typeBoolean) {
+                        if ("true".equalsIgnoreCase(value)) {
+                            intLocalVars[intParamCount++] = 1;
+                        } else if ("false".equalsIgnoreCase(value)) {
+                            intLocalVars[intParamCount++] = 0;
+                        } else {
+                            throw new BallerinaException("Could not parse input: " + value + " to a boolean");
+                        }
+                    } else if (btype == BTypes.typeFloat) {
+                        doubleLocalVars[doubleParamCount++] = new Double(value);
+                    } else if (btype == BTypes.typeInt) {
+                        longLocalVars[longParamCount++] = Long.parseLong(value);
                     } else {
                         throw new BallerinaException("Unsupported parameter type for parameter " + value);
                     }
-                } else if (btype == BTypes.typeFloat) {
-                    doubleLocalVars[doubleParamCount++] = new Double(value);
-                } else if (btype == BTypes.typeInt) {
-                    longLocalVars[longParamCount++] = Long.parseLong(value);
-                } else {
-                    throw new BallerinaException("Unsupported parameter type for parameter " + value);
+                } catch (NumberFormatException e) {
+                    throw new BallerinaException("Could not parse input: " + value + " to a number");
                 }
             }
         }

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/http/Constants.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/http/Constants.java
@@ -29,6 +29,7 @@ public class Constants {
     public static final String SUB_PATH = "SUB_PATH";
     public static final String QUERY_STR = "QUERY_STR";
     public static final String RAW_QUERY_STR = "RAW_QUERY_STR";
+    public static final String FORM_PARAM = "FormParam";
 
     public static final String DEFAULT_INTERFACE = "default";
     public static final String DEFAULT_BASE_PATH = "/";

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/http/Constants.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/http/Constants.java
@@ -30,6 +30,7 @@ public class Constants {
     public static final String QUERY_STR = "QUERY_STR";
     public static final String RAW_QUERY_STR = "RAW_QUERY_STR";
     public static final String FORM_PARAM = "FormParam";
+    public static final String HEADER_PARAM = "HeaderParam";
 
     public static final String DEFAULT_INTERFACE = "default";
     public static final String DEFAULT_BASE_PATH = "/";

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/http/Constants.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/http/Constants.java
@@ -45,6 +45,7 @@ public class Constants {
     public static final String CONTENT_TYPE_HEADER = "Content-Type";
     public static final String ACCEPT_HEADER = "Accept";
     public static final String APPLICATION_OCTET_STREAM = "application/octet-stream";
+    public static final String APPLICATION_X_WWW_FORM_URLENCODED = "application/x-www-form-urlencoded";
     public static final String PROTOCOL = "PROTOCOL";
     public static final String HOST = "HOST";
     public static final String PORT = "PORT";

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/http/HTTPResourceDispatcher.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/http/HTTPResourceDispatcher.java
@@ -110,7 +110,7 @@ public class HTTPResourceDispatcher implements ResourceDispatcher {
             throws UnsupportedEncodingException {
         if (resource.getParamNames().length > 1) {
             String contentType = cMsg.getHeader(Constants.CONTENT_TYPE_HEADER);
-            if (contentType != null && contentType.equals(Constants.APPLICATION_X_WWW_FORM_URLENCODED)) {
+            if (contentType != null && contentType.contains(Constants.APPLICATION_X_WWW_FORM_URLENCODED)) {
                 String payload;
                 if (cMsg.isAlreadyRead()) {
                     payload = cMsg.getMessageDataSource().getMessageAsString();

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/http/HTTPResourceDispatcher.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/http/HTTPResourceDispatcher.java
@@ -21,6 +21,8 @@ package org.ballerinalang.services.dispatchers.http;
 import org.ballerinalang.bre.Context;
 import org.ballerinalang.model.Resource;
 import org.ballerinalang.model.Service;
+import org.ballerinalang.model.util.MessageUtils;
+import org.ballerinalang.runtime.message.StringDataSource;
 import org.ballerinalang.services.dispatchers.ResourceDispatcher;
 import org.ballerinalang.services.dispatchers.uri.QueryParamProcessor;
 import org.ballerinalang.services.dispatchers.uri.URITemplateException;
@@ -49,6 +51,7 @@ public class HTTPResourceDispatcher implements ResourceDispatcher {
 
         String method = (String) cMsg.getProperty(Constants.HTTP_METHOD);
         String subPath = (String) cMsg.getProperty(Constants.SUB_PATH);
+        String contentType = cMsg.getHeader(Constants.CONTENT_TYPE_HEADER);
         subPath = sanitizeSubPath(subPath);
         Map<String, String> resourceArgumentValues = new HashMap<>();
         try {
@@ -58,6 +61,20 @@ public class HTTPResourceDispatcher implements ResourceDispatcher {
                     QueryParamProcessor.processQueryParams
                             ((String) cMsg.getProperty(Constants.QUERY_STR))
                             .forEach((resourceArgumentValues::put));
+                }
+                if (contentType != null && contentType.equals(Constants.APPLICATION_X_WWW_FORM_URLENCODED)) {
+                    String payload;
+                    if (cMsg.isAlreadyRead()) {
+                        payload = cMsg.getMessageDataSource().getMessageAsString();
+                    } else {
+                        payload = MessageUtils.getStringFromInputStream(cMsg.getInputStream());
+                        StringDataSource stringDataSource = new StringDataSource(payload);
+                        cMsg.setMessageDataSource(stringDataSource);
+                        cMsg.setAlreadyRead(true);
+                    }
+                    if (!payload.isEmpty()) {
+                        QueryParamProcessor.processQueryParams(payload).forEach((resourceArgumentValues::put));
+                    }
                 }
                 cMsg.setProperty(org.ballerinalang.runtime.Constants.RESOURCE_ARGS, resourceArgumentValues);
                 return resource;

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/http/HTTPResourceDispatcher.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/http/HTTPResourceDispatcher.java
@@ -19,12 +19,13 @@
 package org.ballerinalang.services.dispatchers.http;
 
 import org.ballerinalang.bre.Context;
+import org.ballerinalang.logging.BLogManager;
 import org.ballerinalang.model.Resource;
 import org.ballerinalang.model.Service;
 import org.ballerinalang.model.util.MessageUtils;
 import org.ballerinalang.runtime.message.StringDataSource;
 import org.ballerinalang.services.dispatchers.ResourceDispatcher;
-import org.ballerinalang.services.dispatchers.uri.QueryParamProcessor;
+import org.ballerinalang.services.dispatchers.uri.ParamProcessor;
 import org.ballerinalang.services.dispatchers.uri.URITemplateException;
 import org.ballerinalang.util.codegen.ResourceInfo;
 import org.ballerinalang.util.codegen.ServiceInfo;
@@ -44,6 +45,7 @@ import java.util.Map;
 public class HTTPResourceDispatcher implements ResourceDispatcher {
 
     private static final Logger log = LoggerFactory.getLogger(HTTPResourceDispatcher.class);
+    private static final Logger bLog = LoggerFactory.getLogger(BLogManager.BALLERINA_ROOT_LOGGER_NAME);
 
     @Override
     public ResourceInfo findResource(ServiceInfo service, CarbonMessage cMsg, CarbonCallback callback)
@@ -56,29 +58,9 @@ public class HTTPResourceDispatcher implements ResourceDispatcher {
         try {
             ResourceInfo resource = service.getUriTemplate().matches(subPath, resourceArgumentValues, cMsg);
             if (resource != null) {
-                if (cMsg.getProperty(Constants.QUERY_STR) != null) {
-                    QueryParamProcessor.processQueryParams
-                            ((String) cMsg.getProperty(Constants.QUERY_STR))
-                            .forEach((resourceArgumentValues::put));
-                }
-                if (resource.getParamAnnotationAttachmentInfo
-                        (Constants.HTTP_PACKAGE_PATH, Constants.FORM_PARAM) != null) {
-                    String contentType = cMsg.getHeader(Constants.CONTENT_TYPE_HEADER);
-                    if (contentType != null && contentType.equals(Constants.APPLICATION_X_WWW_FORM_URLENCODED)) {
-                        String payload;
-                        if (cMsg.isAlreadyRead()) {
-                            payload = cMsg.getMessageDataSource().getMessageAsString();
-                        } else {
-                            payload = MessageUtils.getStringFromInputStream(cMsg.getInputStream());
-                            StringDataSource stringDataSource = new StringDataSource(payload);
-                            cMsg.setMessageDataSource(stringDataSource);
-                            cMsg.setAlreadyRead(true);
-                        }
-                        if (!payload.isEmpty()) {
-                            QueryParamProcessor.processQueryParams(payload).forEach((resourceArgumentValues::put));
-                        }
-                    }
-                }
+                populateQueryParams(cMsg, resourceArgumentValues);
+                populateFormParams(resource, cMsg, resourceArgumentValues);
+                populateHeaderParams(resource, cMsg, resourceArgumentValues);
                 cMsg.setProperty(org.ballerinalang.runtime.Constants.RESOURCE_ARGS, resourceArgumentValues);
                 return resource;
             }
@@ -109,5 +91,55 @@ public class HTTPResourceDispatcher implements ResourceDispatcher {
             subPath = subPath.endsWith("/") ? subPath.substring(0, subPath.length() - 1) : subPath;
         }
         return subPath;
+    }
+
+    private void populateQueryParams(CarbonMessage cMsg, Map<String, String> resourceArgValues)
+            throws UnsupportedEncodingException {
+        if (cMsg.getProperty(Constants.QUERY_STR) != null) {
+            ParamProcessor.processQueryParams
+                    ((String) cMsg.getProperty(Constants.QUERY_STR))
+                    .entrySet().forEach(entry -> {
+                        if (resourceArgValues.put(entry.getKey(), entry.getValue()) != null) {
+                            bLog.warn("parameter key \"" + entry.getKey() + "\" is redeclared.");
+                        }
+                    });
+        }
+    }
+
+    private void populateFormParams(ResourceInfo resource, CarbonMessage cMsg, Map<String, String> resourceArgValues)
+            throws UnsupportedEncodingException {
+        if (resource.getParamNames().length > 1) {
+            String contentType = cMsg.getHeader(Constants.CONTENT_TYPE_HEADER);
+            if (contentType != null && contentType.equals(Constants.APPLICATION_X_WWW_FORM_URLENCODED)) {
+                String payload;
+                if (cMsg.isAlreadyRead()) {
+                    payload = cMsg.getMessageDataSource().getMessageAsString();
+                } else {
+                    payload = MessageUtils.getStringFromInputStream(cMsg.getInputStream());
+                    StringDataSource stringDataSource = new StringDataSource(payload);
+                    cMsg.setMessageDataSource(stringDataSource);
+                    cMsg.setAlreadyRead(true);
+                }
+                if (!payload.isEmpty()) {
+                    ParamProcessor.processQueryParams(payload).entrySet().forEach(entry -> {
+                        if (resourceArgValues.put(entry.getKey(), entry.getValue()) != null) {
+                            bLog.warn("parameter key \"" + entry.getKey() + "\" is redeclared.");
+                        }
+                    });
+                }
+            }
+        }
+    }
+
+    private void populateHeaderParams(ResourceInfo resource, CarbonMessage cMsg, Map<String, String> resourceArgValues)
+            throws UnsupportedEncodingException {
+        if (resource.getParamNames().length > 1) {
+            ParamProcessor.processHeaderParams(cMsg.getHeaders().getAll())
+                    .entrySet().forEach(entry -> {
+                        if (resourceArgValues.put(entry.getKey(), entry.getValue()) != null) {
+                            bLog.warn("parameter key \"" + entry.getKey() + "\" is redeclared.");
+                        }
+                    });
+        }
     }
 }

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/uri/ParamProcessor.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/uri/ParamProcessor.java
@@ -52,13 +52,11 @@ public class ParamProcessor {
         Map<String, String> headerParams = new HashMap<>();
         for (Header header : headers) {
             String name = header.getName();
-            String value = null;
+            String value = "";
             try {
                 value = URLDecoder.decode(header.getValue(), ENCODING);
             } catch (UnsupportedEncodingException e) {
                 throw new BallerinaException("Unsupported encoding in value: " + value + "for " + name);
-            } catch (NullPointerException e) {
-                throw new BallerinaException("Null header value for : " + name);
             }
             headerParams.put(name, value);
         }

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/uri/ParamProcessor.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/uri/ParamProcessor.java
@@ -18,16 +18,20 @@
 
 package org.ballerinalang.services.dispatchers.uri;
 
+import org.ballerinalang.util.exceptions.BallerinaException;
+import org.wso2.carbon.messaging.Header;
+
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
- * Query parameter related operations.
+ * Parameter related operations.
  */
 
-public class QueryParamProcessor {
+public class ParamProcessor {
     public static final String ENCODING = "UTF-8";
 
     public static Map<String, String> processQueryParams(String queryStr) throws UnsupportedEncodingException {
@@ -37,11 +41,27 @@ public class QueryParamProcessor {
             int index = entry.indexOf('=');
             if (index != -1) {
                 String name = entry.substring(0, index);
-                String value = URLDecoder.decode(entry.substring(index + 1),
-                        ENCODING);
+                String value = URLDecoder.decode(entry.substring(index + 1), ENCODING);
                 queryParams.put(name, value);
             }
         }
         return queryParams;
+    }
+
+    public static Map<String, String> processHeaderParams(List<Header> headers) {
+        Map<String, String> headerParams = new HashMap<>();
+        for (Header header : headers) {
+            String name = header.getName();
+            String value = null;
+            try {
+                value = URLDecoder.decode(header.getValue(), ENCODING);
+            } catch (UnsupportedEncodingException e) {
+                throw new BallerinaException("Unsupported encoding in value: " + value + "for " + name);
+            } catch (NullPointerException e) {
+                throw new BallerinaException("Null header value for : " + name);
+            }
+            headerParams.put(name, value);
+        }
+        return headerParams;
     }
 }

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/uri/ParamProcessor.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/uri/ParamProcessor.java
@@ -40,8 +40,8 @@ public class ParamProcessor {
         for (String entry : entries) {
             int index = entry.indexOf('=');
             if (index != -1) {
-                String name = entry.substring(0, index);
-                String value = URLDecoder.decode(entry.substring(index + 1), ENCODING);
+                String name = entry.substring(0, index).trim();
+                String value = URLDecoder.decode(entry.substring(index + 1).trim(), ENCODING);
                 queryParams.put(name, value);
             }
         }
@@ -51,10 +51,10 @@ public class ParamProcessor {
     public static Map<String, String> processHeaderParams(List<Header> headers) {
         Map<String, String> headerParams = new HashMap<>();
         for (Header header : headers) {
-            String name = header.getName();
+            String name = header.getName().trim();
             String value = "";
             try {
-                value = URLDecoder.decode(header.getValue(), ENCODING);
+                value = URLDecoder.decode(header.getValue().trim(), ENCODING);
             } catch (UnsupportedEncodingException e) {
                 throw new BallerinaException("Unsupported encoding in value: " + value + "for " + name);
             }

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/util/codegen/CallableUnitInfo.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/util/codegen/CallableUnitInfo.java
@@ -21,7 +21,6 @@ import org.ballerinalang.model.types.BType;
 import org.ballerinalang.util.codegen.attributes.AnnotationAttributeInfo;
 import org.ballerinalang.util.codegen.attributes.AttributeInfo;
 import org.ballerinalang.util.codegen.attributes.AttributeInfoPool;
-import org.ballerinalang.util.codegen.attributes.ParamAnnotationAttributeInfo;
 import org.ballerinalang.util.codegen.cpentries.WorkerInfoPool;
 
 import java.util.HashMap;
@@ -193,23 +192,6 @@ public class CallableUnitInfo implements AttributeInfoPool, WorkerInfoPool {
         for (AnnAttachmentInfo annotationInfo : attributeInfo.getAttachmentInfoEntries()) {
             if (packageName.equals(annotationInfo.getPkgPath()) && annotationName.equals(annotationInfo.getName())) {
                 return annotationInfo;
-            }
-        }
-        return null;
-    }
-
-    public AnnAttachmentInfo getParamAnnotationAttachmentInfo(String packageName, String annotationName) {
-        ParamAnnotationAttributeInfo attributeInfo = (ParamAnnotationAttributeInfo) getAttributeInfo(
-                AttributeInfo.Kind.PARAMETER_ANNOTATIONS_ATTRIBUTE);
-        if (attributeInfo == null || packageName == null || annotationName == null) {
-            return null;
-        }
-        for (ParamAnnAttachmentInfo paramAnnAttachmentInfo : attributeInfo.getAttachmentInfoArray()) {
-            for (AnnAttachmentInfo annotationInfo : paramAnnAttachmentInfo.getAnnAttachmentInfos()) {
-                if (packageName.equals(annotationInfo.getPkgPath())
-                        && annotationName.equals(annotationInfo.getName())) {
-                    return annotationInfo;
-                }
             }
         }
         return null;

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/util/codegen/CallableUnitInfo.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/util/codegen/CallableUnitInfo.java
@@ -21,6 +21,7 @@ import org.ballerinalang.model.types.BType;
 import org.ballerinalang.util.codegen.attributes.AnnotationAttributeInfo;
 import org.ballerinalang.util.codegen.attributes.AttributeInfo;
 import org.ballerinalang.util.codegen.attributes.AttributeInfoPool;
+import org.ballerinalang.util.codegen.attributes.ParamAnnotationAttributeInfo;
 import org.ballerinalang.util.codegen.cpentries.WorkerInfoPool;
 
 import java.util.HashMap;
@@ -192,6 +193,23 @@ public class CallableUnitInfo implements AttributeInfoPool, WorkerInfoPool {
         for (AnnAttachmentInfo annotationInfo : attributeInfo.getAttachmentInfoEntries()) {
             if (packageName.equals(annotationInfo.getPkgPath()) && annotationName.equals(annotationInfo.getName())) {
                 return annotationInfo;
+            }
+        }
+        return null;
+    }
+
+    public AnnAttachmentInfo getParamAnnotationAttachmentInfo(String packageName, String annotationName) {
+        ParamAnnotationAttributeInfo attributeInfo = (ParamAnnotationAttributeInfo) getAttributeInfo(
+                AttributeInfo.Kind.PARAMETER_ANNOTATIONS_ATTRIBUTE);
+        if (attributeInfo == null || packageName == null || annotationName == null) {
+            return null;
+        }
+        for (ParamAnnAttachmentInfo paramAnnAttachmentInfo : attributeInfo.getAttachmentInfoArray()) {
+            for (AnnAttachmentInfo annotationInfo : paramAnnAttachmentInfo.getAnnAttachmentInfos()) {
+                if (packageName.equals(annotationInfo.getPkgPath())
+                        && annotationName.equals(annotationInfo.getName())) {
+                    return annotationInfo;
+                }
             }
         }
         return null;

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/util/codegen/CodeGenerator.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/util/codegen/CodeGenerator.java
@@ -2600,7 +2600,8 @@ public class CodeGenerator implements NodeVisitor {
             for (AnnotationAttachment annotationAttachment : attachments) {
                 if ("PathParam".equalsIgnoreCase(annotationAttachment.getName())
                         || "QueryParam".equalsIgnoreCase(annotationAttachment.getName())
-                        || "FormParam".equalsIgnoreCase(annotationAttachment.getName())) {
+                        || "FormParam".equalsIgnoreCase(annotationAttachment.getName())
+                        || "HeaderParam".equalsIgnoreCase(annotationAttachment.getName())) {
                     paramNames[i] = annotationAttachment.getAttributeNameValuePairs()
                             .get("value").getLiteralValue().stringValue();
                     isAnnotated = true;

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/util/codegen/CodeGenerator.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/util/codegen/CodeGenerator.java
@@ -2599,7 +2599,8 @@ public class CodeGenerator implements NodeVisitor {
             boolean isAnnotated = false;
             for (AnnotationAttachment annotationAttachment : attachments) {
                 if ("PathParam".equalsIgnoreCase(annotationAttachment.getName())
-                        || "QueryParam".equalsIgnoreCase(annotationAttachment.getName())) {
+                        || "QueryParam".equalsIgnoreCase(annotationAttachment.getName())
+                        || "FormParam".equalsIgnoreCase(annotationAttachment.getName())) {
                     paramNames[i] = annotationAttachment.getAttributeNameValuePairs()
                             .get("value").getLiteralValue().stringValue();
                     isAnnotated = true;

--- a/modules/ballerina-native/src/main/ballerina/ballerina/net/http/annotation.bal
+++ b/modules/ballerina-native/src/main/ballerina/ballerina/net/http/annotation.bal
@@ -43,6 +43,10 @@ annotation FormParam attach parameter {
     string value;
 }
 
+annotation HeaderParam attach parameter {
+    string value;
+}
+
 annotation Consumes attach resource {
     string[] value;
 }

--- a/modules/ballerina-native/src/main/ballerina/ballerina/net/http/annotation.bal
+++ b/modules/ballerina-native/src/main/ballerina/ballerina/net/http/annotation.bal
@@ -39,6 +39,10 @@ annotation QueryParam attach parameter {
     string value;
 }
 
+annotation FormParam attach parameter {
+    string value;
+}
+
 annotation Consumes attach resource {
     string[] value;
 }

--- a/modules/ballerina-native/src/main/ballerina/ballerina/net/http/natives.bal
+++ b/modules/ballerina-native/src/main/ballerina/ballerina/net/http/natives.bal
@@ -41,6 +41,11 @@ native function setStatusCode (message m, int statusCode);
 @doc:Param { value:"reasonPhrase: Reason phrase value" }
 native function setReasonPhrase (message m, string reasonPhrase);
 
+@doc:Description { value:"Gets formParam map from HTTP message"}
+@doc:Param { value:"m: The message object" }
+@doc:Return { value:"map: The map of form params" }
+native function getFormParams (message m) (map);
+
 connector ClientConnector (string serviceUri) {
 
 	@doc:Description { value:"The POST action implementation of the HTTP Connector."}

--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/net/http/GetFormParams.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/net/http/GetFormParams.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.nativeimpl.net.http;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeEnum;
+import org.ballerinalang.model.util.MessageUtils;
+import org.ballerinalang.model.values.BMap;
+import org.ballerinalang.model.values.BMessage;
+import org.ballerinalang.model.values.BString;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.nativeimpl.lang.utils.Constants;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.Attribute;
+import org.ballerinalang.natives.annotations.BallerinaAnnotation;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+import org.ballerinalang.runtime.message.StringDataSource;
+import org.ballerinalang.util.exceptions.BallerinaException;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+
+/**
+ * Get the Form params from HTTP the Message and return as map.
+ */
+@BallerinaFunction(
+        packageName = "ballerina.net.http",
+        functionName = "getFormParams",
+        args = {@Argument(name = "m", type = TypeEnum.MESSAGE)},
+        returnType = {@ReturnType(type = TypeEnum.MAP, elementType = TypeEnum.STRING)},
+        isPublic = true
+)
+@BallerinaAnnotation(annotationName = "Description", attributes = {@Attribute(name = "value",
+        value = "Gets formParam map from HTTP message") })
+@BallerinaAnnotation(annotationName = "Param", attributes = {@Attribute(name = "m",
+        value = "The message object") })
+@BallerinaAnnotation(annotationName = "Return", attributes = {@Attribute(name = "map",
+        value = "The map of form params") })
+public class GetFormParams extends AbstractNativeFunction {
+    @Override
+    public BValue[] execute(Context context) {
+        try {
+            BMessage msg = (BMessage) getRefArgument(context, 0);
+            String contentType = msg.getHeader(Constants.CONTENT_TYPE);
+            if (contentType != null && contentType.contains(Constants.APPLICATION_FORM)) {
+                String payload;
+                if (msg.value().isAlreadyRead()) {
+                    payload = msg.value().getMessageDataSource().getMessageAsString();
+                } else {
+                    payload = MessageUtils.getStringFromInputStream(msg.value().getInputStream());
+                    StringDataSource stringDataSource = new StringDataSource(payload);
+                    msg.value().setMessageDataSource(stringDataSource);
+                    msg.value().setAlreadyRead(true);
+                }
+                if (!payload.isEmpty()) {
+                    return getBValues(processFormParams(payload));
+                } else {
+                    throw new BallerinaException("empty message payload");
+                }
+            }
+        } catch (Throwable e) {
+            throw new BallerinaException("Error while retrieving form param from message: " + e.getMessage());
+        }
+        return new BValue[0];
+    }
+
+    private BMap<String, BString> processFormParams(String payload) throws UnsupportedEncodingException {
+        BMap<String, BString> formParams = new BMap<>();
+        String[] entries = payload.split("&");
+        for (String entry : entries) {
+            int index = entry.indexOf('=');
+            if (index != -1) {
+                String name = entry.substring(0, index).trim();
+                String value = URLDecoder.decode(entry.substring(index + 1).trim(), "UTF-8");
+                formParams.put(name, new BString(value));
+            }
+        }
+        return formParams;
+    }
+}

--- a/modules/ballerina-native/src/test/java/org/ballerinalang/service/ServiceTest.java
+++ b/modules/ballerina-native/src/test/java/org/ballerinalang/service/ServiceTest.java
@@ -18,8 +18,10 @@
 
 package org.ballerinalang.service;
 
+import org.ballerinalang.model.values.BJSON;
 import org.ballerinalang.runtime.message.StringDataSource;
 import org.ballerinalang.services.dispatchers.DispatcherRegistry;
+import org.ballerinalang.services.dispatchers.http.Constants;
 import org.ballerinalang.services.dispatchers.http.HTTPResourceDispatcher;
 import org.ballerinalang.testutils.EnvironmentInitializer;
 import org.ballerinalang.testutils.MessageUtils;
@@ -151,6 +153,45 @@ public class ServiceTest {
         Assert.assertNull(response.getHeader("header1"));
         Assert.assertNull(response.getHeader("header2"));
         Assert.assertNull(response.getHeader("header3"));
+    }
+
+    @Test(description = "Test GetFormParams Native Function")
+    public void testGetFormParamsNativeFunction() {
+        String path = "/echo/getFormParams";
+        CarbonMessage cMsg = MessageUtils.generateHTTPMessage(path, "POST", "firstName=WSO2&team=BalDance");
+        cMsg.setHeader(Constants.CONTENT_TYPE_HEADER, Constants.APPLICATION_X_WWW_FORM_URLENCODED);
+        CarbonMessage response = Services.invoke(cMsg);
+
+        Assert.assertNotNull(response, "Response message not found");
+        BJSON bJson = ((BJSON) response.getMessageDataSource());
+        Assert.assertEquals(bJson.value().get("Name").asText(), "WSO2"
+                , "Name variable not set properly.");
+        Assert.assertEquals(bJson.value().get("Team").asText(), "BalDance"
+                , "Team variable not set properly.");
+
+    }
+
+    @Test(description = "Test GetFormParams with undefined key and empty payloads")
+    public void testGetFormParamsForUndefinedKey() {
+        String path = "/echo/getFormParams";
+        CarbonMessage cMsg = MessageUtils.generateHTTPMessage(path, "POST", "firstName=WSO2&company=BalDance");
+        cMsg.setHeader(Constants.CONTENT_TYPE_HEADER, Constants.APPLICATION_X_WWW_FORM_URLENCODED);
+        CarbonMessage response = Services.invoke(cMsg);
+
+        Assert.assertNotNull(response, "Response message not found");
+        BJSON bJson = ((BJSON) response.getMessageDataSource());
+        Assert.assertEquals(bJson.value().get("Team").asText(), ""
+                , "Team variable not set properly.");
+
+        cMsg = MessageUtils.generateHTTPMessage(path, "POST", "");
+        cMsg.setHeader(Constants.CONTENT_TYPE_HEADER, Constants.APPLICATION_X_WWW_FORM_URLENCODED);
+        response = Services.invoke(cMsg);
+
+        Assert.assertNotNull(response, "Response message not found");
+        StringDataSource stringDataSource = (StringDataSource) response.getMessageDataSource();
+        Assert.assertNotNull(stringDataSource);
+        Assert.assertEquals(stringDataSource.getValue().substring(86, 107), "empty message payload");
+
     }
 
     @AfterClass

--- a/modules/ballerina-native/src/test/java/org/ballerinalang/service/UriTemplateDispatcherTest.java
+++ b/modules/ballerina-native/src/test/java/org/ballerinalang/service/UriTemplateDispatcherTest.java
@@ -349,14 +349,6 @@ public class UriTemplateDispatcherTest {
         Assert.assertEquals(bJson.value().get("Range").asText(), "bytes=500-999"
                 , "Range variable not set properly.");
 
-        cMsg = MessageUtils.generateHTTPMessage(path, "POST", "area=colombo");
-        cMsg.setHeader("Range", null);
-        response = Services.invoke(cMsg);
-
-        Assert.assertNotNull(response, "Response message not found");
-        String responseMessage = response.getMessageDataSource().getMessageAsString();
-        Assert.assertTrue(responseMessage.contains("Null header value for : Range"),
-                "Expected error not found.");
     }
 
     @Test(description = "Test dispatching with integer param")

--- a/modules/ballerina-native/src/test/java/org/ballerinalang/service/UriTemplateDispatcherTest.java
+++ b/modules/ballerina-native/src/test/java/org/ballerinalang/service/UriTemplateDispatcherTest.java
@@ -215,6 +215,58 @@ public class UriTemplateDispatcherTest {
                 , "Resource dispatched to wrong template");
     }
 
+    @Test(description = "Test dispatching with URL. /ecommerceservice/test")
+    public void testUrlMultipleFormParamDispatching() {
+        String path = "/ecommerceservice/test";
+        CarbonMessage cMsg = MessageUtils.generateHTTPMessage(path, "POST", "fname=WSO2&lname=BalDance");
+        cMsg.setHeader(Constants.CONTENT_TYPE_HEADER, Constants.APPLICATION_X_WWW_FORM_URLENCODED);
+        CarbonMessage response = Services.invoke(cMsg);
+        Assert.assertNotNull(response, "Response message not found");
+        BJSON bJson = ((BJSON) response.getMessageDataSource());
+        Assert.assertEquals(bJson.value().get("FirstName").asText(), "WSO2"
+                , "ProductID variable not set properly.");
+        Assert.assertEquals(bJson.value().get("LastName").asText(), "BalDance"
+                , "RegID variable not set properly.");
+    }
+
+    @Test(description = "Test dispatching with unallowed content types")
+    public void testFormParamDispatchingForNotAllowedContentType() {
+        String path = "/ecommerceservice/test";
+        CarbonMessage cMsg = MessageUtils.generateHTTPMessage(path, "POST", "fname=WSO2&lname=BalDance");
+        cMsg.setHeader(Constants.CONTENT_TYPE_HEADER, Constants.APPLICATION_OCTET_STREAM);
+        CarbonMessage response = Services.invoke(cMsg);
+        Assert.assertNotNull(response, "Response message not found");
+        BJSON bJson = ((BJSON) response.getMessageDataSource());
+        Assert.assertEquals(bJson.value().get("FirstName").asText(), "");
+    }
+
+    @Test(description = "Test dispatching with GET request")
+    public void testFormParamDispatchingWithGET() {
+        String path = "/ecommerceservice/test77?fname=WSO2&lname=BalDance";
+        CarbonMessage cMsg = MessageUtils.generateHTTPMessage(path, "GET");
+        CarbonMessage response = Services.invoke(cMsg);
+        Assert.assertNotNull(response, "Response message not found");
+        BJSON bJson = ((BJSON) response.getMessageDataSource());
+        Assert.assertEquals(bJson.value().get("FirstName").asText(), "WSO2"
+                , "ProductID variable not set properly.");
+    }
+
+    @Test(description = "Test dispatching with path, query and form param")
+    public void testMultipleParamDispatching() {
+        String path = "/ecommerceservice/test66/wso2?team=ballerina";
+        CarbonMessage cMsg = MessageUtils.generateHTTPMessage(path, "POST", "area=colombo");
+        cMsg.setHeader(Constants.CONTENT_TYPE_HEADER, Constants.APPLICATION_X_WWW_FORM_URLENCODED);
+        CarbonMessage response = Services.invoke(cMsg);
+        Assert.assertNotNull(response, "Response message not found");
+        BJSON bJson = ((BJSON) response.getMessageDataSource());
+        Assert.assertEquals(bJson.value().get("path").asText(), "wso2"
+                , "ProductID variable not set properly.");
+        Assert.assertEquals(bJson.value().get("query").asText(), "ballerina"
+                , "RegID variable not set properly.");
+        Assert.assertEquals(bJson.value().get("form").asText(), "colombo"
+                , "RegID variable not set properly.");
+    }
+
     @AfterClass
     public void tearDown() {
 //        EnvironmentInitializer.cleanup(application);

--- a/modules/ballerina-native/src/test/java/org/ballerinalang/service/UriTemplateDispatcherTest.java
+++ b/modules/ballerina-native/src/test/java/org/ballerinalang/service/UriTemplateDispatcherTest.java
@@ -224,13 +224,13 @@ public class UriTemplateDispatcherTest {
         Assert.assertNotNull(response, "Response message not found");
         BJSON bJson = ((BJSON) response.getMessageDataSource());
         Assert.assertEquals(bJson.value().get("FirstName").asText(), "WSO2"
-                , "ProductID variable not set properly.");
+                , "FirstName variable not set properly.");
         Assert.assertEquals(bJson.value().get("LastName").asText(), "BalDance"
-                , "RegID variable not set properly.");
+                , "LastName variable not set properly.");
     }
 
-    @Test(description = "Test dispatching with unallowed content types")
-    public void testFormParamDispatchingForNotAllowedContentType() {
+    @Test(description = "Test dispatching with unsupported content types")
+    public void testFormParamDispatchingForUnsupporteddContentType() {
         String path = "/ecommerceservice/test";
         CarbonMessage cMsg = MessageUtils.generateHTTPMessage(path, "POST", "fname=WSO2&lname=BalDance");
         cMsg.setHeader(Constants.CONTENT_TYPE_HEADER, Constants.APPLICATION_OCTET_STREAM);
@@ -248,7 +248,75 @@ public class UriTemplateDispatcherTest {
         Assert.assertNotNull(response, "Response message not found");
         BJSON bJson = ((BJSON) response.getMessageDataSource());
         Assert.assertEquals(bJson.value().get("FirstName").asText(), "WSO2"
-                , "ProductID variable not set properly.");
+                , "FirstName variable not set properly.");
+    }
+
+    @Test(description = "Test dispatching with form param without annotation")
+    public void testFormParamDispatchingWithoutAnnotation() {
+        String path = "/ecommerceservice/test777";
+        CarbonMessage cMsg = MessageUtils.generateHTTPMessage(path, "POST", "fname=WSO2&lname=BalDance");
+        cMsg.setHeader(Constants.CONTENT_TYPE_HEADER, Constants.APPLICATION_X_WWW_FORM_URLENCODED);
+        CarbonMessage response = Services.invoke(cMsg);
+        Assert.assertNotNull(response, "Response message not found");
+        BJSON bJson = ((BJSON) response.getMessageDataSource());
+        Assert.assertEquals(bJson.value().get("FirstName").asText(), "WSO2"
+                , "FirstName variable not set properly.");
+    }
+
+    @Test(description = "Test dispatching with form param with redeclared key")
+    public void testParamDispatchingWithRedeclaredKey() {
+        String path = "/ecommerceservice/test777?fname=ballerina";
+        CarbonMessage cMsg = MessageUtils.generateHTTPMessage(path, "POST", "fname=WSO2&lname=BalDance");
+        cMsg.setHeader(Constants.CONTENT_TYPE_HEADER, Constants.APPLICATION_X_WWW_FORM_URLENCODED);
+        CarbonMessage response = Services.invoke(cMsg);
+        Assert.assertNotNull(response, "Response message not found");
+        BJSON bJson = ((BJSON) response.getMessageDataSource());
+        Assert.assertEquals(bJson.value().get("FirstName").asText(), "WSO2"
+                , "FirstName variable not set properly.");
+    }
+
+    @Test(description = "Test dispatching with boolean form param")
+    public void testBooleanFormParamDispatching() {
+        String path = "/ecommerceservice/test";
+        CarbonMessage cMsg = MessageUtils.generateHTTPMessage(path, "POST", "fname=WSO2&status=true");
+        cMsg.setHeader(Constants.CONTENT_TYPE_HEADER, Constants.APPLICATION_X_WWW_FORM_URLENCODED);
+        CarbonMessage response = Services.invoke(cMsg);
+        Assert.assertNotNull(response, "Response message not found");
+        BJSON bJson = ((BJSON) response.getMessageDataSource());
+        Assert.assertEquals(bJson.value().get("Status").asText(), "true"
+                , "Status variable not set properly.");
+
+        path = "/ecommerceservice/test";
+        cMsg = MessageUtils.generateHTTPMessage(path, "POST", "fname=WSO2&status=90");
+        cMsg.setHeader(Constants.CONTENT_TYPE_HEADER, Constants.APPLICATION_X_WWW_FORM_URLENCODED);
+        response = Services.invoke(cMsg);
+
+        Assert.assertNotNull(response, "Response message not found");
+        String responseMessage = response.getMessageDataSource().getMessageAsString();
+        Assert.assertTrue(responseMessage.contains("Could not parse input: 90 to a boolean"),
+                "Expected error not found.");
+    }
+
+    @Test(description = "Test dispatching with integer form param")
+    public void testIntegerFormParamDispatching() {
+        String path = "/ecommerceservice/test";
+        CarbonMessage cMsg = MessageUtils.generateHTTPMessage(path, "POST", "fname=WSO2&id=90");
+        cMsg.setHeader(Constants.CONTENT_TYPE_HEADER, Constants.APPLICATION_X_WWW_FORM_URLENCODED);
+        CarbonMessage response = Services.invoke(cMsg);
+        Assert.assertNotNull(response, "Response message not found");
+        BJSON bJson = ((BJSON) response.getMessageDataSource());
+        Assert.assertEquals(bJson.value().get("Id").asText(), "90"
+                , "Id variable not set properly.");
+
+        path = "/ecommerceservice/test";
+        cMsg = MessageUtils.generateHTTPMessage(path, "POST", "fname=WSO2&id=hello");
+        cMsg.setHeader(Constants.CONTENT_TYPE_HEADER, Constants.APPLICATION_X_WWW_FORM_URLENCODED);
+        response = Services.invoke(cMsg);
+
+        Assert.assertNotNull(response, "Response message not found");
+        String responseMessage = response.getMessageDataSource().getMessageAsString();
+        Assert.assertTrue(responseMessage.contains("Could not parse input: hello to a number"),
+                "Expected error not found.");
     }
 
     @Test(description = "Test dispatching with path, query and form param")
@@ -260,11 +328,77 @@ public class UriTemplateDispatcherTest {
         Assert.assertNotNull(response, "Response message not found");
         BJSON bJson = ((BJSON) response.getMessageDataSource());
         Assert.assertEquals(bJson.value().get("path").asText(), "wso2"
-                , "ProductID variable not set properly.");
+                , "path variable not set properly.");
         Assert.assertEquals(bJson.value().get("query").asText(), "ballerina"
-                , "RegID variable not set properly.");
+                , "query variable not set properly.");
         Assert.assertEquals(bJson.value().get("form").asText(), "colombo"
-                , "RegID variable not set properly.");
+                , "form variable not set properly.");
+    }
+
+    @Test(description = "Test dispatching with header param")
+    public void testHeaderParamDispatching() {
+        String path = "/ecommerceservice/test88";
+        CarbonMessage cMsg = MessageUtils.generateHTTPMessage(path, "POST", "area=colombo");
+        cMsg.setHeader(Constants.CONTENT_TYPE_HEADER, Constants.APPLICATION_X_WWW_FORM_URLENCODED);
+        cMsg.setHeader("Range", "bytes=500-999");
+        CarbonMessage response = Services.invoke(cMsg);
+        Assert.assertNotNull(response, "Response message not found");
+        BJSON bJson = ((BJSON) response.getMessageDataSource());
+        Assert.assertEquals(bJson.value().get("cType").asText(), Constants.APPLICATION_X_WWW_FORM_URLENCODED
+                , "cType variable not set properly.");
+        Assert.assertEquals(bJson.value().get("Range").asText(), "bytes=500-999"
+                , "Range variable not set properly.");
+
+        cMsg = MessageUtils.generateHTTPMessage(path, "POST", "area=colombo");
+        cMsg.setHeader("Range", null);
+        response = Services.invoke(cMsg);
+
+        Assert.assertNotNull(response, "Response message not found");
+        String responseMessage = response.getMessageDataSource().getMessageAsString();
+        Assert.assertTrue(responseMessage.contains("Null header value for : Range"),
+                "Expected error not found.");
+    }
+
+    @Test(description = "Test dispatching with integer param")
+    public void testIntegerHeaderParamDispatching() {
+        String path = "/ecommerceservice/test99";
+        CarbonMessage cMsg = MessageUtils.generateHTTPMessage(path, "POST", "area=colombo");
+        cMsg.setHeader("Range", "55");
+        CarbonMessage response = Services.invoke(cMsg);
+        Assert.assertNotNull(response, "Response message not found");
+        BJSON bJson = ((BJSON) response.getMessageDataSource());
+        Assert.assertEquals(bJson.value().get("Range").asText(), "55"
+                , "Range variable not set properly.");
+
+        cMsg = MessageUtils.generateHTTPMessage(path, "POST", "area=colombo");
+        cMsg.setHeader("Range", "colombo");
+        response = Services.invoke(cMsg);
+
+        Assert.assertNotNull(response, "Response message not found");
+        String responseMessage = response.getMessageDataSource().getMessageAsString();
+        Assert.assertTrue(responseMessage.contains("Could not parse input: colombo to a number"),
+                "Expected error not found.");
+    }
+
+    @Test(description = "Test dispatching with boolean param")
+    public void testBooleanHeaderParamDispatching() {
+        String path = "/ecommerceservice/test991";
+        CarbonMessage cMsg = MessageUtils.generateHTTPMessage(path, "POST", "area=colombo");
+        cMsg.setHeader("Range", "true");
+        CarbonMessage response = Services.invoke(cMsg);
+        Assert.assertNotNull(response, "Response message not found");
+        BJSON bJson = ((BJSON) response.getMessageDataSource());
+        Assert.assertEquals(bJson.value().get("Range").asText(), "true"
+                , "Range variable not set properly.");
+
+        cMsg = MessageUtils.generateHTTPMessage(path, "POST", "area=colombo");
+        cMsg.setHeader("Range", "31");
+        response = Services.invoke(cMsg);
+
+        Assert.assertNotNull(response, "Response message not found");
+        String responseMessage = response.getMessageDataSource().getMessageAsString();
+        Assert.assertTrue(responseMessage.contains("Could not parse input: 31 to a boolean"),
+                "Expected error not found.");
     }
 
     @AfterClass

--- a/modules/ballerina-native/src/test/resources/lang/service/echoService.bal
+++ b/modules/ballerina-native/src/test/resources/lang/service/echoService.bal
@@ -35,4 +35,16 @@ service<http> echo {
         messages:removeAllHeaders(m);
         reply m;
     }
+
+    @http:POST{}
+    resource getFormParams (message m) {
+        message response = {};
+        map params = {};
+        params = http:getFormParams(m);
+        var name,_ = (string)params.firstName;
+        var team,_ = (string)params.team;
+        json responseJson = {"Name":name , "Team":team};
+        messages:setJsonPayload(response, responseJson);
+        reply response;
+    }
 }

--- a/modules/ballerina-native/src/test/resources/lang/service/uritemplate/uri-template.bal
+++ b/modules/ballerina-native/src/test/resources/lang/service/uritemplate/uri-template.bal
@@ -94,4 +94,31 @@ service<http> Ecommerce {
         messages:setJsonPayload(response, responseJson);
         reply response;
     }
+
+    @http:POST{}
+    @http:Path {value:"/test"}
+    resource productsInfo7 (message m, @http:FormParam {value:"fname"} string firstName, string lname) {
+        message response = {};
+        json responseJson = {"FirstName":firstName, "LastName":lname};
+        messages:setJsonPayload(response, responseJson);
+        reply response;
+    }
+
+    @http:POST{}
+    @http:Path {value:"/test66/{abc}"}
+    resource productsInfo8 (message m, @http:PathParam {value:"abc"} string name, @http:FormParam {value:"team"} string myTeam, string area) {
+        message response = {};
+        json responseJson = {"path":name, "query":myTeam, "form":area};
+        messages:setJsonPayload(response, responseJson);
+        reply response;
+    }
+
+    @http:GET{}
+    @http:Path {value:"/test77"}
+    resource productsInfo9 (message m, @http:FormParam {value:"fname"} string firstName) {
+        message response = {};
+        json responseJson = {"FirstName":firstName};
+        messages:setJsonPayload(response, responseJson);
+        reply response;
+    }
 }

--- a/modules/ballerina-native/src/test/resources/lang/service/uritemplate/uri-template.bal
+++ b/modules/ballerina-native/src/test/resources/lang/service/uritemplate/uri-template.bal
@@ -97,9 +97,9 @@ service<http> Ecommerce {
 
     @http:POST{}
     @http:Path {value:"/test"}
-    resource productsInfo7 (message m, @http:FormParam {value:"fname"} string firstName, string lname) {
+    resource productsInfo7 (message m, @http:FormParam {value:"fname"} string firstName, string lname, int id, boolean status) {
         message response = {};
-        json responseJson = {"FirstName":firstName, "LastName":lname};
+        json responseJson = {"FirstName":firstName, "LastName":lname, "Id":id, "Status":status};
         messages:setJsonPayload(response, responseJson);
         reply response;
     }
@@ -118,6 +118,46 @@ service<http> Ecommerce {
     resource productsInfo9 (message m, @http:FormParam {value:"fname"} string firstName) {
         message response = {};
         json responseJson = {"FirstName":firstName};
+        messages:setJsonPayload(response, responseJson);
+        reply response;
+    }
+
+    @http:POST{}
+    @http:Path {value:"/test777"}
+    resource productsInfo99 (message m, string fname) {
+        message response = {};
+        json responseJson = {"FirstName":fname};
+        messages:setJsonPayload(response, responseJson);
+        reply response;
+    }
+
+    @http:POST{}
+    @http:Path {value:"/test88"}
+    resource productsInfo10 (message m, @http:HeaderParam {value:"Content-Type"} string cType, string Range) {
+        message response = {};
+        json responseJson = {"cType":cType, "Range": Range};
+        messages:setJsonPayload(response, responseJson);
+        reply response;
+    }
+
+    @http:POST{}
+    @http:Path {value:"/test99"}
+    resource productsInfo11 (message m, @http:HeaderParam {value:"Range"} int Range) {
+        message response = {};
+        string bar;
+        bar, _ = <string> Range;
+        json responseJson = {"Range": bar};
+        messages:setJsonPayload(response, responseJson);
+        reply response;
+    }
+
+    @http:POST{}
+    @http:Path {value:"/test991"}
+    resource productsInfo12 (message m, @http:HeaderParam {value:"Range"} boolean Range) {
+        message response = {};
+        boolean bar;
+        bar, _ = <boolean> Range;
+        json responseJson = {"Range": bar};
         messages:setJsonPayload(response, responseJson);
         reply response;
     }


### PR DESCRIPTION
This PR $Subject as follows. Parameter can be stated either as default values or with annotations. 

@http:POST{}
     @http:Path {value:"/test"}
      resource product (message m, @http:FormParam {value:"fname"} string firstName, 
                                                                @http:HeaderParam {value:"Range"} int range,
                                                                 string lastName ) {
        //.......
    }