### PR TITLE
Stop creating a pid file when running a service

### DIFF
--- a/modules/launcher/src/main/java/org/ballerinalang/launcher/LauncherUtils.java
+++ b/modules/launcher/src/main/java/org/ballerinalang/launcher/LauncherUtils.java
@@ -48,7 +48,6 @@ import java.util.List;
  * @since 0.8.0
  */
 public class LauncherUtils {
-    public static final String BALLERINA_HOME = "ballerina.home";
 
     public static void runProgram(Path sourceRootPath, Path sourcePath, boolean runServices, String[] args) {
         ProgramFile programFile;
@@ -84,7 +83,6 @@ public class LauncherUtils {
     }
 
     private static void runServices(ProgramFile programFile) {
-        LauncherUtils.writePID(System.getProperty(BALLERINA_HOME));
         PrintStream outStream = System.out;
 
         // TODO : Fix this properly.


### PR DESCRIPTION
Resolves #2616 

This PR stops creating the PID for services. This is required only for 'ballerina server' mode.