### PR TITLE
Add missing source handler reference to the context

### DIFF
--- a/modules/ballerina-core/src/main/java/org/ballerinalang/runtime/ServerConnectorMessageHandler.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/runtime/ServerConnectorMessageHandler.java
@@ -150,6 +150,7 @@ public class ServerConnectorMessageHandler {
         Context context = new Context(programFile);
         context.setServiceInfo(serviceInfo);
         context.setCarbonMessage(resourceMessage);
+        context.setProperty("SRC_HANDLER", resourceMessage.getProperty("SRC_HANDLER"));
         context.setBalCallback(new DefaultBalCallback(resourceCallback));
         ControlStackNew controlStackNew = context.getControlStackNew();
 


### PR DESCRIPTION
This PR fixes the issue with the source handler reference being null in the context. The source handler is required when correlating the interactions of the client with the interactions with the upstream server. 