### PR TITLE
Replace quote with double quotes

### DIFF
--- a/samples/ballerina-by-example/examples/datatables/datatables.description
+++ b/samples/ballerina-by-example/examples/datatables/datatables.description
@@ -14,9 +14,8 @@
 //    updated timestamp
 //);
 //
-//insert into employees values(1, 'John', 1050.50, false,
-//'1990-12-31', '11:30:45', '2007-05-23 09:15:28');
+//insert into employees values(1, "John", 1050.50, false,
+//"1990-12-31", "11:30:45", "2007-05-23 09:15:28");
 //
-//insert into employees values(2, 'Anne', 4060.50, true, '1999-12-31',
-//'13:40:24', '2017-05-23 09:15:28');
-
+//insert into employees values(2, "Anne", 4060.50, true,
+// "1999-12-31", "13:40:24", "2017-05-23 09:15:28");


### PR DESCRIPTION
This is to avoid the issue of single quotes being replaced with backtick when the doc gen tool is run