### PR TITLE
[WebSocket] Binary Support

### DIFF
--- a/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/ws/WebSocketResourceDispatcher.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/services/dispatchers/ws/WebSocketResourceDispatcher.java
@@ -61,7 +61,7 @@ public class WebSocketResourceDispatcher implements ResourceDispatcher {
             if (cMsg instanceof TextCarbonMessage) {
                 return getResource(service, Constants.ANNOTATION_NAME_ON_TEXT_MESSAGE);
             } else if (cMsg instanceof BinaryCarbonMessage) {
-                throw new BallerinaException("Binary messages are not supported!");
+                return getResource(service, Constants.ANNOTATION_NAME_ON_BINARY_MESSAGE);
             } else if (cMsg instanceof ControlCarbonMessage) {
                 throw new BallerinaException("Pong messages are not supported!");
             } else if (cMsg instanceof StatusCarbonMessage) {

--- a/modules/ballerina-native/src/main/ballerina/ballerina/net/ws/annotation.bal
+++ b/modules/ballerina-native/src/main/ballerina/ballerina/net/ws/annotation.bal
@@ -13,5 +13,8 @@ annotation OnOpen attach resource {
 annotation OnTextMessage attach resource {
 }
 
+annotation OnBinaryMessage attach resource {
+}
+
 annotation OnClose attach resource {
 }

--- a/modules/ballerina-native/src/main/ballerina/ballerina/net/ws/natives.bal
+++ b/modules/ballerina-native/src/main/ballerina/ballerina/net/ws/natives.bal
@@ -6,6 +6,10 @@ import ballerina.doc;
 @doc:Param { value:"text: Text which should be sent" }
 native function pushText (string text);
 
+@doc:Description { value:"This pushes binary data from server to the the same client who sent the message."}
+@doc:Param { value:"binary: Blob message which should be sent" }
+native function pushBinary (blob binary);
+
 @doc:Description { value:"This pushes text from server to all the connected clients of the service."}
 @doc:Param { value:"text: Text which should be sent" }
 native function broadcastText (string text);

--- a/modules/ballerina-native/src/main/ballerina/ballerina/net/ws/natives.bal
+++ b/modules/ballerina-native/src/main/ballerina/ballerina/net/ws/natives.bal
@@ -30,6 +30,11 @@ native function removeStoredConnection (string connectionName);
 @doc:Param { value:"text: Text which should be sent" }
 native function pushTextToConnection (string connectionName, string text);
 
+@doc:Description { value:"Push binary message to the connection chose by the user from the connection store."}
+@doc:Param { value:"connectionName: Name of the connection" }
+@doc:Param { value:"binary: Binary message which should be sent" }
+native function pushBinaryToConnection (string connectionName, blob binary);
+
 @doc:Description { value:"Close stored connection."}
 @doc:Param { value:"connectionName: Name of the connection" }
 native function closeStoredConnection (string connectionName);

--- a/modules/ballerina-native/src/main/ballerina/ballerina/net/ws/natives.bal
+++ b/modules/ballerina-native/src/main/ballerina/ballerina/net/ws/natives.bal
@@ -56,6 +56,12 @@ native function removeConnectionGroup (string connectionGroupName);
 @doc:Param { value:"text: Text which should be sent" }
 native function pushTextToGroup (string connectionGroupName, string text);
 
+@doc:Description { value:"Push binary message from server to all the connected clients of the service."}
+@doc:Param { value:"connectionGroupName: Name of the connection group" }
+@doc:Param { value:"binary: Binary message which should be sent" }
+native function pushBinaryToGroup (string connectionGroupName, blob binary);
+
+
 @doc:Description { value:"Close all the connections in connection group."}
 @doc:Param { value:"connectionGroupName: Name of the connection group" }
 native function closeConnectionGroup(string connectionGroupName);
@@ -66,6 +72,11 @@ connector ClientConnector (string url, string callbackService) {
     @doc:Param { value:"c: WebSocket Client Connector"}
     @doc:Param { value:"text: text which should be sent"}
     native action pushText(ClientConnector c, string text);
+
+    @doc:Description { value:"Push binary message to the server"}
+    @doc:Param { value:"c: WebSocket Client Connector"}
+    @doc:Param { value:"binary: Binary message which should be sent"}
+    native action pushBinary(ClientConnector c, blob binary);
 
 }
 

--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/actions/ws/PushBinary.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/actions/ws/PushBinary.java
@@ -1,0 +1,85 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.nativeimpl.actions.ws;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeEnum;
+import org.ballerinalang.model.values.BConnector;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.Attribute;
+import org.ballerinalang.natives.annotations.BallerinaAction;
+import org.ballerinalang.natives.annotations.BallerinaAnnotation;
+import org.ballerinalang.natives.connectors.AbstractNativeAction;
+import org.ballerinalang.services.dispatchers.ws.Constants;
+import org.ballerinalang.services.dispatchers.ws.WebSocketConnectionManager;
+import org.ballerinalang.util.exceptions.BallerinaException;
+import org.osgi.service.component.annotations.Component;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import javax.websocket.Session;
+
+/**
+ * Push binary message to the remote server.
+ */
+
+@BallerinaAction(
+        packageName = "ballerina.net.ws",
+        actionName = "pushBinary",
+        connectorName = Constants.CONNECTOR_NAME,
+        args = {
+                @Argument(name = "c", type = TypeEnum.CONNECTOR),
+                @Argument(name = "binary", type = TypeEnum.BLOB),
+        },
+        connectorArgs = {
+                @Argument(name = "serviceUri", type = TypeEnum.STRING),
+                @Argument(name = "callbackService", type = TypeEnum.STRING)
+        })
+@BallerinaAnnotation(annotationName = "Description",
+                     attributes = {@Attribute(name = "value",
+                                              value = "Push binary message to the remote server.") })
+@BallerinaAnnotation(annotationName = "Param", attributes = {@Attribute(name = "c",
+                                                                        value = "WebSocket Client Connector") })
+@BallerinaAnnotation(annotationName = "Param", attributes = {@Attribute(name = "binary",
+                                                                        value = "Binary message which should be sent")})
+@Component(
+        name = "action.net.ws.pushBinary",
+        immediate = true,
+        service = AbstractNativeAction.class)
+
+public class PushBinary extends AbstractWebSocketAction {
+    @Override
+    public BValue execute(Context context) {
+        BConnector bConnector = (BConnector) getRefArgument(context, 0);
+        byte[] bytes = getBlobArgument(context, 0);
+        Session serverSession = getServerSession(context);
+        if (serverSession == null) {
+            throw new BallerinaException("Internal error occurred. Cannot find a connection");
+        }
+        Session clientSession = WebSocketConnectionManager.getInstance().
+                getClientSessionForConnector(bConnector, serverSession);
+        try {
+            clientSession.getBasicRemote().sendBinary(ByteBuffer.wrap(bytes));
+        } catch (IOException e) {
+            throw new BallerinaException("I/O exception occurred during sending the message");
+        }
+        return null;
+    }
+}

--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/lang/messages/GetBinaryPayload.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/lang/messages/GetBinaryPayload.java
@@ -34,6 +34,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wso2.carbon.messaging.BinaryCarbonMessage;
 
+import java.nio.ByteBuffer;
+
 /**
  * Native function to get payload as Blob..
  * ballerina.model.messages:getBinaryPayload
@@ -64,7 +66,14 @@ public class GetBinaryPayload extends AbstractNativeFunction {
                 result = new BBlob((byte[]) msg.getMessageDataSource().getDataObject());
             } else {
                 BinaryCarbonMessage binaryCarbonMessage = (BinaryCarbonMessage) msg.value();
-                byte[] arr = binaryCarbonMessage.readBytes().array();
+                ByteBuffer buffer = binaryCarbonMessage.readBytes();
+                byte[] arr;
+                if (buffer.hasArray()) {
+                    arr = binaryCarbonMessage.readBytes().array();
+                } else {
+                    arr = new byte[buffer.remaining()];
+                    buffer.get(arr);
+                }
                 result = new BBlob(arr);
             }
             if (log.isDebugEnabled()) {

--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/net/ws/PushBinary.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/net/ws/PushBinary.java
@@ -1,0 +1,79 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.nativeimpl.net.ws;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeEnum;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.Attribute;
+import org.ballerinalang.natives.annotations.BallerinaAnnotation;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.services.dispatchers.ws.Constants;
+import org.ballerinalang.services.dispatchers.ws.WebSocketServicesRegistry;
+import org.ballerinalang.util.exceptions.BallerinaException;
+import org.wso2.carbon.messaging.CarbonMessage;
+
+import java.nio.ByteBuffer;
+import javax.websocket.Session;
+
+/**
+ * Send binary message to the same client who sent the message to the given WebSocket Upgrade Path.
+ */
+
+@BallerinaFunction(
+        packageName = "ballerina.net.ws",
+        functionName = "pushBinary",
+        args = {
+                @Argument(name = "binary", type = TypeEnum.BLOB)
+        },
+        isPublic = true
+)
+@BallerinaAnnotation(annotationName = "Description",
+                     attributes = { @Attribute(name = "value", value = "This pushes binary from server to the the " +
+                             "same client who sent the message.") })
+@BallerinaAnnotation(annotationName = "Param",
+                     attributes = { @Attribute(name = "binary", value = "Binary message which should be sent") })
+
+public class PushBinary extends AbstractNativeFunction {
+    @Override
+    public BValue[] execute(Context context) {
+        if (context.getServiceInfo() == null ||
+                !context.getServiceInfo().getProtocolPkgPath().equals(Constants.WEBSOCKET_PACKAGE_PATH)) {
+            throw new BallerinaException("This function is only working with WebSocket services");
+        }
+
+        try {
+            CarbonMessage carbonMessage = context.getCarbonMessage();
+            Session session = (Session) carbonMessage.getProperty(Constants.WEBSOCKET_SERVER_SESSION);;
+            if (WebSocketServicesRegistry.getInstance().isClientService(context.getServiceInfo()) &&
+                    session == null) {
+                throw new BallerinaException("pushing text from client service is not supported. " +
+                                                     "This is only supported for WebSocket to WebSocket mediation");
+            }
+
+            byte[] binaryData = getBlobArgument(context, 0);
+            session.getBasicRemote().sendBinary(ByteBuffer.wrap(binaryData));
+        } catch (Throwable e) {
+            throw new BallerinaException("Cannot send the message. Error occurred.");
+        }
+        return VOID_RETURN;
+    }
+}

--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/net/ws/connectiongroup/PushBinaryToGroup.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/net/ws/connectiongroup/PushBinaryToGroup.java
@@ -1,7 +1,83 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
 package org.ballerinalang.nativeimpl.net.ws.connectiongroup;
 
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeEnum;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.Attribute;
+import org.ballerinalang.natives.annotations.BallerinaAnnotation;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.services.dispatchers.ws.WebSocketConnectionManager;
+import org.ballerinalang.util.exceptions.BallerinaException;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+import javax.websocket.Session;
+
 /**
- * Created by irunika on 7/27/17.
+ * This pushes binary message to a group which is previously define.
  */
-public class PushBinaryToGroup {
+
+@BallerinaFunction(
+        packageName = "ballerina.net.ws",
+        functionName = "pushBinaryToGroup",
+        args = {
+                @Argument(name = "connectionGroupName", type = TypeEnum.STRING),
+                @Argument(name = "binary", type = TypeEnum.BLOB)
+        },
+        isPublic = true
+)
+@BallerinaAnnotation(annotationName = "Description",
+                     attributes = { @Attribute(name = "value", value = "Push binary message from server to all " +
+                             "the connected clients of the service.") })
+@BallerinaAnnotation(annotationName = "Param",
+                     attributes = { @Attribute(name = "connectionGroupName", value = "Name of the connection group") })
+@BallerinaAnnotation(annotationName = "Param",
+                     attributes = { @Attribute(name = "binary", value = "Binary message which should be sent") })
+public class PushBinaryToGroup extends AbstractNativeFunction {
+    @Override
+    public BValue[] execute(Context context) {
+
+        if (context.getServiceInfo() == null) {
+            throw new BallerinaException("This function is only working with services");
+        }
+
+        String connectionGroupName = getStringArgument(context, 0);
+        byte[] bytes = getBlobArgument(context, 0);
+        List<Session> sessions = WebSocketConnectionManager.getInstance().getConnectionGroup(connectionGroupName);
+        if (sessions == null) {
+            throw new BallerinaException("Connection group name " + connectionGroupName +
+                                                 " not exists. Cannot push text to group");
+        }
+        sessions.forEach(
+                session -> {
+                    try {
+                        session.getBasicRemote().sendBinary(ByteBuffer.wrap(bytes));
+                    } catch (IOException e) {
+                        throw new BallerinaException("IO exception occurred during broadcasting text", e, context);
+                    }
+                }
+        );
+        return VOID_RETURN;
+    }
 }

--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/net/ws/connectiongroup/PushBinaryToGroup.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/net/ws/connectiongroup/PushBinaryToGroup.java
@@ -1,0 +1,7 @@
+package org.ballerinalang.nativeimpl.net.ws.connectiongroup;
+
+/**
+ * Created by irunika on 7/27/17.
+ */
+public class PushBinaryToGroup {
+}

--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/net/ws/connectionstore/PushBinaryToConnection.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/net/ws/connectionstore/PushBinaryToConnection.java
@@ -52,7 +52,7 @@ import javax.websocket.Session;
 @BallerinaAnnotation(annotationName = "Param",
                      attributes = { @Attribute(name = "connectionName", value = "name of the stored connection") })
 @BallerinaAnnotation(annotationName = "Param",
-                     attributes = { @Attribute(name = "text", value = "Text which should be sent") })
+                     attributes = { @Attribute(name = "binary", value = "Binary message which should be sent") })
 public class PushBinaryToConnection extends AbstractNativeFunction {
     @Override
     public BValue[] execute(Context context) {

--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/net/ws/connectionstore/PushBinaryToConnection.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/net/ws/connectionstore/PushBinaryToConnection.java
@@ -30,43 +30,44 @@ import org.ballerinalang.services.dispatchers.ws.WebSocketConnectionManager;
 import org.ballerinalang.util.exceptions.BallerinaException;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import javax.websocket.Session;
 
 /**
- * Push text to the connection chose by the user from the connection store.
+ * Push binary message to the connection chose by the user from the connection store.
  */
+
 @BallerinaFunction(
         packageName = "ballerina.net.ws",
-        functionName = "pushTextToConnection",
+        functionName = "pushBinaryToConnection",
         args = {
                 @Argument(name = "connectionName", type = TypeEnum.STRING),
-                @Argument(name = "text", type = TypeEnum.STRING)
+                @Argument(name = "binary", type = TypeEnum.BLOB)
         },
         isPublic = true
 )
 @BallerinaAnnotation(annotationName = "Description",
-                     attributes = { @Attribute(name = "value", value = "Push text to the connection chose by " +
-                             "the user from the connection store.") })
+                     attributes = { @Attribute(name = "value", value = "Push binary message to the connection " +
+                             "chose by the user from the connection store.") })
 @BallerinaAnnotation(annotationName = "Param",
                      attributes = { @Attribute(name = "connectionName", value = "name of the stored connection") })
 @BallerinaAnnotation(annotationName = "Param",
                      attributes = { @Attribute(name = "text", value = "Text which should be sent") })
-public class PushTextToConnection extends AbstractNativeFunction {
+public class PushBinaryToConnection extends AbstractNativeFunction {
     @Override
     public BValue[] execute(Context context) {
-
         if (context.getServiceInfo() == null) {
             throw new BallerinaException("This function is only working with services");
         }
 
         String connectionName = getStringArgument(context, 0);
-        String text = getStringArgument(context, 1);
+        byte[] bytes = getBlobArgument(context, 0);
         Session session = WebSocketConnectionManager.getInstance().getStoredConnection(connectionName);
         if (session == null) {
             throw new BallerinaException("Cannot find a connection for the connection name: " + connectionName);
         }
         try {
-            session.getBasicRemote().sendText(text);
+            session.getBasicRemote().sendBinary(ByteBuffer.wrap(bytes));
         } catch (IOException e) {
             throw new BallerinaException("IO exception occurred during pushing text to client", e, context);
         }

--- a/modules/ballerina-native/src/test/java/org/ballerinalang/nativeimpl/functions/ws/ConnectionGroupTest.java
+++ b/modules/ballerina-native/src/test/java/org/ballerinalang/nativeimpl/functions/ws/ConnectionGroupTest.java
@@ -28,6 +28,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -75,6 +76,19 @@ public class ConnectionGroupTest {
         Assert.assertEquals(session2.getTextReceived(), textExpectedForEven);
         Assert.assertEquals(session3.getTextReceived(), textExpectedForOdd);
         Assert.assertEquals(session4.getTextReceived(), textExpectedForEven);
+    }
+
+    @Test(priority = 0)
+    public void testSendingBinaryMessageToGrouping() {
+        byte[] bytes = {5, 6, 7, 8, 9};
+        ByteBuffer buffer = ByteBuffer.wrap(bytes);
+
+        Services.invoke(MessageUtils.generateWebSocketBinaryMessage(buffer, session1, wsEndpointPath));
+
+        Assert.assertEquals(session1.getBufferReceived(), null);
+        Assert.assertEquals(session2.getBufferReceived(), buffer);
+        Assert.assertEquals(session3.getBufferReceived(), null);
+        Assert.assertEquals(session4.getBufferReceived(), buffer);
     }
 
     @Test(priority = 1)

--- a/modules/ballerina-native/src/test/java/org/ballerinalang/nativeimpl/functions/ws/ConnectionStoreTest.java
+++ b/modules/ballerina-native/src/test/java/org/ballerinalang/nativeimpl/functions/ws/ConnectionStoreTest.java
@@ -28,6 +28,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -47,6 +48,8 @@ public class ConnectionStoreTest {
 
     private final String wsPath = "/chat-store/ws";
     private final String httpBasePath = "/data";
+    private final String httpPathForText = httpBasePath + "/text";
+    private final String httpPathForBinary = httpBasePath + "/binary";
 
     @BeforeClass
     public void  setup() {
@@ -68,11 +71,11 @@ public class ConnectionStoreTest {
     }
 
     @Test(priority = 0)
-    public void testStoringConnections() {
+    public void testStringReceivedToConnections() {
         String textSent;
         //Sending message to client 1 and check
         textSent = "Hi store 1";
-        Services.invoke(MessageUtils.generateHTTPMessage(httpBasePath + "/1", "POST", textSent));
+        Services.invoke(MessageUtils.generateHTTPMessage(httpPathForText + "/1", "POST", textSent));
         Assert.assertEquals(session1.getTextReceived(), textSent);
         Assert.assertEquals(session2.getTextReceived(), null);
         Assert.assertEquals(session3.getTextReceived(), null);
@@ -80,7 +83,7 @@ public class ConnectionStoreTest {
 
         //Sending message to client 2 and check
         textSent = "Hi store 2";
-        Services.invoke(MessageUtils.generateHTTPMessage(httpBasePath + "/2", "POST", textSent));
+        Services.invoke(MessageUtils.generateHTTPMessage(httpPathForText + "/2", "POST", textSent));
         Assert.assertEquals(session1.getTextReceived(), null);
         Assert.assertEquals(session2.getTextReceived(), textSent);
         Assert.assertEquals(session3.getTextReceived(), null);
@@ -88,7 +91,7 @@ public class ConnectionStoreTest {
 
         //Sending message to client 3 and check
         textSent = "Hi store 3";
-        Services.invoke(MessageUtils.generateHTTPMessage(httpBasePath + "/3", "POST", textSent));
+        Services.invoke(MessageUtils.generateHTTPMessage(httpPathForText + "/3", "POST", textSent));
         Assert.assertEquals(session1.getTextReceived(), null);
         Assert.assertEquals(session2.getTextReceived(), null);
         Assert.assertEquals(session3.getTextReceived(), textSent);
@@ -96,11 +99,22 @@ public class ConnectionStoreTest {
 
         //Sending message to client 4 and check
         textSent = "Hi store 4";
-        Services.invoke(MessageUtils.generateHTTPMessage(httpBasePath + "/4", "POST", textSent));
+        Services.invoke(MessageUtils.generateHTTPMessage(httpPathForText + "/4", "POST", textSent));
         Assert.assertEquals(session1.getTextReceived(), null);
         Assert.assertEquals(session2.getTextReceived(), null);
         Assert.assertEquals(session3.getTextReceived(), null);
         Assert.assertEquals(session4.getTextReceived(), textSent);
+    }
+
+    @Test(priority = 0)
+    public void testBinaryReceivedForConnection() {
+        byte[] bytes = {1, 2, 3, 4, 5};
+        ByteBuffer buffer = ByteBuffer.wrap(bytes);
+        Services.invoke(MessageUtils.generateWebSocketBinaryMessage(buffer, session1, wsPath));
+        Assert.assertEquals(session1.getBufferReceived(), null);
+        Assert.assertEquals(session2.getBufferReceived(), null);
+        Assert.assertEquals(session3.getBufferReceived(), buffer);
+        Assert.assertEquals(session4.getBufferReceived(), null);
     }
 
     @Test(priority = 1)

--- a/modules/ballerina-native/src/test/java/org/ballerinalang/nativeimpl/functions/ws/WebSocketEndpointTest.java
+++ b/modules/ballerina-native/src/test/java/org/ballerinalang/nativeimpl/functions/ws/WebSocketEndpointTest.java
@@ -29,6 +29,9 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.messaging.CarbonMessage;
 
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
 /**
  * Test connected client scenarios. When the client connects, send  and receive text and closing the connection.
  */
@@ -67,6 +70,16 @@ public class WebSocketEndpointTest {
         CarbonMessage client1Message = MessageUtils.generateWebSocketTextMessage(expectedText, session1, uri);
         Services.invoke(client1Message);
         Assert.assertEquals(session1.getTextReceived(), expectedText);
+    }
+
+    @Test
+    public void testPushBinary() {
+        String expectedText = "binary";
+        CarbonMessage clientMessage = MessageUtils.generateWebSocketTextMessage(expectedText, session2, uri);
+        Services.invoke(clientMessage);
+        ByteBuffer binaryReceived = session2.getBufferReceived();
+        String textReceived = StandardCharsets.UTF_8.decode(binaryReceived).toString();
+        Assert.assertEquals(textReceived, expectedText);
     }
 
     @Test(description = "Test closing a connection and broadcast.",

--- a/modules/ballerina-native/src/test/java/org/ballerinalang/nativeimpl/functions/ws/WebSocketEndpointTest.java
+++ b/modules/ballerina-native/src/test/java/org/ballerinalang/nativeimpl/functions/ws/WebSocketEndpointTest.java
@@ -72,7 +72,8 @@ public class WebSocketEndpointTest {
         Assert.assertEquals(session1.getTextReceived(), expectedText);
     }
 
-    @Test
+    @Test(description = "Test sending binary messages.",
+          priority = 1)
     public void testPushBinary() {
         String expectedText = "binary";
         CarbonMessage clientMessage = MessageUtils.generateWebSocketTextMessage(expectedText, session2, uri);
@@ -80,6 +81,17 @@ public class WebSocketEndpointTest {
         ByteBuffer binaryReceived = session2.getBufferReceived();
         String textReceived = StandardCharsets.UTF_8.decode(binaryReceived).toString();
         Assert.assertEquals(textReceived, expectedText);
+    }
+
+    @Test(description = "Test the resource for Binary message.",
+          priority = 1)
+    public void testOnBinaryMessageResource() {
+        byte[] bytes = {1, 2, 3, 4, 5};
+        ByteBuffer expectedByteBuffer = ByteBuffer.wrap(bytes);
+        CarbonMessage clientMessage = MessageUtils.generateWebSocketBinaryMessage(expectedByteBuffer, session3, uri);
+        Services.invoke(clientMessage);
+        ByteBuffer receivedBuffer = session3.getBufferReceived();
+        Assert.assertEquals(receivedBuffer, expectedByteBuffer);
     }
 
     @Test(description = "Test closing a connection and broadcast.",

--- a/modules/ballerina-native/src/test/java/org/ballerinalang/testutils/MessageUtils.java
+++ b/modules/ballerina-native/src/test/java/org/ballerinalang/testutils/MessageUtils.java
@@ -21,12 +21,14 @@ package org.ballerinalang.testutils;
 import org.ballerinalang.runtime.message.BallerinaMessageDataSource;
 import org.ballerinalang.runtime.message.StringDataSource;
 import org.ballerinalang.services.dispatchers.http.Constants;
+import org.wso2.carbon.messaging.BinaryCarbonMessage;
 import org.wso2.carbon.messaging.CarbonMessage;
 import org.wso2.carbon.messaging.DefaultCarbonMessage;
 import org.wso2.carbon.messaging.Header;
 import org.wso2.carbon.messaging.StatusCarbonMessage;
 import org.wso2.carbon.messaging.TextCarbonMessage;
 
+import java.nio.ByteBuffer;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
@@ -90,6 +92,11 @@ public class MessageUtils {
     public static CarbonMessage generateWebSocketTextMessage(String text, Session session, String path) {
         TextCarbonMessage textMessage = new TextCarbonMessage(text);
         return setWebSocketCommonProperties(textMessage, session, path);
+    }
+
+    public static CarbonMessage generateWebSocketBinaryMessage(ByteBuffer byteBuffer, Session session, String path) {
+        BinaryCarbonMessage binaryMessage = new BinaryCarbonMessage(byteBuffer, true);
+        return setWebSocketCommonProperties(binaryMessage, session, path);
     }
 
     public static CarbonMessage generateWebSocketOnOpenMessage(Session session, String path) {

--- a/modules/ballerina-native/src/test/resources/samples/websocket/connection_group_sample/connectionGroupTest.bal
+++ b/modules/ballerina-native/src/test/resources/samples/websocket/connection_group_sample/connectionGroupTest.bal
@@ -39,6 +39,12 @@ service<ws> oddEvenWebSocketConnector {
         }
     }
 
+    @ws:OnBinaryMessage {}
+    resource onBinaryMessage(message m) {
+        blob b = messages:getBinaryPayload(m);
+        ws:pushBinaryToGroup("evenGroup", b);
+    }
+
     @ws:OnClose {}
     resource onClose(message m) {
         system:println("client left the server.");

--- a/modules/ballerina-native/src/test/resources/samples/websocket/connection_store_sample/httpService.bal
+++ b/modules/ballerina-native/src/test/resources/samples/websocket/connection_store_sample/httpService.bal
@@ -6,9 +6,17 @@ import ballerina.net.ws;
 service<http> dataService {
 
     @http:POST {}
-    @http:Path {value:"/{id}"}
+    @http:Path {value:"text/{id}"}
     resource sendToConnection (message m, @http:PathParam {value:"id"} string id) {
         ws:pushTextToConnection(id, messages:getStringPayload(m));
+        message res = {};
+        reply res;
+    }
+
+    @http:POST {}
+    @http:Path {value:"binary/{id}"}
+    resource sendBinaryToConnection (message m, @http:PathParam {value:"id"} string id) {
+        ws:pushBinaryToConnection(id, messages:getBinaryPayload(m));
         message res = {};
         reply res;
     }

--- a/modules/ballerina-native/src/test/resources/samples/websocket/connection_store_sample/websocketEndpoint.bal
+++ b/modules/ballerina-native/src/test/resources/samples/websocket/connection_store_sample/websocketEndpoint.bal
@@ -13,6 +13,12 @@ service<ws> websocketEndpoint {
         ws:storeConnection(id);
     }
 
+    @ws:OnBinaryMessage {}
+    resource onBinaryMessage(message m) {
+        blob b = messages:getBinaryPayload(m);
+        ws:pushBinaryToConnection("3", b);
+    }
+
     @ws:OnClose {}
     resource onClose(message m) {
         system:println("client left the server.");

--- a/modules/ballerina-native/src/test/resources/samples/websocket/endpointTest.bal
+++ b/modules/ballerina-native/src/test/resources/samples/websocket/endpointTest.bal
@@ -24,6 +24,12 @@ service<ws> testEndpoint {
         ws:pushText(messages:getStringPayload(m));
     }
 
+    @ws:OnBinaryMessage {}
+    resource onBinaryMessage(message m) {
+        blob b = messages:getBinaryPayload(m);
+        ws:pushBinary(b);
+    }
+
     @ws:OnClose {}
     resource onClose(message m) {
         ws:broadcastText("client left");

--- a/modules/ballerina-native/src/test/resources/samples/websocket/endpointTest.bal
+++ b/modules/ballerina-native/src/test/resources/samples/websocket/endpointTest.bal
@@ -1,4 +1,5 @@
 import ballerina.lang.messages;
+import ballerina.lang.strings;
 import ballerina.net.http;
 import ballerina.net.ws;
 
@@ -16,6 +17,9 @@ service<ws> testEndpoint {
         string  text = messages:getStringPayload(m);
         if ("closeMe" == text) {
             ws:closeConnection();
+        } else if ("binary" == text) {
+            blob b = strings:toBlob(text, "UTF-8");
+            ws:pushBinary(b);
         }
         ws:pushText(messages:getStringPayload(m));
     }


### PR DESCRIPTION
This PR introduce binary support for WebSocket.

**Annotations**
- OnBinaryMessage: Resource level annotation which triggers when a binary message is received.

**Functions**
- pushBinary
- pushBinaryToConnection
- pushBinaryToGroup

**Client connectior actions**
- pushBinary