### PR TITLE
Add support for enabling HTTP trace logs using flags

### DIFF
--- a/modules/ballerina-logging/src/main/java/org/ballerinalang/logging/BLogManager.java
+++ b/modules/ballerina-logging/src/main/java/org/ballerinalang/logging/BLogManager.java
@@ -57,23 +57,39 @@ public class BLogManager extends LogManager {
         });
 
         super.readConfiguration(propertiesToInputStream(properties));
-
-        // keep a reference to prevent this logger from being garbage collected
-        httpTraceLogger = Logger.getLogger("wirelog.http");
     }
 
     public void setWirelogHandler(String wirelogFlag) throws IOException {
-        String file;
+        File file;
         if ("--default".equals(wirelogFlag)) {
-            file = System.getProperty("ballerina.home") + File.separator + "logs" + File.separator + "http.log";
+            file = new File(
+                    System.getProperty("ballerina.home") + File.separator + "logs" + File.separator + "http.log");
         } else {
-            file = Paths.get(wirelogFlag).toFile().getAbsolutePath();
+            file = Paths.get(wirelogFlag).toFile();
         }
 
-        Handler handler = new HTTPTraceLogHandler(file);
+        if (!file.exists()) {
+            if (!file.getParentFile().exists()) {
+                if (file.getParentFile().mkdirs()) {
+                    if (!file.createNewFile()) {
+                        throw new IOException("error in creating the file: " + file.getAbsolutePath());
+                    }
+                } else {
+                    throw new IOException(
+                            "error in creating the parent directories: " + file.getParentFile().getAbsolutePath());
+                }
+            } else {
+                if (!file.createNewFile()) {
+                    throw new IOException("error in creating the file: " + file.getAbsolutePath());
+                }
+            }
+        }
+
+        Handler handler = new HTTPTraceLogHandler(file.getAbsolutePath());
         handler.setLevel(Level.FINE);
 
         if (httpTraceLogger == null) {
+            // keep a reference to prevent this logger from being garbage collected
             httpTraceLogger = Logger.getLogger("wirelog.http");
         }
 

--- a/modules/ballerina-logging/src/main/java/org/ballerinalang/logging/formatters/HTTPTraceLogFormatter.java
+++ b/modules/ballerina-logging/src/main/java/org/ballerinalang/logging/formatters/HTTPTraceLogFormatter.java
@@ -28,7 +28,7 @@ import java.util.logging.Formatter;
 import java.util.logging.LogRecord;
 
 /**
- * A custom log formatter for formatting log files other than ballerina.log, error.log and bre.log.
+ * A custom log formatter for formatting HTTP trace log files.
  *
  * @since 0.92
  */

--- a/modules/ballerina-logging/src/main/java/org/ballerinalang/logging/formatters/HTTPTraceLogFormatter.java
+++ b/modules/ballerina-logging/src/main/java/org/ballerinalang/logging/formatters/HTTPTraceLogFormatter.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.logging.formatters;
+
+import org.ballerinalang.logging.BLogManager;
+import org.ballerinalang.logging.util.BLogLevelMapper;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Date;
+import java.util.logging.Formatter;
+import java.util.logging.LogRecord;
+
+/**
+ * A custom log formatter for formatting log files other than ballerina.log, error.log and bre.log.
+ *
+ * @since 0.92
+ */
+public class HTTPTraceLogFormatter extends Formatter {
+
+    private static String format = BLogManager.getLogManager().getProperty(
+            HTTPTraceLogFormatter.class.getCanonicalName() + ".format");
+
+    @Override
+    public String format(LogRecord record) {
+        String source = record.getLoggerName();
+        String ex = "";
+
+        if (record.getThrown() != null) {
+            StringWriter stringWriter = new StringWriter();
+            stringWriter.append('\n');
+            record.getThrown().printStackTrace(new PrintWriter(stringWriter));
+            ex = stringWriter.toString();
+        }
+
+        return String.format(format,
+                             new Date(record.getMillis()),
+                             BLogLevelMapper.getBallerinaLogLevel(record.getLevel()),
+                             source,
+                             record.getMessage(),
+                             ex);
+    }
+}

--- a/modules/ballerina-logging/src/main/java/org/ballerinalang/logging/handlers/HTTPTraceLogHandler.java
+++ b/modules/ballerina-logging/src/main/java/org/ballerinalang/logging/handlers/HTTPTraceLogHandler.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.logging.handlers;
+
+import java.io.IOException;
+import java.util.logging.FileHandler;
+
+/**
+ * A handler for handling HTTP tracing logs.
+ *
+ * @since 0.92
+ */
+public class HTTPTraceLogHandler extends FileHandler {
+    public HTTPTraceLogHandler() throws IOException, SecurityException {
+    }
+
+    public HTTPTraceLogHandler(String file) throws IOException {
+        super(file);
+    }
+}

--- a/modules/launcher/src/main/java/org/ballerinalang/launcher/Main.java
+++ b/modules/launcher/src/main/java/org/ballerinalang/launcher/Main.java
@@ -195,8 +195,9 @@ public class Main {
         private String ballerinaDebugPort;
 
         @Parameter(names = "--wirelog",
-                   description = "path to the wire log file, use of --default sets " +
-                                                                "'<BALLERINA_HOME>/logs/http.log' as the log file")
+                   description = "path to the wire log file, " +
+                                        "use of --default sets '<BALLERINA_HOME>/logs/http.log' as the log file, " +
+                                        "use --console to log to std_out")
         private String wirelog;
 
         public void execute() {

--- a/modules/launcher/src/main/java/org/ballerinalang/launcher/Main.java
+++ b/modules/launcher/src/main/java/org/ballerinalang/launcher/Main.java
@@ -5,12 +5,14 @@ import com.beust.jcommander.MissingCommandException;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
+import org.ballerinalang.logging.BLogManager;
 import org.ballerinalang.util.exceptions.BLangRuntimeException;
 import org.ballerinalang.util.exceptions.ParserException;
 import org.ballerinalang.util.exceptions.SemanticException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
 import java.nio.file.Path;
@@ -192,6 +194,9 @@ public class Main {
         @Parameter(names = "--ballerina.debug", hidden = true, description = "remote debugging port")
         private String ballerinaDebugPort;
 
+        @Parameter(names = "--wirelog", hidden = true, description = "enable wire logging")
+        private String wirelog;
+
         public void execute() {
             if (helpFlag) {
                 String commandUsageInfo = BLauncherCmd.getCommandUsageInfo(parentCmdParser, "run");
@@ -201,6 +206,16 @@ public class Main {
 
             if (argList == null || argList.size() == 0) {
                 throw LauncherUtils.createUsageException("no ballerina program given");
+            }
+
+            if (wirelog != null) {
+                BLogManager logManager = (BLogManager) BLogManager.getLogManager();
+                try {
+                    logManager.setWirelogHandler(wirelog);
+                    System.setProperty("wirelog.enabled", Boolean.TRUE.toString());
+                } catch (IOException e) {
+                    throw LauncherUtils.createLauncherException("error in creating the log file: " + wirelog);
+                }
             }
 
             // Enable remote debugging

--- a/modules/launcher/src/main/java/org/ballerinalang/launcher/Main.java
+++ b/modules/launcher/src/main/java/org/ballerinalang/launcher/Main.java
@@ -194,7 +194,9 @@ public class Main {
         @Parameter(names = "--ballerina.debug", hidden = true, description = "remote debugging port")
         private String ballerinaDebugPort;
 
-        @Parameter(names = "--wirelog", hidden = true, description = "enable wire logging")
+        @Parameter(names = "--wirelog",
+                   description = "path to the wire log file, use of --default sets " +
+                                                                "'<BALLERINA_HOME>/logs/http.log' as the log file")
         private String wirelog;
 
         public void execute() {


### PR DESCRIPTION
This PR adds support for enabling wire logs by passing a flag to the run command. The user has 3 options:

- Log to a custom location: `ballerina run example.bal --wirelog path/to/wire/log/file`
- Log to the console: `ballerina run example.bal --wirelog --console`
- Log to `<BALLERINA_HOME>/logs/http.log` file: `ballerina run example.bal --wirelog --default`

The wire logs are turned off by default. If the above options doesn't suffice, one can use the config file at `/bre/conf/logging.properties`.