### PR TITLE
Implement ballerina resiliency features using ballerina code

### DIFF
--- a/modules/ballerina-native/src/main/ballerina/ballerina/resiliency/cb/connector.bal
+++ b/modules/ballerina-native/src/main/ballerina/ballerina/resiliency/cb/connector.bal
@@ -1,0 +1,344 @@
+package ballerina.resiliency.cb;
+
+import ballerina.net.http;
+import ballerina.lang.time;
+import ballerina.lang.messages;
+import ballerina.lang.errors;
+
+
+time:Time lastErrorTime = time:currentTime();
+float errorCount;
+float requestCount;
+int circuitState;
+
+connector ClientConnector<http:ClientConnector hc> (int requestVolumeThreshold, int failurePercentageThreshold,
+                                                    int sleepWindowMillis) {
+    action post (string path, message m) (message) {
+        requestCount = requestCount + 1;
+        int eligibility = checkEligibility(requestVolumeThreshold, failurePercentageThreshold, sleepWindowMillis);
+        message response;
+        if (eligibility == 0) {
+            try {
+                response = hc.post(path, m);
+            } catch (errors:Error e) {
+                errorCount = errorCount + 1;
+                lastErrorTime = time:currentTime();
+                message errorMsg = {};
+                messages:setStringPayload(errorMsg, e.msg);
+                http:setStatusCode(errorMsg, 500);
+                return errorMsg;
+            }
+        } else if (eligibility == 1) {
+            try {
+                response = hc.post(path, m);
+            } catch (errors:Error e) {
+                errorCount = 0;
+                lastErrorTime = time:currentTime();
+                circuitState = 2;
+                message errorMsg = {};
+                messages:setStringPayload(errorMsg, e.msg);
+                http:setStatusCode(errorMsg, 500);
+                return errorMsg;
+            }
+        } else {
+            message errorMsg = {};
+            time:Time currentT = time:currentTime();
+            int timeDifference = currentT.time - lastErrorTime.time;
+            int remainingTime = sleepWindowMillis - timeDifference;
+            messages:setStringPayload(errorMsg, "Back end system is suspended due to errors. Next invocation is in " +
+                                                remainingTime + " milliseconds");
+            http:setStatusCode(errorMsg, 500);
+            return errorMsg;
+        }
+
+        return response;
+    }
+
+    action head (string path, message m) (message) {
+        requestCount = requestCount + 1;
+        int eligibility = checkEligibility(requestVolumeThreshold, failurePercentageThreshold, sleepWindowMillis);
+        message response;
+        if (eligibility == 0) {
+            try {
+                response = hc.head(path, m);
+            } catch (errors:Error e) {
+                errorCount = errorCount + 1;
+                lastErrorTime = time:currentTime();
+                message errorMsg = {};
+                messages:setStringPayload(errorMsg, e.msg);
+                http:setStatusCode(errorMsg, 500);
+                return errorMsg;
+            }
+        } else if (eligibility == 1) {
+            try {
+                response = hc.head(path, m);
+            } catch (errors:Error e) {
+                errorCount = 0;
+                lastErrorTime = time:currentTime();
+                circuitState = 2;
+                message errorMsg = {};
+                messages:setStringPayload(errorMsg, e.msg);
+                http:setStatusCode(errorMsg, 500);
+                return errorMsg;
+            }
+        } else {
+            message errorMsg = {};
+            time:Time currentT = time:currentTime();
+            int timeDifference = currentT.time - lastErrorTime.time;
+            int remainingTime = sleepWindowMillis - timeDifference;
+            messages:setStringPayload(errorMsg, "Back end system is suspended due to errors. Next invocation is in " +
+                                                remainingTime + " milliseconds");
+            http:setStatusCode(errorMsg, 500);
+            return errorMsg;
+        }
+
+        return response;
+    }
+
+    action put (string path, message m) (message){
+        requestCount = requestCount + 1;
+        int eligibility = checkEligibility(requestVolumeThreshold, failurePercentageThreshold, sleepWindowMillis);
+        message response;
+        if (eligibility == 0) {
+            try {
+                response = hc.put(path, m);
+            } catch (errors:Error e) {
+                errorCount = errorCount + 1;
+                lastErrorTime = time:currentTime();
+                message errorMsg = {};
+                messages:setStringPayload(errorMsg, e.msg);
+                http:setStatusCode(errorMsg, 500);
+                return errorMsg;
+            }
+        } else if (eligibility == 1) {
+            try {
+                response = hc.put(path, m);
+            } catch (errors:Error e) {
+                errorCount = 0;
+                lastErrorTime = time:currentTime();
+                circuitState = 2;
+                message errorMsg = {};
+                messages:setStringPayload(errorMsg, e.msg);
+                http:setStatusCode(errorMsg, 500);
+                return errorMsg;
+            }
+        } else {
+            message errorMsg = {};
+            time:Time currentT = time:currentTime();
+            int timeDifference = currentT.time - lastErrorTime.time;
+            int remainingTime = sleepWindowMillis - timeDifference;
+            messages:setStringPayload(errorMsg, "Back end system is suspended due to errors. Next invocation is in " +
+                                                remainingTime + " milliseconds");
+            http:setStatusCode(errorMsg, 500);
+            return errorMsg;
+        }
+
+        return response;
+    }
+
+    action execute (string httpVerb, string path, message m) (message){
+        requestCount = requestCount + 1;
+        int eligibility = checkEligibility(requestVolumeThreshold, failurePercentageThreshold, sleepWindowMillis);
+        message response;
+        if (eligibility == 0) {
+            try {
+                response = hc.execute(httpVerb, path, m);
+            } catch (errors:Error e) {
+                errorCount = errorCount + 1;
+                lastErrorTime = time:currentTime();
+                message errorMsg = {};
+                messages:setStringPayload(errorMsg, e.msg);
+                http:setStatusCode(errorMsg, 500);
+                return errorMsg;
+            }
+        } else if (eligibility == 1) {
+            try {
+                response = hc.execute(httpVerb, path, m);
+            } catch (errors:Error e) {
+                errorCount = 0;
+                lastErrorTime = time:currentTime();
+                circuitState = 2;
+                message errorMsg = {};
+                messages:setStringPayload(errorMsg, e.msg);
+                http:setStatusCode(errorMsg, 500);
+                return errorMsg;
+            }
+        } else {
+            message errorMsg = {};
+            time:Time currentT = time:currentTime();
+            int timeDifference = currentT.time - lastErrorTime.time;
+            int remainingTime = sleepWindowMillis - timeDifference;
+            messages:setStringPayload(errorMsg, "Back end system is suspended due to errors. Next invocation is in " +
+                                                remainingTime + " milliseconds");
+            http:setStatusCode(errorMsg, 500);
+            return errorMsg;
+        }
+
+        return response;
+    }
+
+    action patch (string path, message m) (message){
+        requestCount = requestCount + 1;
+        int eligibility = checkEligibility(requestVolumeThreshold, failurePercentageThreshold, sleepWindowMillis);
+        message response;
+        if (eligibility == 0) {
+            try {
+                response = hc.patch(path, m);
+            } catch (errors:Error e) {
+                errorCount = errorCount + 1;
+                lastErrorTime = time:currentTime();
+                message errorMsg = {};
+                messages:setStringPayload(errorMsg, e.msg);
+                http:setStatusCode(errorMsg, 500);
+                return errorMsg;
+            }
+        } else if (eligibility == 1) {
+            try {
+                response = hc.patch(path, m);
+            } catch (errors:Error e) {
+                errorCount = 0;
+                lastErrorTime = time:currentTime();
+                circuitState = 2;
+                message errorMsg = {};
+                messages:setStringPayload(errorMsg, e.msg);
+                http:setStatusCode(errorMsg, 500);
+                return errorMsg;
+            }
+        } else {
+            message errorMsg = {};
+            time:Time currentT = time:currentTime();
+            int timeDifference = currentT.time - lastErrorTime.time;
+            int remainingTime = sleepWindowMillis - timeDifference;
+            messages:setStringPayload(errorMsg, "Back end system is suspended due to errors. Next invocation is in " +
+                                                remainingTime + " milliseconds");
+            http:setStatusCode(errorMsg, 500);
+            return errorMsg;
+        }
+
+        return response;
+    }
+
+    action delete (string path, message m) (message){
+        requestCount = requestCount + 1;
+        int eligibility = checkEligibility(requestVolumeThreshold, failurePercentageThreshold, sleepWindowMillis);
+        message response;
+        if (eligibility == 0) {
+            try {
+                response = hc.delete(path, m);
+            } catch (errors:Error e) {
+                errorCount = errorCount + 1;
+                lastErrorTime = time:currentTime();
+                message errorMsg = {};
+                messages:setStringPayload(errorMsg, e.msg);
+                http:setStatusCode(errorMsg, 500);
+                return errorMsg;
+            }
+        } else if (eligibility == 1) {
+            try {
+                response = hc.delete(path, m);
+            } catch (errors:Error e) {
+                errorCount = 0;
+                lastErrorTime = time:currentTime();
+                circuitState = 2;
+                message errorMsg = {};
+                messages:setStringPayload(errorMsg, e.msg);
+                http:setStatusCode(errorMsg, 500);
+                return errorMsg;
+            }
+        } else {
+            message errorMsg = {};
+            time:Time currentT = time:currentTime();
+            int timeDifference = currentT.time - lastErrorTime.time;
+            int remainingTime = sleepWindowMillis - timeDifference;
+            messages:setStringPayload(errorMsg, "Back end system is suspended due to errors. Next invocation is in " +
+                                                remainingTime + " milliseconds");
+            http:setStatusCode(errorMsg, 500);
+            return errorMsg;
+        }
+
+        return response;
+    }
+
+    action get (string path, message m) (message){
+        requestCount = requestCount + 1;
+        int eligibility = checkEligibility(requestVolumeThreshold, failurePercentageThreshold, sleepWindowMillis);
+        message response;
+        if (eligibility == 0) {
+            try {
+                response = hc.get(path, m);
+            } catch (errors:Error e) {
+                errorCount = errorCount + 1;
+                lastErrorTime = time:currentTime();
+                message errorMsg = {};
+                messages:setStringPayload(errorMsg, e.msg);
+                http:setStatusCode(errorMsg, 500);
+                return errorMsg;
+            }
+        } else if (eligibility == 1) {
+            try {
+                response = hc.get(path, m);
+            } catch (errors:Error e) {
+                errorCount = 0;
+                lastErrorTime = time:currentTime();
+                circuitState = 2;
+                message errorMsg = {};
+                messages:setStringPayload(errorMsg, e.msg);
+                http:setStatusCode(errorMsg, 500);
+                return errorMsg;
+            }
+        } else {
+            message errorMsg = {};
+            time:Time currentT = time:currentTime();
+            int timeDifference = currentT.time - lastErrorTime.time;
+            int remainingTime = sleepWindowMillis - timeDifference;
+            messages:setStringPayload(errorMsg, "Back end system is suspended due to errors. Next invocation is in " +
+                                                remainingTime + " milliseconds");
+            http:setStatusCode(errorMsg, 500);
+            return errorMsg;
+        }
+
+        return response;
+    }
+}
+
+function checkEligibility(int volumeThreshold, int failurePercentage, int sleepMillis)(int) {
+    if (circuitState == 2) {
+        time:Time currentT = time:currentTime();
+        int timeDifference = currentT.time - lastErrorTime.time;
+        if (timeDifference > sleepMillis) {
+            errorCount = 0;
+            requestCount = 0;
+            //lastErrorTime = time:currentTime();
+            circuitState = 1;
+            return circuitState;
+        }
+        return circuitState;
+    } else {
+        if (requestCount < volumeThreshold) {
+            return circuitState;
+        } else {
+            time:Time currentT = time:currentTime();
+            int timeDifference = currentT.time - lastErrorTime.time;
+            if (timeDifference > sleepMillis) {
+                errorCount = 0;
+                requestCount = 0;
+                lastErrorTime = time:currentTime();
+                circuitState = 1;
+                return circuitState;
+            } else {
+                float currentFailurePercentage = (errorCount / requestCount) * 100;
+                if (currentFailurePercentage < failurePercentage) {
+                    return circuitState;
+                } else {
+                    circuitState = 1;
+                    requestCount = 0;
+                    errorCount = 0;
+                    lastErrorTime = time:currentTime();
+                    return circuitState;
+                }
+            }
+
+        }
+    }
+
+}

--- a/modules/ballerina-native/src/main/ballerina/ballerina/resiliency/fo/connector.bal
+++ b/modules/ballerina-native/src/main/ballerina/ballerina/resiliency/fo/connector.bal
@@ -1,0 +1,252 @@
+package ballerina.resiliency.fo;
+
+import ballerina.net.http;
+import ballerina.lang.messages;
+import ballerina.lang.errors;
+
+connector ClientConnector(http:ClientConnector[] testConnectorArray) {
+    action post (string path, message m) (message) {
+        int arrayLength = lengthof (testConnectorArray);
+        int index = 0;
+        http:ClientConnector t1 = testConnectorArray[index];
+        message response;
+        int runningIndex = index;
+        int startingIndex = -1;
+        while (startingIndex != index) {
+            try {
+                startingIndex = runningIndex;
+                index = index + 1;
+                response = t1.post(path, m);
+            } catch (errors:Error e) {
+                if (arrayLength > index) {
+                    t1 = testConnectorArray[index];
+                } else {
+                    if (startingIndex > 0) {
+                        index = 0;
+                    } else {
+                        message errorMsg = {};
+                        messages:setStringPayload(errorMsg, "All the load balanced endpoints failed. Last error was " +
+                                                            e.msg);
+                        http:setStatusCode(errorMsg, 500);
+                        return errorMsg;
+                    }
+                }
+            }
+            if (response != null) {
+                break;
+            }
+        }
+
+        return response;
+    }
+
+    action head (string path, message m) (message) {
+        int arrayLength = lengthof (testConnectorArray);
+        int index = 0;
+        http:ClientConnector t1 = testConnectorArray[index];
+        message response;
+        int runningIndex = index;
+        int startingIndex = -1;
+        while (startingIndex != index) {
+            try {
+                startingIndex = runningIndex;
+                index = index + 1;
+                response = t1.head(path, m);
+            } catch (errors:Error e) {
+                if (arrayLength > index) {
+                    t1 = testConnectorArray[index];
+                } else {
+                    if (startingIndex > 0) {
+                        index = 0;
+                    } else {
+                        message errorMsg = {};
+                        messages:setStringPayload(errorMsg, "All the load balanced endpoints failed. Last error was " +
+                                                            e.msg);
+                        http:setStatusCode(errorMsg, 500);
+                        return errorMsg;
+                    }
+                }
+            }
+            if (response != null) {
+                break;
+            }
+        }
+
+        return response;
+    }
+
+    action put (string path, message m) (message){
+        int arrayLength = lengthof (testConnectorArray);
+        int index = 0;
+        http:ClientConnector t1 = testConnectorArray[index];
+        message response;
+        int runningIndex = index;
+        int startingIndex = -1;
+        while (startingIndex != index) {
+            try {
+                startingIndex = runningIndex;
+                index = index + 1;
+                response = t1.put(path, m);
+            } catch (errors:Error e) {
+                if (arrayLength > index) {
+                    t1 = testConnectorArray[index];
+                } else {
+                    if (startingIndex > 0) {
+                        index = 0;
+                    } else {
+                        message errorMsg = {};
+                        messages:setStringPayload(errorMsg, "All the load balanced endpoints failed. Last error was " +
+                                                            e.msg);
+                        http:setStatusCode(errorMsg, 500);
+                        return errorMsg;
+                    }
+                }
+            }
+            if (response != null) {
+                break;
+            }
+        }
+
+        return response;
+    }
+
+    action execute (string httpVerb, string path, message m) (message){
+        int arrayLength = lengthof (testConnectorArray);
+        int index = 0;
+        http:ClientConnector t1 = testConnectorArray[index];
+        message response;
+        int runningIndex = index;
+        int startingIndex = -1;
+        while (startingIndex != index) {
+            try {
+                startingIndex = runningIndex;
+                index = index + 1;
+                response = t1.execute(httpVerb, path, m);
+            } catch (errors:Error e) {
+                if (arrayLength > index) {
+                    t1 = testConnectorArray[index];
+                } else {
+                    if (startingIndex > 0) {
+                        index = 0;
+                    } else {
+                        message errorMsg = {};
+                        messages:setStringPayload(errorMsg, "All the load balanced endpoints failed. Last error was " +
+                                                            e.msg);
+                        http:setStatusCode(errorMsg, 500);
+                        return errorMsg;
+                    }
+                }
+            }
+            if (response != null) {
+                break;
+            }
+        }
+
+        return response;
+    }
+
+    action patch (string path, message m) (message){
+        int arrayLength = lengthof (testConnectorArray);
+        int index = 0;
+        http:ClientConnector t1 = testConnectorArray[index];
+        message response;
+        int runningIndex = index;
+        int startingIndex = -1;
+        while (startingIndex != index) {
+            try {
+                startingIndex = runningIndex;
+                index = index + 1;
+                response = t1.patch(path, m);
+            } catch (errors:Error e) {
+                if (arrayLength > index) {
+                    t1 = testConnectorArray[index];
+                } else {
+                    if (startingIndex > 0) {
+                        index = 0;
+                    } else {
+                        message errorMsg = {};
+                        messages:setStringPayload(errorMsg, "All the load balanced endpoints failed. Last error was " +
+                                                            e.msg);
+                        http:setStatusCode(errorMsg, 500);
+                        return errorMsg;
+                    }
+                }
+            }
+            if (response != null) {
+                break;
+            }
+        }
+
+        return response;
+    }
+
+    action delete (string path, message m) (message){
+        int arrayLength = lengthof (testConnectorArray);
+        int index = 0;
+        http:ClientConnector t1 = testConnectorArray[index];
+        message response;
+        int runningIndex = index;
+        int startingIndex = -1;
+        while (startingIndex != index) {
+            try {
+                startingIndex = runningIndex;
+                index = index + 1;
+                response = t1.delete(path, m);
+            } catch (errors:Error e) {
+                if (arrayLength > index) {
+                    t1 = testConnectorArray[index];
+                } else {
+                    if (startingIndex > 0) {
+                        index = 0;
+                    } else {
+                        message errorMsg = {};
+                        messages:setStringPayload(errorMsg, "All the load balanced endpoints failed. Last error was " +
+                                                            e.msg);
+                        http:setStatusCode(errorMsg, 500);
+                        return errorMsg;
+                    }
+                }
+            }
+            if (response != null) {
+                break;
+            }
+        }
+
+        return response;
+    }
+
+    action get (string path, message m) (message){
+        int arrayLength = lengthof (testConnectorArray);
+        int index = 0;
+        http:ClientConnector t1 = testConnectorArray[index];
+        message response;
+        int runningIndex = index;
+        int startingIndex = -1;
+        while (startingIndex != index) {
+            try {
+                startingIndex = runningIndex;
+                index = index + 1;
+                response = t1.get(path, m);
+            } catch (errors:Error e) {
+                if (arrayLength > index) {
+                    t1 = testConnectorArray[index];
+                } else {
+                    if (startingIndex > 0) {
+                        index = 0;
+                    } else {
+                        message errorMsg = {};
+                        messages:setStringPayload(errorMsg, "All the load balanced endpoints failed. Last error was " +
+                                                            e.msg);
+                        http:setStatusCode(errorMsg, 500);
+                        return errorMsg;
+                    }
+                }
+            }
+            if (response != null) {
+                break;
+            }
+        }
+
+        return response;
+    }
+}

--- a/modules/ballerina-native/src/main/ballerina/ballerina/resiliency/fo/connector.bal
+++ b/modules/ballerina-native/src/main/ballerina/ballerina/resiliency/fo/connector.bal
@@ -25,7 +25,7 @@ connector ClientConnector(http:ClientConnector[] testConnectorArray) {
                         index = 0;
                     } else {
                         message errorMsg = {};
-                        messages:setStringPayload(errorMsg, "All the load balanced endpoints failed. Last error was " +
+                        messages:setStringPayload(errorMsg, "All the failover endpoints failed. Last error was " +
                                                             e.msg);
                         http:setStatusCode(errorMsg, 500);
                         return errorMsg;

--- a/modules/ballerina-native/src/main/ballerina/ballerina/resiliency/lb/connector.bal
+++ b/modules/ballerina-native/src/main/ballerina/ballerina/resiliency/lb/connector.bal
@@ -1,0 +1,296 @@
+package ballerina.resiliency.lb;
+
+import ballerina.net.http;
+import ballerina.lang.messages;
+import ballerina.lang.errors;
+
+int count = 0;
+
+connector ClientConnector(http:ClientConnector[] testConnectorArray, string algorithm, boolean failover) {
+    action post (string path, message m) (message) {
+        int arrayLength = lengthof (testConnectorArray);
+        int index = count % arrayLength;
+        http:ClientConnector t1 = testConnectorArray[index];
+        count = count + 1;
+        message response;
+        int runningIndex = index;
+        int startingIndex = -1;
+
+        if (failover) {
+            while (startingIndex != index) {
+                try {
+                    startingIndex = runningIndex;
+                    index = index + 1;
+                    response = t1.post(path, m);
+                } catch (errors:Error e) {
+                    if (arrayLength > index) {
+                        t1 = testConnectorArray[index];
+                    } else {
+                        if (startingIndex > 0) {
+                            index = 0;
+                        } else {
+                            message errorMsg = {};
+                            messages:setStringPayload(errorMsg, "All the load balanced endpoints failed. Last error was " +
+                                                                e.msg);
+                            http:setStatusCode(errorMsg, 500);
+                            return errorMsg;
+                        }
+                    }
+                }
+                if (response != null) {
+                    break;
+                }
+            }
+        } else {
+            response = t1.post(path, m);
+        }
+
+        return response;
+    }
+
+    action head (string path, message m) (message) {
+        int arrayLength = lengthof (testConnectorArray);
+        int index = count % arrayLength;
+        http:ClientConnector t1 = testConnectorArray[index];
+        count = count + 1;
+        message response;
+        int runningIndex = index;
+        int startingIndex = -1;
+
+        if (failover) {
+            while (startingIndex != index) {
+                try {
+                    startingIndex = runningIndex;
+                    index = index + 1;
+                    response = t1.head(path, m);
+                } catch (errors:Error e) {
+                    if (arrayLength > index) {
+                        t1 = testConnectorArray[index];
+                    } else {
+                        if (startingIndex > 0) {
+                            index = 0;
+                        } else {
+                            message errorMsg = {};
+                            messages:setStringPayload(errorMsg, "All the load balanced endpoints failed. Last error was " +
+                                                                e.msg);
+                            http:setStatusCode(errorMsg, 500);
+                            return errorMsg;
+                        }
+                    }
+                }
+                if (response != null) {
+                    break;
+                }
+            }
+        } else {
+            response = t1.head(path, m);
+        }
+
+        return response;
+    }
+
+    action put (string path, message m) (message){
+        int arrayLength = lengthof (testConnectorArray);
+        int index = count % arrayLength;
+        http:ClientConnector t1 = testConnectorArray[index];
+        count = count + 1;
+        message response;
+        int runningIndex = index;
+        int startingIndex = -1;
+
+        if (failover) {
+            while (startingIndex != index) {
+                try {
+                    startingIndex = runningIndex;
+                    index = index + 1;
+                    response = t1.put(path, m);
+                } catch (errors:Error e) {
+                    if (arrayLength > index) {
+                        t1 = testConnectorArray[index];
+                    } else {
+                        if (startingIndex > 0) {
+                            index = 0;
+                        } else {
+                            message errorMsg = {};
+                            messages:setStringPayload(errorMsg, "All the load balanced endpoints failed. Last error was " +
+                                                                e.msg);
+                            http:setStatusCode(errorMsg, 500);
+                            return errorMsg;
+                        }
+                    }
+                }
+                if (response != null) {
+                    break;
+                }
+            }
+        } else {
+            response = t1.put(path, m);
+        }
+
+        return response;
+    }
+
+    action execute (string httpVerb, string path, message m) (message){
+        int arrayLength = lengthof (testConnectorArray);
+        int index = count % arrayLength;
+        http:ClientConnector t1 = testConnectorArray[index];
+        count = count + 1;
+        message response;
+        int runningIndex = index;
+        int startingIndex = -1;
+
+        if (failover) {
+            while (startingIndex != index) {
+                try {
+                    startingIndex = runningIndex;
+                    index = index + 1;
+                    response = t1.execute(httpVerb, path, m);
+                } catch (errors:Error e) {
+                    if (arrayLength > index) {
+                        t1 = testConnectorArray[index];
+                    } else {
+                        if (startingIndex > 0) {
+                            index = 0;
+                        } else {
+                            message errorMsg = {};
+                            messages:setStringPayload(errorMsg, "All the load balanced endpoints failed. Last error was " +
+                                                                e.msg);
+                            http:setStatusCode(errorMsg, 500);
+                            return errorMsg;
+                        }
+                    }
+                }
+                if (response != null) {
+                    break;
+                }
+            }
+        } else {
+            response = t1.execute(httpVerb, path, m);
+        }
+
+        return response;
+    }
+
+    action patch (string path, message m) (message){
+        int arrayLength = lengthof (testConnectorArray);
+        int index = count % arrayLength;
+        http:ClientConnector t1 = testConnectorArray[index];
+        count = count + 1;
+        message response;
+        int runningIndex = index;
+        int startingIndex = -1;
+
+        if (failover) {
+            while (startingIndex != index) {
+                try {
+                    startingIndex = runningIndex;
+                    index = index + 1;
+                    response = t1.patch(path, m);
+                } catch (errors:Error e) {
+                    if (arrayLength > index) {
+                        t1 = testConnectorArray[index];
+                    } else {
+                        if (startingIndex > 0) {
+                            index = 0;
+                        } else {
+                            message errorMsg = {};
+                            messages:setStringPayload(errorMsg, "All the load balanced endpoints failed. Last error was " +
+                                                                e.msg);
+                            http:setStatusCode(errorMsg, 500);
+                            return errorMsg;
+                        }
+                    }
+                }
+                if (response != null) {
+                    break;
+                }
+            }
+        } else {
+            response = t1.patch(path, m);
+        }
+
+        return response;
+    }
+
+    action delete (string path, message m) (message){
+        int arrayLength = lengthof (testConnectorArray);
+        int index = count % arrayLength;
+        http:ClientConnector t1 = testConnectorArray[index];
+        count = count + 1;
+        message response;
+        int runningIndex = index;
+        int startingIndex = -1;
+
+        if (failover) {
+            while (startingIndex != index) {
+                try {
+                    startingIndex = runningIndex;
+                    index = index + 1;
+                    response = t1.delete(path, m);
+                } catch (errors:Error e) {
+                    if (arrayLength > index) {
+                        t1 = testConnectorArray[index];
+                    } else {
+                        if (startingIndex > 0) {
+                            index = 0;
+                        } else {
+                            message errorMsg = {};
+                            messages:setStringPayload(errorMsg, "All the load balanced endpoints failed. Last error was " +
+                                                                e.msg);
+                            http:setStatusCode(errorMsg, 500);
+                            return errorMsg;
+                        }
+                    }
+                }
+                if (response != null) {
+                    break;
+                }
+            }
+        } else {
+            response = t1.delete(path, m);
+        }
+
+        return response;
+    }
+
+    action get (string path, message m) (message){
+        int arrayLength = lengthof (testConnectorArray);
+        int index = count % arrayLength;
+        http:ClientConnector t1 = testConnectorArray[index];
+        count = count + 1;
+        message response;
+        int runningIndex = index;
+        int startingIndex = -1;
+
+        if (failover) {
+            while (startingIndex != index) {
+                try {
+                    startingIndex = runningIndex;
+                    index = index + 1;
+                    response = t1.get(path, m);
+                } catch (errors:Error e) {
+                    if (arrayLength > index) {
+                        t1 = testConnectorArray[index];
+                    } else {
+                        if (startingIndex > 0) {
+                            index = 0;
+                        } else {
+                            message errorMsg = {};
+                            messages:setStringPayload(errorMsg, "All the load balanced endpoints failed. Last error was " +
+                                                                e.msg);
+                            http:setStatusCode(errorMsg, 500);
+                            return errorMsg;
+                        }
+                    }
+                }
+                if (response != null) {
+                    break;
+                }
+            }
+        } else {
+            response = t1.get(path, m);
+        }
+
+        return response;
+    }
+}

--- a/modules/ballerina-native/src/main/ballerina/ballerina/resiliency/rt/connector.bal
+++ b/modules/ballerina-native/src/main/ballerina/ballerina/resiliency/rt/connector.bal
@@ -5,14 +5,13 @@ import ballerina.lang.messages;
 import ballerina.lang.errors;
 import ballerina.lang.system;
 
-int errorCount = 1;
+int errorCount;
 
 connector ClientConnector<http:ClientConnector hc> (int maxRetryCount, int retryDuration) {
     action post (string path, message m) (message) {
         message response;
         string err;
         while (maxRetryCount > errorCount) {
-            system:println("Retry " + (errorCount+1));
             try {
                 response = hc.post(path, m);
             } catch (errors:Error e) {

--- a/modules/ballerina-native/src/main/ballerina/ballerina/resiliency/rt/connector.bal
+++ b/modules/ballerina-native/src/main/ballerina/ballerina/resiliency/rt/connector.bal
@@ -1,0 +1,206 @@
+package ballerina.resiliency.rt;
+
+import ballerina.net.http;
+import ballerina.lang.messages;
+import ballerina.lang.errors;
+import ballerina.lang.system;
+
+int errorCount = 1;
+
+connector ClientConnector<http:ClientConnector hc> (int maxRetryCount, int retryDuration) {
+    action post (string path, message m) (message) {
+        message response;
+        string err;
+        while (maxRetryCount > errorCount) {
+            system:println("Retry " + (errorCount+1));
+            try {
+                response = hc.post(path, m);
+            } catch (errors:Error e) {
+                err = e.msg;
+                errorCount = errorCount + 1;
+                if (errorCount == maxRetryCount) {
+                    break;
+                }
+            }
+            if (response != null) {
+                return response;
+            }
+            system:sleep(retryDuration);
+        }
+
+        message errorMsg = {};
+        messages:setStringPayload(errorMsg, "Retry failed after " +
+                                            maxRetryCount + " attempts with error: " + err);
+        http:setStatusCode(errorMsg, 500);
+        errorCount = 0;
+        return errorMsg;
+    }
+
+    action head (string path, message m) (message) {
+        message response;
+        string err;
+        while (maxRetryCount > errorCount) {
+            system:println("Retry " + (errorCount+1));
+            try {
+                response = hc.head(path, m);
+            } catch (errors:Error e) {
+                err = e.msg;
+                errorCount = errorCount + 1;
+                if (errorCount == maxRetryCount) {
+                    break;
+                }
+            }
+            if (response != null) {
+                return response;
+            }
+            system:sleep(retryDuration);
+        }
+
+        message errorMsg = {};
+        messages:setStringPayload(errorMsg, "Retry failed after " +
+                                            maxRetryCount + " attempts with error: " + err);
+        http:setStatusCode(errorMsg, 500);
+        errorCount = 0;
+        return errorMsg;
+    }
+
+    action put (string path, message m) (message){
+        message response;
+        string err;
+        while (maxRetryCount > errorCount) {
+            system:println("Retry " + (errorCount+1));
+            try {
+                response = hc.put(path, m);
+            } catch (errors:Error e) {
+                err = e.msg;
+                errorCount = errorCount + 1;
+                if (errorCount == maxRetryCount) {
+                    break;
+                }
+            }
+            if (response != null) {
+                return response;
+            }
+            system:sleep(retryDuration);
+        }
+
+        message errorMsg = {};
+        messages:setStringPayload(errorMsg, "Retry failed after " +
+                                            maxRetryCount + " attempts with error: " + err);
+        http:setStatusCode(errorMsg, 500);
+        errorCount = 0;
+        return errorMsg;
+    }
+
+    action execute (string httpVerb, string path, message m) (message){
+        message response;
+        string err;
+        while (maxRetryCount > errorCount) {
+            system:println("Retry " + (errorCount+1));
+            try {
+                response = hc.execute(httpVerb, path, m);
+            } catch (errors:Error e) {
+                err = e.msg;
+                errorCount = errorCount + 1;
+                if (errorCount == maxRetryCount) {
+                    break;
+                }
+            }
+            if (response != null) {
+                return response;
+            }
+            system:sleep(retryDuration);
+        }
+
+        message errorMsg = {};
+        messages:setStringPayload(errorMsg, "Retry failed after " +
+                                            maxRetryCount + " attempts with error: " + err);
+        http:setStatusCode(errorMsg, 500);
+        errorCount = 0;
+        return errorMsg;
+    }
+
+    action patch (string path, message m) (message){
+        message response;
+        string err;
+        while (maxRetryCount > errorCount) {
+            system:println("Retry " + (errorCount+1));
+            try {
+                response = hc.patch(path, m);
+            } catch (errors:Error e) {
+                err = e.msg;
+                errorCount = errorCount + 1;
+                if (errorCount == maxRetryCount) {
+                    break;
+                }
+            }
+            if (response != null) {
+                return response;
+            }
+            system:sleep(retryDuration);
+        }
+
+        message errorMsg = {};
+        messages:setStringPayload(errorMsg, "Retry failed after " +
+                                            maxRetryCount + " attempts with error: " + err);
+        http:setStatusCode(errorMsg, 500);
+        errorCount = 0;
+        return errorMsg;
+    }
+
+    action delete (string path, message m) (message){
+        message response;
+        string err;
+        while (maxRetryCount > errorCount) {
+            system:println("Retry " + (errorCount+1));
+            try {
+                response = hc.delete(path, m);
+            } catch (errors:Error e) {
+                err = e.msg;
+                errorCount = errorCount + 1;
+                if (errorCount == maxRetryCount) {
+                    break;
+                }
+            }
+            if (response != null) {
+                return response;
+            }
+            system:sleep(retryDuration);
+        }
+
+        message errorMsg = {};
+        messages:setStringPayload(errorMsg, "Retry failed after " +
+                                            maxRetryCount + " attempts with error: " + err);
+        http:setStatusCode(errorMsg, 500);
+        errorCount = 0;
+        return errorMsg;
+    }
+
+    action get (string path, message m) (message){
+        message response;
+        string err;
+        while (maxRetryCount > errorCount) {
+            system:println("Retry " + (errorCount+1));
+            try {
+                response = hc.get(path, m);
+            } catch (errors:Error e) {
+                err = e.msg;
+                errorCount = errorCount + 1;
+                if (errorCount == maxRetryCount) {
+                    break;
+                }
+            }
+            if (response != null) {
+                return response;
+            }
+            system:sleep(retryDuration);
+        }
+
+        message errorMsg = {};
+        messages:setStringPayload(errorMsg, "Retry failed after " +
+                                            maxRetryCount + " attempts with error: " + err);
+        http:setStatusCode(errorMsg, 500);
+        errorCount = 0;
+        return errorMsg;
+    }
+}


### PR DESCRIPTION
This PR adds the support for following ballerina resiliency features which are written as filter connectors in ballerina.

- Circuit Breaker
- Retry
- Fail over
- Load balance

All these filter connectors can be applied on top of HTTP connector. Given below are few examples.

### Circuit Breaker example
```
import ballerina.net.http;
import ballerina.lang.system;
import ballerina.resiliency.cb;


@http:configuration {basePath:"/passthrough"}
service<http> passthrough {

    @http:resourceConfig {
        methods:["POST"],
        path:"/test"
    }
    resource passthrough (message m) {
        http:ClientConnector nyseEP1 = create http:ClientConnector("http://localhost:8284/services/RespondProxy") with cb:ClientConnector(10, 50, 30000);
        system:println("Within main resource");
        message response = nyseEP1.post("/", m);
        reply response;
    }

}
```

### Retry example
```
import ballerina.net.http;
import ballerina.lang.system;
import ballerina.resiliency.rt;


@http:configuration {basePath:"/passthrough"}
service<http> passthrough {

    @http:resourceConfig {
        methods:["POST"],
        path:"/test"
    }
    resource passthrough (message m) {
        http:ClientConnector nyseEP1 = create http:ClientConnector("http://localhost:8280/services/RespondProxy") with rt:ClientConnector(3, 10000);
        system:println("Within main resource");
        message response = nyseEP1.post("/", m);
        reply response;
    }

}
```

### Failover example
```
import ballerina.net.http;
import ballerina.lang.messages;
import ballerina.lang.system;
import ballerina.resiliency.fo;

@http:configuration {basePath:"/passthrough"}
service<http> passthrough {

    @http:resourceConfig {
        methods:["POST"],
        path:"/test"
    }
    resource passthrough (message m) {
        http:ClientConnector nyseEP1 = create http:ClientConnector("http://localhost:8286/services/RespondProxy33");
        http:ClientConnector nyseEP2 = create http:ClientConnector("http://localhost:8283/services/RespondProxy");
        http:ClientConnector nyseEP3 = create http:ClientConnector("http://localhost:8280/services/RespondProxy");
        http:ClientConnector[] tArray = [nyseEP1, nyseEP2, nyseEP3];
        fo:ClientConnector testFO = create fo:ClientConnector(tArray);
        json j = {"name":"chanaka"};
        message request = {};
        messages:setJsonPayload(request, j);
        message value1;
        message value2;
        value1 = testFO.post("/", m);
        system:println(value1);
        reply value1;
    }
}
```
### Load Balance example
```
import ballerina.net.http;
import ballerina.lang.messages;
import ballerina.lang.system;
import ballerina.resiliency.lb;

@http:configuration {basePath:"/passthrough"}
service<http> passthrough {

    @http:resourceConfig {
        methods:["POST"],
        path:"/test"
    }
    resource passthrough (message m) {
        http:ClientConnector nyseEP1 = create http:ClientConnector("http://localhost:8286/services/RespondProxy33");
        http:ClientConnector nyseEP2 = create http:ClientConnector("http://localhost:8280/services/RespondProxy");
        http:ClientConnector nyseEP3 = create http:ClientConnector("http://localhost:8285/services/RespondProxy44");
        http:ClientConnector[] tArray = [nyseEP1, nyseEP2, nyseEP3];
        lb:ClientConnector testLB = create lb:ClientConnector(tArray, "RoundRobin", false);
        json j = {"name":"chanaka"};
        message request = {};
        messages:setJsonPayload(request, j);
        message value1;
        message value2;
        value1 = testLB.post("/", m);
        system:println(value1);
        reply value1;
    }
}
```