### PR TITLE
Improvements for SQLConnector 

### DIFF
--- a/modules/ballerina-core/src/main/java/org/ballerinalang/bre/BallerinaTransactionManager.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/bre/BallerinaTransactionManager.java
@@ -98,6 +98,8 @@ public class BallerinaTransactionManager {
         if (transactionLevel == 1) {
             rollbackNonXAConnections();
             rollbackXATransaction();
+            closeAllConnections();
+            transactionContextStore.clear();
         }
     }
 

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BLangVM.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BLangVM.java
@@ -2524,7 +2524,7 @@ public class BLangVM {
             } else if (status == -1) { //Transaction failed
                 ballerinaTransactionManager.setTransactionError(true);
                 ballerinaTransactionManager.rollbackTransactionBlock();
-            } else { //status = 1 Transaction aborted
+            } else { //status = 1 Transaction end
                 ballerinaTransactionManager.endTransactionBlock();
                 if (ballerinaTransactionManager.isOuterTransaction()) {
                     context.setBallerinaTransactionManager(null);

--- a/modules/ballerina-native/src/main/ballerina/ballerina/data/sql/natives.bal
+++ b/modules/ballerina-native/src/main/ballerina/ballerina/data/sql/natives.bal
@@ -25,6 +25,7 @@ struct Parameter {
 @doc:Field {value:"isolateInternalQueries: Determines whether HikariCP isolates internal pool queries, such as the connection alive test, in their own transaction"}
 @doc:Field {value:"allowPoolSuspension: Whether the pool can be suspended and resumed through JMX"}
 @doc:Field {value:"readOnly:  Whether Connections obtained from the pool are in read-only mode by default"}
+@doc:Field {value:"isXA:  Whether Connections are used for a distributed transaction"}
 @doc:Field {value:"maximumPoolSize: Maximum size that the pool is allowed to reach, including both idle and in-use connections"}
 @doc:Field {value:"connectionTimeout: Maximum number of milliseconds that a client will wait for a connection from the pool"}
 @doc:Field {value:"idleTimeout: Maximum amount of time that a connection is allowed to sit idle in the pool"}
@@ -46,6 +47,7 @@ struct ConnectionProperties {
 	boolean isolateInternalQueries;
 	boolean allowPoolSuspension;
 	boolean readOnly;
+	boolean isXA;
 	int maximumPoolSize = -1;
 	int connectionTimeout = -1;
 	int idleTimeout = -1;

--- a/modules/ballerina-native/src/main/ballerina/ballerina/data/sql/natives.bal
+++ b/modules/ballerina-native/src/main/ballerina/ballerina/data/sql/natives.bal
@@ -6,12 +6,10 @@ import ballerina.doc;
 @doc:Field {value:"sqlType : The data type of the corresponding SQL parameter"}
 @doc:Field {value:"value: Value of paramter pass into the SQL query"}
 @doc:Field {value:"direction: Direction of the SQL Parameter 0 - IN, 1- OUT, 2 - INOUT"}
-@doc:Field {value:"structuredType: Underline SQL type to be used for parameter of SQL array type or custom structure type to be used with struct type"}
 struct Parameter {
 	string sqlType;
 	any value;
 	int direction;
-	string structuredType;
 }
 
 @doc:Description { value: "ConnectionProperties structs represents the properties which are used to configure DB connection pool"}

--- a/modules/ballerina-native/src/main/ballerina/ballerina/data/sql/natives.bal
+++ b/modules/ballerina-native/src/main/ballerina/ballerina/data/sql/natives.bal
@@ -3,7 +3,7 @@ package ballerina.data.sql;
 import ballerina.doc;
 
 @doc:Description { value: "Parameter struct represents a query parameter for the SQL queries specified in connector actions"}
-@doc:Field {value:"sqlType : The data type of the corresponding SQL parameter"}
+@doc:Field {value:"sqlType: The data type of the corresponding SQL parameter"}
 @doc:Field {value:"value: Value of paramter pass into the SQL query"}
 @doc:Field {value:"direction: Direction of the SQL Parameter 0 - IN, 1- OUT, 2 - INOUT"}
 struct Parameter {

--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/Constants.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/Constants.java
@@ -78,6 +78,23 @@ public final class Constants {
     }
 
     /**
+     * XA Datasoruce for DB Types with first class support.
+     */
+    public static final class XADataSources {
+        public static final String MYSQL_5_XA_DATASOURCE = "com.mysql.jdbc.jdbc2.optional.MysqlXADataSource";
+        public static final String MYSQL_6_XA_DATASOURCE = "com.mysql.cj.jdbc.MysqlXADataSource";
+        public static final String SQLSERVER_XA_DATASOURCE = "com.microsoft.sqlserver.jdbc.SQLServerXADataSource";
+        public static final String ORACLE_XA_DATASOURCE  = "oracle.jdbc.xa.client.OracleXADataSource";
+        public static final String SYBASE_XA_DATASOURCE  = "com.sybase.jdbc3.jdbc.SybXADataSource";
+        public static final String POSTGRE_XA_DATASOURCE  = "org.postgresql.xa.PGXADataSource";
+        public static final String IBMDB2_XA_DATASOURCE  = "com.ibm.db2.jdbc.DB2XADataSource";
+        public static final String HSQLDB_XA_DATASOURCE  = "org.hsqldb.jdbc.pool.JDBCXADataSource";
+        public static final String H2_XA_DATASOURCE = "org.h2.jdbcx.JdbcDataSource";
+        public static final String DERBY_SERVER_XA_DATASOURCE = "org.apache.derby.jdbc.ClientXADataSource";
+        public static final String DERBY_FILE_XA_DATASOURCE = "org.apache.derby.jdbc.EmbeddedXADataSource";
+    }
+
+    /**
      * Constants default DB ports.
      */
     public static final class DefaultPort {
@@ -109,4 +126,6 @@ public final class Constants {
     public static final String STRUCT_TIME = "Time";
     public static final String STRUCT_TIME_PACKAGE = "ballerina.lang.time";
     public static final String URL = "url";
+    public static final String USER = "user";
+    public static final String PASSWORD = "password";
 }

--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/Constants.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/Constants.java
@@ -105,4 +105,5 @@ public final class Constants {
     public static final String CONNECTOR_NAME = "ClientConnector";
     public static final String DATASOURCE_KEY = "datasource_key";
     public static final String TIMEZONE_UTC = "UTC";
+    public static final String QUESTION_MARK = "?";
 }

--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/Constants.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/Constants.java
@@ -108,4 +108,5 @@ public final class Constants {
     public static final String QUESTION_MARK = "?";
     public static final String STRUCT_TIME = "Time";
     public static final String STRUCT_TIME_PACKAGE = "ballerina.lang.time";
+    public static final String URL = "url";
 }

--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/Constants.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/Constants.java
@@ -106,4 +106,6 @@ public final class Constants {
     public static final String DATASOURCE_KEY = "datasource_key";
     public static final String TIMEZONE_UTC = "UTC";
     public static final String QUESTION_MARK = "?";
+    public static final String STRUCT_TIME = "Time";
+    public static final String STRUCT_TIME_PACKAGE = "ballerina.lang.time";
 }

--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/SQLDatasource.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/SQLDatasource.java
@@ -24,6 +24,7 @@ import org.ballerinalang.model.values.BBoolean;
 import org.ballerinalang.model.values.BFloat;
 import org.ballerinalang.model.values.BInteger;
 import org.ballerinalang.model.values.BMap;
+import org.ballerinalang.model.values.BRefType;
 import org.ballerinalang.model.values.BString;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.model.values.BValue;
@@ -104,98 +105,105 @@ public class SQLDatasource implements BValue {
             String username, String password) {
         try {
             HikariConfig config = new HikariConfig();
-            if (!username.isEmpty()) {
-                config.setUsername(username);
-            }
-            if (!password.isEmpty()) {
-                config.setPassword(password);
-            }
-            String jdbcurl = options.getStringField(0);
-            String dataSourceClassName = options.getStringField(1);
-            if (!dataSourceClassName.isEmpty()) {
-                config.setDataSourceClassName(dataSourceClassName);
-            } else {
-                if (jdbcurl.isEmpty()) {
-                    jdbcurl = constructJDBCURL(dbType, hostOrPath, port, dbName, username, password);
-                }
-                if (!jdbcurl.isEmpty()) {
-                    config.setJdbcUrl(jdbcurl);
+            config.setUsername(username);
+            config.setPassword(password);
+            if (options != null) {
+                BMap dataSourceConfigMap = (BMap) options.getRefField(0);
+                String jdbcurl = options.getStringField(0);
+                String dataSourceClassName = options.getStringField(1);
+                if (!dataSourceClassName.isEmpty()) {
+                    config.setDataSourceClassName(dataSourceClassName);
+                    if (dataSourceConfigMap != null) {
+                        if (dataSourceConfigMap.get(Constants.URL) == null) {
+                            if (jdbcurl.isEmpty()) {
+                                jdbcurl = constructJDBCURL(dbType, hostOrPath, port, dbName, username, password);
+                            }
+                            dataSourceConfigMap.put(Constants.URL, new BString(jdbcurl));
+                        }
+                    } else {
+                        dataSourceConfigMap = new BMap<String, BRefType>();
+                        if (jdbcurl.isEmpty()) {
+                            jdbcurl = constructJDBCURL(dbType, hostOrPath, port, dbName, username, password);
+                        }
+                        dataSourceConfigMap.put(Constants.URL, new BString(jdbcurl));
+                    }
                 } else {
-                    throw new BallerinaException("invalid database connection properties for db " + dbType);
+                    if (jdbcurl.isEmpty()) {
+                        jdbcurl = constructJDBCURL(dbType, hostOrPath, port, dbName, username, password);
+                    }
+                    config.setJdbcUrl(jdbcurl);
                 }
-            }
-            String connectionTestQuery = options.getStringField(2);
-            if (!connectionTestQuery.isEmpty()) {
-                config.setConnectionTestQuery(connectionTestQuery);
-            }
-            String poolName = options.getStringField(3);
-            if (!poolName.isEmpty()) {
-                config.setPoolName(poolName);
-            }
-            String catalog = options.getStringField(4);
-            if (!catalog.isEmpty()) {
-                config.setCatalog(catalog);
-            }
-            String connectionInitSQL = options.getStringField(5);
-            if (!connectionInitSQL.isEmpty()) {
-                config.setConnectionInitSql(connectionInitSQL);
-            }
-            String driverClassName = options.getStringField(6);
-            if (!driverClassName.isEmpty()) {
-                config.setDriverClassName(driverClassName);
-            }
-            String transactionIsolation = options.getStringField(7);
-            if (!transactionIsolation.isEmpty()) {
-                config.setTransactionIsolation(transactionIsolation);
-            }
-            int maximumPoolSize = (int) options.getIntField(0);
-            if (maximumPoolSize != -1) {
-                config.setMaximumPoolSize(maximumPoolSize);
-            }
-            long connectionTimeout = options.getIntField(1);
-            if (connectionTimeout != -1) {
-                config.setConnectionTimeout(connectionTimeout);
-            }
-            long idleTimeout = options.getIntField(2);
-            if (idleTimeout != -1) {
-                config.setIdleTimeout(idleTimeout);
-            }
-            int minimumIdle = (int) options.getIntField(3);
-            if (minimumIdle != -1) {
-                config.setMinimumIdle(minimumIdle);
-            }
-            long maxLifetime = options.getIntField(4);
-            if (maxLifetime != -1) {
-                config.setMaxLifetime(maxLifetime);
-            }
-            long validationTimeout = options.getIntField(5);
-            if (validationTimeout != -1) {
-                config.setValidationTimeout(validationTimeout);
-            }
-            long leakDetectionThreshold = options.getIntField(6);
-            if (leakDetectionThreshold != -1) {
-                config.setLeakDetectionThreshold(leakDetectionThreshold);
-            }
-            boolean autoCommit = options.getBooleanField(0) != 0;
-            config.setAutoCommit(autoCommit);
-            boolean isolateInternalQueries = options.getBooleanField(1) != 0;
-            config.setIsolateInternalQueries(isolateInternalQueries);
-            boolean allowPoolSuspension = options.getBooleanField(2) != 0;
-            config.setAllowPoolSuspension(allowPoolSuspension);
-            boolean readOnly = options.getBooleanField(3) != 0;
-            config.setReadOnly(readOnly);
-            BMap mapSourceConfigs = (BMap) options.getRefField(0);
-            if (mapSourceConfigs != null) {
-                setDataSourceProperties(mapSourceConfigs, config);
+                String connectionTestQuery = options.getStringField(2);
+                if (!connectionTestQuery.isEmpty()) {
+                    config.setConnectionTestQuery(connectionTestQuery);
+                }
+                String poolName = options.getStringField(3);
+                if (!poolName.isEmpty()) {
+                    config.setPoolName(poolName);
+                }
+                String catalog = options.getStringField(4);
+                if (!catalog.isEmpty()) {
+                    config.setCatalog(catalog);
+                }
+                String connectionInitSQL = options.getStringField(5);
+                if (!connectionInitSQL.isEmpty()) {
+                    config.setConnectionInitSql(connectionInitSQL);
+                }
+                String driverClassName = options.getStringField(6);
+                if (!driverClassName.isEmpty()) {
+                    config.setDriverClassName(driverClassName);
+                }
+                String transactionIsolation = options.getStringField(7);
+                if (!transactionIsolation.isEmpty()) {
+                    config.setTransactionIsolation(transactionIsolation);
+                }
+                int maximumPoolSize = (int) options.getIntField(0);
+                if (maximumPoolSize != -1) {
+                    config.setMaximumPoolSize(maximumPoolSize);
+                }
+                long connectionTimeout = options.getIntField(1);
+                if (connectionTimeout != -1) {
+                    config.setConnectionTimeout(connectionTimeout);
+                }
+                long idleTimeout = options.getIntField(2);
+                if (idleTimeout != -1) {
+                    config.setIdleTimeout(idleTimeout);
+                }
+                int minimumIdle = (int) options.getIntField(3);
+                if (minimumIdle != -1) {
+                    config.setMinimumIdle(minimumIdle);
+                }
+                long maxLifetime = options.getIntField(4);
+                if (maxLifetime != -1) {
+                    config.setMaxLifetime(maxLifetime);
+                }
+                long validationTimeout = options.getIntField(5);
+                if (validationTimeout != -1) {
+                    config.setValidationTimeout(validationTimeout);
+                }
+                long leakDetectionThreshold = options.getIntField(6);
+                if (leakDetectionThreshold != -1) {
+                    config.setLeakDetectionThreshold(leakDetectionThreshold);
+                }
+                boolean autoCommit = options.getBooleanField(0) != 0;
+                config.setAutoCommit(autoCommit);
+                boolean isolateInternalQueries = options.getBooleanField(1) != 0;
+                config.setIsolateInternalQueries(isolateInternalQueries);
+                boolean allowPoolSuspension = options.getBooleanField(2) != 0;
+                config.setAllowPoolSuspension(allowPoolSuspension);
+                boolean readOnly = options.getBooleanField(3) != 0;
+                config.setReadOnly(readOnly);
+                if (dataSourceConfigMap != null) {
+                    setDataSourceProperties(dataSourceConfigMap, config);
+                }
+            } else {
+                String jdbcurl = constructJDBCURL(dbType, hostOrPath, port, dbName, username, password);
+                config.setJdbcUrl(jdbcurl);
             }
             hikariDataSource = new HikariDataSource(config);
         } catch (Throwable t) {
             String errorMessage = "error in sql connector configuration";
-            if (t.getCause() != null) {
-                throw new BallerinaException(errorMessage + ": " + t.getCause().getMessage());
-            } else {
-                throw new BallerinaException(errorMessage);
-            }
+            throw new BallerinaException(errorMessage + ": " + t.getMessage());
         }
     }
 
@@ -272,7 +280,7 @@ public class SQLDatasource implements BValue {
             jdbcUrl.append("jdbc:derby:").append(hostOrPath).append(File.separator).append(dbName);
             break;
         default:
-            jdbcUrl.append("");
+            throw new BallerinaException("unknown database type : " + dbType);
         }
         return jdbcUrl.toString();
     }

--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/SQLTransactionContext.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/SQLTransactionContext.java
@@ -41,6 +41,10 @@ public class SQLTransactionContext implements BallerinaTransactionContext {
         return this.conn;
     }
 
+    public void updateConnection (Connection conn) {
+        this.conn = conn;
+    }
+
     @Override
     public void commit() {
         try {

--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/client/AbstractSQLAction.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/client/AbstractSQLAction.java
@@ -231,7 +231,7 @@ public abstract class AbstractSQLAction extends AbstractNativeAction {
             BValue value = paramValue.getRefField(0);
             String sqlType = paramValue.getStringField(0);
             if (value != null && value.getType().getTag() == TypeTags.ARRAY_TAG && !Constants.SQLDataTypes.ARRAY
-                    .equals(sqlType)) {
+                    .equalsIgnoreCase(sqlType)) {
                 count = (int) ((BNewArray) value).size();
             } else {
                 count = 1;
@@ -403,7 +403,7 @@ public abstract class AbstractSQLAction extends AbstractNativeAction {
             int direction = (int) paramStruct.getIntField(0);
             String structuredSQLType = paramStruct.getStringField(1);
             if (value != null && value.getType().getTag() == TypeTags.ARRAY_TAG && !Constants.SQLDataTypes.ARRAY
-                    .equals(sqlType)) {
+                    .equalsIgnoreCase(sqlType)) {
                 int arrayLength = (int) ((BNewArray) value).size();
                 int typeTag = ((BArrayType) value.getType()).getElementType().getTag();
                 for (int i = 0; i < arrayLength; i++) {

--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/client/AbstractSQLAction.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/client/AbstractSQLAction.java
@@ -109,7 +109,7 @@ public abstract class AbstractSQLAction extends AbstractNativeAction {
             BDataTable dataTable = new BDataTable(new SQLDataIterator(conn, stmt, rs, utcCalendar),
                     getColumnDefinitions(rs));
             context.getControlStackNew().getCurrentFrame().returnValues[0] = dataTable;
-        } catch (SQLException e) {
+        } catch (Throwable e) {
             SQLDatasourceUtils.cleanupConnection(rs, stmt, conn, isInTransaction);
             throw new BallerinaException("execute query failed: " + e.getMessage(), e);
         }
@@ -193,7 +193,7 @@ public abstract class AbstractSQLAction extends AbstractNativeAction {
             } else {
                 SQLDatasourceUtils.cleanupConnection(null, stmt, conn, isInTransaction);
             }
-        } catch (SQLException e) {
+        } catch (Throwable e) {
             SQLDatasourceUtils.cleanupConnection(rs, stmt, conn, isInTransaction);
             throw new BallerinaException("execute stored procedure failed: " + e.getMessage(), e);
         }

--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/client/AbstractSQLAction.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/client/AbstractSQLAction.java
@@ -401,7 +401,6 @@ public abstract class AbstractSQLAction extends AbstractNativeAction {
             String sqlType = paramStruct.getStringField(0);
             BValue value = paramStruct.getRefField(0);
             int direction = (int) paramStruct.getIntField(0);
-            String structuredSQLType = paramStruct.getStringField(1);
             if (value != null && value.getType().getTag() == TypeTags.ARRAY_TAG && !Constants.SQLDataTypes.ARRAY
                     .equalsIgnoreCase(sqlType)) {
                 int arrayLength = (int) ((BNewArray) value).size();
@@ -427,18 +426,18 @@ public abstract class AbstractSQLAction extends AbstractNativeAction {
                     default:
                         throw new BallerinaException("unsupported array type for parameter index " + index);
                     }
-                    setParameter(conn, stmt, sqlType, paramValue, direction, currentOrdinal, structuredSQLType);
+                    setParameter(conn, stmt, sqlType, paramValue, direction, currentOrdinal);
                     currentOrdinal++;
                 }
             } else {
-                setParameter(conn, stmt, sqlType, value, direction, currentOrdinal, structuredSQLType);
+                setParameter(conn, stmt, sqlType, value, direction, currentOrdinal);
                 currentOrdinal++;
             }
         }
     }
 
     private void setParameter(Connection conn, PreparedStatement stmt, String sqlType, BValue value, int direction,
-            int index, String structuredSQLType) {
+            int index) {
         if (sqlType == null || sqlType.isEmpty()) {
             SQLDatasourceUtils.setStringValue(stmt, value, index, direction, Types.VARCHAR);
         } else {
@@ -518,11 +517,11 @@ public abstract class AbstractSQLAction extends AbstractNativeAction {
                 SQLDatasourceUtils.setNClobValue(stmt, value, index, direction, Types.NCLOB);
                 break;
             case Constants.SQLDataTypes.ARRAY:
-                SQLDatasourceUtils.setArrayValue(conn, stmt, value, index, direction, Types.ARRAY, structuredSQLType);
+                SQLDatasourceUtils.setArrayValue(conn, stmt, value, index, direction, Types.ARRAY);
                 break;
             case Constants.SQLDataTypes.STRUCT:
                 SQLDatasourceUtils
-                        .setUserDefinedValue(conn, stmt, value, index, direction, Types.STRUCT, structuredSQLType);
+                        .setUserDefinedValue(conn, stmt, value, index, direction, Types.STRUCT);
                 break;
             default:
                 throw new BallerinaException("unsupported datatype as parameter: " + sqlType + " index:" + index);

--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/client/AbstractSQLAction.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/client/AbstractSQLAction.java
@@ -220,6 +220,10 @@ public abstract class AbstractSQLAction extends AbstractNativeAction {
         }
     }
 
+    /**
+     * If there are any arrays of parameter for types other than sql array, the given query is expanded by adding "?" s
+     * to .match with the array size.
+     */
     private String createProcessedQueryString(String query, BRefValueArray parameters) {
         String currentQuery = query;
         int start = 0;
@@ -244,9 +248,7 @@ public abstract class AbstractSQLAction extends AbstractNativeAction {
     }
 
     /**
-     * Given the starting position, this method searches for the first occurrence
-     * of "?" and replace it with `count` "?"'s. Returns [0] - end position of
-     * "?"'s, [1] - modified query.
+     * Search for the first occurrence of "?" from the given starting point and replace it with given number of "?"'s.
      */
     private Object[] expandQuery(int start, int count, String query) {
         StringBuilder result = new StringBuilder();

--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/client/SQLDatasourceUtils.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/client/SQLDatasourceUtils.java
@@ -631,7 +631,7 @@ public class SQLDatasourceUtils {
     }
 
     public static void setArrayValue(Connection conn, PreparedStatement stmt, BValue value, int index, int direction,
-            int sqlType, String structuredSQLType1) {
+            int sqlType) {
         Object[] arrayData = getArrayData(value);
         Object[] arrayValue = (Object[]) arrayData[0];
         String structuredSQLType = (String) arrayData[1];
@@ -710,7 +710,7 @@ public class SQLDatasourceUtils {
     }
 
     public static void setUserDefinedValue(Connection conn, PreparedStatement stmt, BValue value, int index,
-            int direction, int sqlType, String structuredSQLType1) {
+            int direction, int sqlType) {
         Object[] structData = getStructData(value);
         Object[] dataArray = (Object[]) structData[0];
         String structuredSQLType = (String) structData[1];

--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/client/SQLDatasourceUtils.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/client/SQLDatasourceUtils.java
@@ -293,7 +293,7 @@ public class SQLDatasourceUtils {
                 throw new BallerinaException("invalid direction for the parameter with index: " + index);
             }
         } catch (SQLException e) {
-            throw new BallerinaException("error in set TinyInt value to statement: " + e.getMessage(), e);
+            throw new BallerinaException("error in set tinyint value to statement: " + e.getMessage(), e);
         }
     }
 
@@ -329,7 +329,7 @@ public class SQLDatasourceUtils {
                 throw new BallerinaException("Invalid direction for the parameter, index: " + index);
             }
         } catch (SQLException e) {
-            throw new BallerinaException("Error in set Small Int value to statement." + e.getMessage(), e);
+            throw new BallerinaException("error in set smallint value to statement." + e.getMessage(), e);
         }
     }
 
@@ -365,7 +365,7 @@ public class SQLDatasourceUtils {
                 throw new BallerinaException("invalid direction for the parameter with index: " + index);
             }
         } catch (SQLException e) {
-            throw new BallerinaException("error in set Big Int value to statement: " + e.getMessage(), e);
+            throw new BallerinaException("error in set bigint value to statement: " + e.getMessage(), e);
         }
     }
 
@@ -398,20 +398,25 @@ public class SQLDatasourceUtils {
             } else if (Constants.QueryParamDirection.OUT == direction) {
                 ((CallableStatement) stmt).registerOutParameter(index + 1, sqlType);
             } else {
-                throw new BallerinaException("Invalid direction for the parameter, index: " + index);
+                throw new BallerinaException("invalid direction for the parameter, index: " + index);
             }
         } catch (SQLException e) {
-            throw new BallerinaException("Error in set float value to statement." + e.getMessage(), e);
+            throw new BallerinaException("error in set float value to statement." + e.getMessage(), e);
         }
     }
 
     public static void setDateValue(PreparedStatement stmt, BValue value, int index, int direction, int sqlType) {
         Date val = null;
         if (value != null) {
-            if (value instanceof BInteger) {
+            if (value instanceof BStruct && value.getType().getName().equals(Constants.STRUCT_TIME) && value
+                    .getType().getPackagePath().equals(Constants.STRUCT_TIME_PACKAGE)) {
+                val = new Date(((BStruct) value).getIntField(0));
+            } else if (value instanceof BInteger) {
                 val = new Date(((BInteger) value).intValue());
             } else if (value instanceof BString) {
                 val = SQLDatasourceUtils.convertToDate(value.stringValue());
+            } else {
+                throw new BallerinaException("invalid input type for date parameter with index: " + index);
             }
         }
         try {
@@ -442,10 +447,15 @@ public class SQLDatasourceUtils {
             Calendar utcCalendar) {
         Timestamp val = null;
         if (value != null) {
-            if (value instanceof BInteger) {
+            if (value instanceof BStruct && value.getType().getName().equals(Constants.STRUCT_TIME) && value
+                    .getType().getPackagePath().equals(Constants.STRUCT_TIME_PACKAGE)) {
+                val = new Timestamp(((BStruct) value).getIntField(0));
+            } else if (value instanceof BInteger) {
                 val = new Timestamp(((BInteger) value).intValue());
             } else if (value instanceof BString) {
                 val = SQLDatasourceUtils.convertToTimeStamp(value.stringValue());
+            } else {
+                throw new BallerinaException("invalid input type for timestamp parameter with index: " + index);
             }
         }
         try {
@@ -468,7 +478,7 @@ public class SQLDatasourceUtils {
                 throw new BallerinaException("invalid direction for the parameter, index: " + index);
             }
         } catch (SQLException e) {
-            throw new BallerinaException("error in set Timestamp value to statement: " + e.getMessage(), e);
+            throw new BallerinaException("error in set timestamp value to statement: " + e.getMessage(), e);
         }
     }
 
@@ -476,7 +486,10 @@ public class SQLDatasourceUtils {
             Calendar utcCalendar) {
         Time val = null;
         if (value != null) {
-            if (value instanceof BInteger) {
+            if (value instanceof BStruct && value.getType().getName().equals(Constants.STRUCT_TIME) && value
+                    .getType().getPackagePath().equals(Constants.STRUCT_TIME_PACKAGE)) {
+                val = new Time(((BStruct) value).getIntField(0));
+            } else if (value instanceof BInteger) {
                 val = new Time(((BInteger) value).intValue());
             } else if (value instanceof BString) {
                 val = SQLDatasourceUtils.convertToTime(value.stringValue());
@@ -502,7 +515,7 @@ public class SQLDatasourceUtils {
                 throw new BallerinaException("invalid direction for the parameter with index: " + index);
             }
         } catch (SQLException e) {
-            throw new BallerinaException("error in set Timestamp value to statement: " + e.getMessage(), e);
+            throw new BallerinaException("error in set timestamp value to statement: " + e.getMessage(), e);
         }
     }
 
@@ -876,7 +889,7 @@ public class SQLDatasourceUtils {
             }
             return sb.toString();
         } catch (IOException | SQLException e) {
-            throw new BallerinaException("error occurred while reading CLOB value: " + e.getMessage(), e);
+            throw new BallerinaException("error occurred while reading clob value: " + e.getMessage(), e);
         }
     }
 
@@ -900,7 +913,7 @@ public class SQLDatasourceUtils {
                     new String(data.getBytes(1L, (int) data.length()), Charset.defaultCharset()));
             return new String(encode, Charset.defaultCharset());
         } catch (SQLException e) {
-            throw new BallerinaException("error occurred while reading BLOB value", e);
+            throw new BallerinaException("error occurred while reading blob value", e);
         }
     }
 

--- a/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/client/SQLDatasourceUtils.java
+++ b/modules/ballerina-native/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/client/SQLDatasourceUtils.java
@@ -674,6 +674,14 @@ public class SQLDatasourceUtils {
         }
     }
 
+    public static void setNullObject(PreparedStatement stmt, int index) {
+        try {
+            stmt.setObject(index + 1, null);
+        } catch (SQLException e) {
+            throw new BallerinaException("error in set null to parameter with index: " + index);
+        }
+    }
+
     private static Object[] getArrayData(BValue value) {
         if (value == null || value.getType().getTag() != TypeTags.ARRAY_TAG) {
             return new Object[] { null, null };

--- a/modules/ballerina-native/src/test/java/org/ballerinalang/nativeimpl/actions/SQLActionsTest.java
+++ b/modules/ballerina-native/src/test/java/org/ballerinalang/nativeimpl/actions/SQLActionsTest.java
@@ -221,6 +221,13 @@ public class SQLActionsTest {
     }
 
     @Test(groups = "ConnectorTest")
+    public void testNullINParameterValues() {
+        BValue[] returns = BLangFunctions.invokeNew(bLangProgram, "testNullINParameterValues");
+        BInteger retValue = (BInteger) returns[0];
+        Assert.assertEquals(retValue.intValue(), 1);
+    }
+
+    @Test(groups = "ConnectorTest")
     public void testNullINParameters() {
         BValue[] returns = BLangFunctions.invokeNew(bLangProgram, "testNullINParameters");
         BInteger retValue = (BInteger) returns[0];

--- a/modules/ballerina-native/src/test/java/org/ballerinalang/nativeimpl/actions/SQLActionsTest.java
+++ b/modules/ballerina-native/src/test/java/org/ballerinalang/nativeimpl/actions/SQLActionsTest.java
@@ -159,6 +159,14 @@ public class SQLActionsTest {
     }
 
     @Test(groups = "ConnectorTest")
+    public void testArrayofQueryParameters() {
+        BValue[] returns = BLangFunctions.invokeNew(bLangProgram, "testArrayofQueryParameters");
+        BString retValue = (BString) returns[0];
+        final String expected = "Peter";
+        Assert.assertEquals(retValue.stringValue(), expected);
+    }
+
+    @Test(groups = "ConnectorTest")
     public void testInsertTableDataWithParameters() {
         BValue[] returns = BLangFunctions.invokeNew(bLangProgram, "testInsertTableDataWithParameters");
         BInteger retValue = (BInteger) returns[0];
@@ -278,15 +286,15 @@ public class SQLActionsTest {
 
         Assert.assertTrue(returns[2] instanceof BMap);
         BMap<BString, BInteger> longArray = (BMap) returns[2];
-        Assert.assertEquals(longArray.get(new BString("0")).intValue(), 10000000);
-        Assert.assertEquals(longArray.get(new BString("1")).intValue(), 20000000);
-        Assert.assertEquals(longArray.get(new BString("2")).intValue(), 30000000);
+        Assert.assertEquals(longArray.get(new BString("0")).intValue(), 1503383034226L);
+        Assert.assertEquals(longArray.get(new BString("1")).intValue(), 1503383034224L);
+        Assert.assertEquals(longArray.get(new BString("2")).intValue(), 1503383034225L);
 
         Assert.assertTrue(returns[3] instanceof BMap);
         BMap<BString, BFloat> doubleArray = (BMap) returns[3];
-        Assert.assertEquals(doubleArray.get(new BString("0")).floatValue(), 245.23);
-        Assert.assertEquals(doubleArray.get(new BString("1")).floatValue(), 5559.49);
-        Assert.assertEquals(doubleArray.get(new BString("2")).floatValue(), 8796.123);
+        Assert.assertEquals(doubleArray.get(new BString("0")).floatValue(), 1503383034226.23D);
+        Assert.assertEquals(doubleArray.get(new BString("1")).floatValue(), 1503383034224.43D);
+        Assert.assertEquals(doubleArray.get(new BString("2")).floatValue(), 1503383034225.123D);
 
         Assert.assertTrue(returns[4] instanceof BMap);
         BMap<BString, BString> stringArray = (BMap) returns[4];
@@ -344,6 +352,7 @@ public class SQLActionsTest {
         BIntArray retValue = (BIntArray) returns[0];
         Assert.assertEquals((int) retValue.get(0), 1);
         Assert.assertEquals((int) retValue.get(1), 1);
+        Assert.assertEquals((int) retValue.get(2), 1);
     }
 
     @Test(dependsOnGroups = "ConnectorTest")
@@ -390,6 +399,14 @@ public class SQLActionsTest {
           expectedExceptionsMessageRegExp = ".*error in sql connector configuration.*")
     public void testInvalidDBType() {
         BLangFunctions.invokeNew(bLangProgram, "testInvalidDBType");
+    }
+
+    @Test(groups = "ConnectorTest")
+    public void testStructOutParameters() {
+        BValue[] returns = BLangFunctions.invokeNew(bLangProgram, "testStructOutParameters");
+        BString retValue = (BString) returns[0];
+        String expected = "10";
+        Assert.assertEquals(retValue.stringValue(), expected);
     }
 
     @AfterSuite

--- a/modules/ballerina-native/src/test/java/org/ballerinalang/nativeimpl/actions/SQLActionsTest.java
+++ b/modules/ballerina-native/src/test/java/org/ballerinalang/nativeimpl/actions/SQLActionsTest.java
@@ -37,7 +37,7 @@ import java.io.File;
 import java.util.Calendar;
 
 /**
- * Test class for SQL Connector test.
+ * Test class for SQL Connector actions test.
  *
  * @since 0.8.0
  */
@@ -48,7 +48,7 @@ public class SQLActionsTest {
 
     @BeforeClass()
     public void setup() {
-        bLangProgram = BTestUtils.getProgramFile("samples/sqlConnectorTest.bal");
+        bLangProgram = BTestUtils.getProgramFile("samples/sql-actions-test.bal");
         SQLDBUtils.deleteFiles(new File(SQLDBUtils.DB_DIRECTORY), DB_NAME);
         SQLDBUtils.initDatabase(SQLDBUtils.DB_DIRECTORY, DB_NAME, "datafiles/SQLConnectorDataFile.sql");
     }
@@ -129,22 +129,6 @@ public class SQLActionsTest {
     @Test(groups = "ConnectorTest")
     public void testCallProcedureWithResultSet() {
         BValue[] returns = BLangFunctions.invokeNew(bLangProgram, "testCallProcedureWithResultSet");
-        BString retValue = (BString) returns[0];
-        final String expected = "Peter";
-        Assert.assertEquals(retValue.stringValue(), expected);
-    }
-
-    @Test(groups = "ConnectorTest")
-    public void testConnectorWithDataSource() {
-        BValue[] returns = BLangFunctions.invokeNew(bLangProgram, "testConnectorWithDataSource");
-        BString retValue = (BString) returns[0];
-        final String expected = "Peter";
-        Assert.assertEquals(retValue.stringValue(), expected);
-    }
-
-    @Test(groups = "ConnectorTest")
-    public void testConnectionPoolProperties() {
-        BValue[] returns = BLangFunctions.invokeNew(bLangProgram, "testConnectionPoolProperties");
         BString retValue = (BString) returns[0];
         final String expected = "Peter";
         Assert.assertEquals(retValue.stringValue(), expected);
@@ -400,12 +384,6 @@ public class SQLActionsTest {
         BValue[] returns = BLangFunctions.invokeNew(bLangProgram, "testDateTimeOutParams", args);
         Assert.assertEquals(returns.length, 1);
         Assert.assertEquals(((BInteger) returns[0]).intValue(), 1);
-    }
-
-    @Test(expectedExceptions = RuntimeException.class,
-          expectedExceptionsMessageRegExp = ".*error in sql connector configuration.*")
-    public void testInvalidDBType() {
-        BLangFunctions.invokeNew(bLangProgram, "testInvalidDBType");
     }
 
     @Test(groups = "ConnectorTest")

--- a/modules/ballerina-native/src/test/java/org/ballerinalang/nativeimpl/actions/SQLConnectorInitTest.java
+++ b/modules/ballerina-native/src/test/java/org/ballerinalang/nativeimpl/actions/SQLConnectorInitTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.ballerinalang.nativeimpl.actions;
+
+
+import org.ballerinalang.model.values.BString;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.nativeimpl.util.BTestUtils;
+import org.ballerinalang.nativeimpl.util.SQLDBUtils;
+import org.ballerinalang.util.codegen.ProgramFile;
+import org.ballerinalang.util.program.BLangFunctions;
+import org.testng.Assert;
+import org.testng.annotations.AfterSuite;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+
+/**
+ * Test class for SQL Connector init tests.
+ *
+ * @since 0.94
+ */
+public class SQLConnectorInitTest {
+    private ProgramFile bLangProgram;
+    private static final String DB_NAME = "TEST_SQL_CONNECTOR";
+
+    @BeforeClass()
+    public void setup() {
+        bLangProgram = BTestUtils.getProgramFile("samples/sql-connector-init-test.bal");
+        SQLDBUtils.deleteFiles(new File(SQLDBUtils.DB_DIRECTORY), DB_NAME);
+        SQLDBUtils.initDatabase(SQLDBUtils.DB_DIRECTORY, DB_NAME, "datafiles/SQLConnectorDataFile.sql");
+    }
+
+    @Test(groups = "ConnectorTest")
+    public void testConnectorWithDefaultPropertiesForListedDB() {
+        BValue[] returns = BLangFunctions.invokeNew(bLangProgram, "testConnectorWithDefaultPropertiesForListedDB");
+        BString retValue = (BString) returns[0];
+        final String expected = "Peter";
+        Assert.assertEquals(retValue.stringValue(), expected);
+    }
+
+    @Test(groups = "ConnectorTest")
+    public void testConnectorWithDirectUrl() {
+        BValue[] returns = BLangFunctions.invokeNew(bLangProgram, "testConnectorWithDirectUrl");
+        BString retValue = (BString) returns[0];
+        final String expected = "Peter";
+        Assert.assertEquals(retValue.stringValue(), expected);
+    }
+
+    @Test(groups = "ConnectorTest")
+    public void testConnectorWithDataSourceClass() {
+        BValue[] returns = BLangFunctions.invokeNew(bLangProgram, "testConnectorWithDataSourceClass");
+        BString retValue = (BString) returns[0];
+        final String expected = "Peter";
+        Assert.assertEquals(retValue.stringValue(), expected);
+    }
+
+    @Test(groups = "ConnectorTest")
+    public void testConnectorWithDataSourceClassWithoutURL() {
+        BValue[] returns = BLangFunctions.invokeNew(bLangProgram, "testConnectorWithDataSourceClassWithoutURL");
+        BString retValue = (BString) returns[0];
+        final String expected = "Peter";
+        Assert.assertEquals(retValue.stringValue(), expected);
+    }
+
+    @Test(groups = "ConnectorTest")
+    public void testConnectorWithDataSourceClassURLPriority() {
+        BValue[] returns = BLangFunctions.invokeNew(bLangProgram, "testConnectorWithDataSourceClassURLPriority");
+        BString retValue = (BString) returns[0];
+        final String expected = "Peter";
+        Assert.assertEquals(retValue.stringValue(), expected);
+    }
+
+    @Test(groups = "ConnectorTest")
+    public void testConnectionPoolProperties() {
+        BValue[] returns = BLangFunctions.invokeNew(bLangProgram, "testConnectionPoolProperties");
+        BString retValue = (BString) returns[0];
+        final String expected = "Peter";
+        Assert.assertEquals(retValue.stringValue(), expected);
+    }
+
+    @Test(expectedExceptions = RuntimeException.class,
+        expectedExceptionsMessageRegExp = ".*error in sql connector configuration: unknown database type : TESTDB.*")
+    public void testInvalidDBType() {
+        BLangFunctions.invokeNew(bLangProgram, "testInvalidDBType");
+    }
+
+    @AfterSuite
+    public void cleanup() {
+        SQLDBUtils.deleteDirectory(new File(SQLDBUtils.DB_DIRECTORY));
+    }
+}

--- a/modules/ballerina-native/src/test/java/org/ballerinalang/nativeimpl/actions/SQLConnectorInitTest.java
+++ b/modules/ballerina-native/src/test/java/org/ballerinalang/nativeimpl/actions/SQLConnectorInitTest.java
@@ -96,7 +96,8 @@ public class SQLConnectorInitTest {
     }
 
     @Test(expectedExceptions = RuntimeException.class,
-        expectedExceptionsMessageRegExp = ".*error in sql connector configuration: unknown database type : TESTDB.*")
+        expectedExceptionsMessageRegExp =
+                ".*error in sql connector configuration: cannot generate url for unknown database type : TESTDB.*")
     public void testInvalidDBType() {
         BLangFunctions.invokeNew(bLangProgram, "testInvalidDBType");
     }

--- a/modules/ballerina-native/src/test/java/org/ballerinalang/nativeimpl/actions/SQLTransactionTest.java
+++ b/modules/ballerina-native/src/test/java/org/ballerinalang/nativeimpl/actions/SQLTransactionTest.java
@@ -37,7 +37,6 @@ import java.io.File;
  * @since 0.92
  */
 public class SQLTransactionTest {
-    private static final double DELTA = 0.01;
     private ProgramFile bLangProgram;
     private static final String DB_NAME = "TEST_SQL_CONNECTOR";
 

--- a/modules/ballerina-native/src/test/resources/datafiles/SQLConnectorDataFile.sql
+++ b/modules/ballerina-native/src/test/resources/datafiles/SQLConnectorDataFile.sql
@@ -169,3 +169,23 @@ CREATE PROCEDURE TestArrayINOutParams (IN id INT, OUT insertedCount INTEGER, INO
   SELECT string_array INTO varcharArray FROM ArrayTypes where row_id = 1;
   END
 /
+CREATE TYPE customtype AS INTEGER;
+/
+CREATE TABLE structdatatable(id INTEGER, structdata customtype);
+/
+INSERT INTO structdatatable(id,structdata) VALUES (1,10);
+/
+CREATE PROCEDURE TestStructOut (OUT var customtype)
+  READS SQL DATA
+  BEGIN ATOMIC
+  SELECT structdata INTO var from structdatatable where id = 1;
+  END
+/
+CREATE PROCEDURE TestStructInOut (OUT countVal INTEGER, INOUT var customtype)
+  MODIFIES SQL DATA
+  BEGIN ATOMIC
+  INSERT INTO structdatatable(id,structdata) VALUES (2,var);
+  select count(*) into countVal from structdatatable where id = 2;
+ SELECT structdata INTO var from structdatatable where id = 1;
+  END
+/

--- a/modules/ballerina-native/src/test/resources/samples/sql-actions-test.bal
+++ b/modules/ballerina-native/src/test/resources/samples/sql-actions-test.bal
@@ -3,10 +3,6 @@ import ballerina.data.sql;
 import ballerina.lang.errors;
 import ballerina.lang.time;
 
-struct ResultCustomers {
-    string FIRSTNAME;
-}
-
 struct ResultDataType {
     int INT_TYPE;
     int LONG_TYPE;
@@ -16,6 +12,10 @@ struct ResultDataType {
 
 struct ResultCount {
     int COUNTVAL;
+}
+
+struct ResultCustomers {
+    string FIRSTNAME;
 }
 
 struct ResultArrayType {
@@ -152,50 +152,6 @@ function testCallProcedureWithResultSet () (string firstName) {
 
     sql:Parameter[] parameters = [];
     datatable dt = testDB.call ("{call SelectPersonData()}", parameters);
-    errors:TypeCastError err;
-    ResultCustomers rs;
-    while (datatables:hasNext(dt)) {
-        any dataStruct = datatables:next(dt);
-        rs, err = (ResultCustomers) dataStruct;
-        firstName = rs.FIRSTNAME;
-    }
-    testDB.close ();
-    return;
-}
-
-function testConnectorWithDataSource () (string firstName) {
-    map propertiesMap = {"user":"SA", "password":"", "loginTimeout":0,
-                        "url":"jdbc:hsqldb:file:./target/tempdb/TEST_SQL_CONNECTOR"};
-    sql:ConnectionProperties properties = {dataSourceClassName:"org.hsqldb.jdbc.JDBCDataSource",
-                                              datasourceProperties:propertiesMap};
-    sql:ClientConnector testDB = create sql:ClientConnector(sql:HSQLDB_FILE, "", 0, "", "", "", properties);
-
-    sql:Parameter[] parameters = [];
-    datatable dt = testDB.select ("SELECT  FirstName from Customers where registrationID = 1", parameters);
-    errors:TypeCastError err;
-    ResultCustomers rs;
-    while (datatables:hasNext(dt)) {
-        any dataStruct = datatables:next(dt);
-        rs, err = (ResultCustomers) dataStruct;
-        firstName = rs.FIRSTNAME;
-    }
-    testDB.close ();
-    return;
-}
-
-function testConnectionPoolProperties () (string firstName) {
-    sql:ConnectionProperties properties = {url:"jdbc:hsqldb:file:./target/tempdb/TEST_SQL_CONNECTOR",
-                          driverClassName:"org.hsqldb.jdbcDriver", maximumPoolSize:1,
-                          idleTimeout:600000, connectionTimeout:30000, autoCommit:true, maxLifetime:1800000,
-                          minimumIdle:1, poolName:"testHSQLPool", isolateInternalQueries:false,
-                          allowPoolSuspension:false, readOnly:false, validationTimeout:5000, leakDetectionThreshold:0,
-                          connectionInitSql:"SELECT 1 FROM INFORMATION_SCHEMA.SYSTEM_USERS",
-                          transactionIsolation:"TRANSACTION_READ_COMMITTED", catalog:"PUBLIC",
-                          connectionTestQuery:"SELECT 1 FROM INFORMATION_SCHEMA.SYSTEM_USERS"};
-    sql:ClientConnector testDB = create sql:ClientConnector(sql:HSQLDB_FILE, "", 0, "", "SA", "", properties);
-
-    sql:Parameter[] parameters = [];
-    datatable dt = testDB.select ("SELECT  FirstName from Customers where registrationID = 1", parameters);
     errors:TypeCastError err;
     ResultCustomers rs;
     while (datatables:hasNext(dt)) {
@@ -602,10 +558,6 @@ function testBatchUpdate () (int[]) {
     return updateCount;
 }
 
-struct Time {
-    string s;
-}
-
 function testDateTimeInParameters () (int[]) {
     sql:ConnectionProperties properties = {maximumPoolSize:1};
     sql:ClientConnector testDB = create sql:ClientConnector(sql:HSQLDB_FILE, "./target/tempdb/", 0,
@@ -678,17 +630,6 @@ function testDateTimeOutParams (int time, int date, int timestamp) (int count) {
         count = rs.COUNTVAL;
     }
     testDB.close();
-    return;
-}
-
-function testInvalidDBType () {
-    sql:ConnectionProperties properties = {maximumPoolSize:1};
-    sql:ClientConnector testDB = create sql:ClientConnector("TESTDB", "./target/tempdb/", 0, "TEST_SQL_CONNECTOR", "SA",
-                                                            "", properties);
-
-    sql:Parameter[] parameters = [];
-    testDB.update ("Insert into Customers(firstName) values ('James')",parameters);
-    testDB.close ();
     return;
 }
 

--- a/modules/ballerina-native/src/test/resources/samples/sql-actions-test.bal
+++ b/modules/ballerina-native/src/test/resources/samples/sql-actions-test.bal
@@ -31,9 +31,8 @@ function testInsertTableData () (int) {
     sql:ConnectionProperties properties = {maximumPoolSize:1};
     sql:ClientConnector testDB = create sql:ClientConnector(sql:HSQLDB_FILE, "./target/tempdb/", 0, "TEST_SQL_CONNECTOR", "SA", "", properties);
 
-    sql:Parameter[] parameters = [];
     int insertCount = testDB.update ("Insert into Customers (firstName,lastName,registrationID,creditLimit,country)
-                                     values ('James', 'Clerk', 2, 5000.75, 'USA')", parameters);
+                                     values ('James', 'Clerk', 2, 5000.75, 'USA')", null);
     testDB.close ();
     return insertCount;
 }
@@ -42,9 +41,8 @@ function testCreateTable () (int) {
     sql:ConnectionProperties properties = {maximumPoolSize:1};
     sql:ClientConnector testDB = create sql:ClientConnector(sql:HSQLDB_FILE, "./target/tempdb/", 0, "TEST_SQL_CONNECTOR", "SA", "", properties);
 
-    sql:Parameter[] parameters = [];
     int returnValue = testDB.update ("CREATE TABLE IF NOT EXISTS Students(studentID int, LastName varchar(255))",
-                                     parameters);
+                                     null);
     testDB.close ();
     return returnValue;
 }
@@ -65,11 +63,9 @@ function testGeneratedKeyOnInsert () (string) {
 
     int insertCount;
     string[] generatedID;
-    sql:Parameter[] parameters = [];
-    string[] keyColumns = [];
     insertCount, generatedID = testDB.updateWithGeneratedKeys ("insert into Customers (firstName,lastName,
                              registrationID,creditLimit,country) values ('Mary', 'Williams', 3, 5000.75, 'USA')",
-                             parameters, keyColumns);
+                             null, null);
     testDB.close ();
     return generatedID[0];
 }
@@ -82,10 +78,9 @@ function testGeneratedKeyWithColumn () (string) {
     string[] generatedID;
     string[] keyColumns;
     keyColumns = ["CUSTOMERID"];
-    sql:Parameter[] parameters = [];
     insertCount, generatedID = testDB.updateWithGeneratedKeys ("insert into Customers (firstName,lastName,
                                registrationID,creditLimit,country) values ('Kathy', 'Williams', 4, 5000.75, 'USA')",
-                               parameters, keyColumns);
+                               null, keyColumns);
     testDB.close ();
     return generatedID[0];
 }
@@ -94,8 +89,7 @@ function testSelectData () (string firstName) {
     sql:ConnectionProperties properties = {maximumPoolSize:1};
     sql:ClientConnector testDB = create sql:ClientConnector(sql:HSQLDB_FILE, "./target/tempdb/", 0, "TEST_SQL_CONNECTOR", "SA", "", properties);
 
-    sql:Parameter[] parameters = [];
-    datatable dt = testDB.select ("SELECT  FirstName from Customers where registrationID = 1", parameters);
+    datatable dt = testDB.select ("SELECT  FirstName from Customers where registrationID = 1", null);
     errors:TypeCastError err;
     ResultCustomers rs;
     while (datatables:hasNext(dt)) {
@@ -132,9 +126,8 @@ function testCallProcedure () (string firstName) {
     sql:ConnectionProperties properties = {maximumPoolSize:1};
     sql:ClientConnector testDB = create sql:ClientConnector(sql:HSQLDB_FILE, "./target/tempdb/", 0, "TEST_SQL_CONNECTOR", "SA", "", properties);
 
-    sql:Parameter[] parameters = [];
-    testDB.call ("{call InsertPersonData(100,'James')}", parameters);
-    datatable dt = testDB.select ("SELECT  FirstName from Customers where registrationID = 100", parameters);
+    testDB.call ("{call InsertPersonData(100,'James')}", null);
+    datatable dt = testDB.select ("SELECT  FirstName from Customers where registrationID = 100", null);
     errors:TypeCastError err;
     ResultCustomers rs;
     while (datatables:hasNext(dt)) {

--- a/modules/ballerina-native/src/test/resources/samples/sql-connector-init-test.bal
+++ b/modules/ballerina-native/src/test/resources/samples/sql-connector-init-test.bal
@@ -1,0 +1,134 @@
+import ballerina.data.sql;
+import ballerina.lang.errors;
+import ballerina.lang.datatables;
+
+struct ResultCustomers {
+    string FIRSTNAME;
+}
+
+
+function testConnectorWithDefaultPropertiesForListedDB () (string firstName) {
+    sql:ClientConnector testDB = create sql:ClientConnector(sql:HSQLDB_FILE, "./target/tempdb/", 0,
+                                                            "TEST_SQL_CONNECTOR", "SA", "", null);
+
+    sql:Parameter[] parameters = [];
+    datatable dt = testDB.select ("SELECT  FirstName from Customers where registrationID = 1", parameters);
+    errors:TypeCastError err;
+    ResultCustomers rs;
+    while (datatables:hasNext(dt)) {
+        any dataStruct = datatables:next(dt);
+        rs, err = (ResultCustomers) dataStruct;
+        firstName = rs.FIRSTNAME;
+    }
+    testDB.close ();
+    return;
+}
+
+function testConnectorWithDirectUrl () (string firstName) {
+    sql:ConnectionProperties Properties = {url:"jdbc:hsqldb:file:./target/tempdb/TEST_SQL_CONNECTOR"};
+    sql:ClientConnector testDB = create sql:ClientConnector("", "", 0, "", "SA", "", Properties);
+
+    sql:Parameter[] parameters = [];
+    datatable dt = testDB.select ("SELECT  FirstName from Customers where registrationID = 1", parameters);
+    errors:TypeCastError err;
+    ResultCustomers rs;
+    while (datatables:hasNext(dt)) {
+        any dataStruct = datatables:next(dt);
+        rs, err = (ResultCustomers) dataStruct;
+        firstName = rs.FIRSTNAME;
+    }
+    testDB.close ();
+    return;
+}
+
+function testConnectorWithDataSourceClass () (string firstName) {
+    map propertiesMap = {"loginTimeout":109, "url":"jdbc:hsqldb:file:./target/tempdb/TEST_SQL_CONNECTOR"};
+    sql:ConnectionProperties properties = {dataSourceClassName:"org.hsqldb.jdbc.JDBCDataSource",
+                                              datasourceProperties:propertiesMap};
+    sql:ClientConnector testDB = create sql:ClientConnector("", "", 0, "", "SA", "", properties);
+
+    sql:Parameter[] parameters = [];
+    datatable dt = testDB.select ("SELECT  FirstName from Customers where registrationID = 1", parameters);
+    errors:TypeCastError err;
+    ResultCustomers rs;
+    while (datatables:hasNext(dt)) {
+        any dataStruct = datatables:next(dt);
+        rs, err = (ResultCustomers) dataStruct;
+        firstName = rs.FIRSTNAME;
+    }
+    testDB.close ();
+    return;
+}
+
+function testConnectorWithDataSourceClassWithoutURL () (string firstName) {
+     sql:ConnectionProperties properties = {dataSourceClassName:"org.hsqldb.jdbc.JDBCDataSource"};
+     sql:ClientConnector testDB = create sql:ClientConnector(sql:HSQLDB_FILE, "./target/tempdb/", 0,
+                                                             "TEST_SQL_CONNECTOR", "SA", "", properties);
+
+     sql:Parameter[] parameters = [];
+     datatable dt = testDB.select ("SELECT  FirstName from Customers where registrationID = 1", parameters);
+     errors:TypeCastError err;
+     ResultCustomers rs;
+     while (datatables:hasNext(dt)) {
+         any dataStruct = datatables:next(dt);
+         rs, err = (ResultCustomers) dataStruct;
+         firstName = rs.FIRSTNAME;
+     }
+     testDB.close ();
+     return;
+ }
+
+function testConnectorWithDataSourceClassURLPriority () (string firstName) {
+    map propertiesMap = {"url":"jdbc:hsqldb:file:./target/tempdb/TEST_SQL_CONNECTOR"};
+    sql:ConnectionProperties properties = {dataSourceClassName:"org.hsqldb.jdbc.JDBCDataSource",
+                                              datasourceProperties:propertiesMap};
+    sql:ClientConnector testDB = create sql:ClientConnector(sql:HSQLDB_FILE, "./target/tempdb/", 0,
+                                                            "INVALID_DB_NAME", "SA", "", properties);
+
+    sql:Parameter[] parameters = [];
+    datatable dt = testDB.select ("SELECT  FirstName from Customers where registrationID = 1", parameters);
+    errors:TypeCastError err;
+    ResultCustomers rs;
+    while (datatables:hasNext(dt)) {
+        any dataStruct = datatables:next(dt);
+        rs, err = (ResultCustomers) dataStruct;
+        firstName = rs.FIRSTNAME;
+    }
+    testDB.close ();
+    return;
+}
+
+function testConnectionPoolProperties () (string firstName) {
+    sql:ConnectionProperties properties = {url:"jdbc:hsqldb:file:./target/tempdb/TEST_SQL_CONNECTOR",
+                          driverClassName:"org.hsqldb.jdbcDriver", maximumPoolSize:1,
+                          idleTimeout:600000, connectionTimeout:30000, autoCommit:true, maxLifetime:1800000,
+                          minimumIdle:1, poolName:"testHSQLPool", isolateInternalQueries:false,
+                          allowPoolSuspension:false, readOnly:false, validationTimeout:5000, leakDetectionThreshold:0,
+                          connectionInitSql:"SELECT 1 FROM INFORMATION_SCHEMA.SYSTEM_USERS",
+                          transactionIsolation:"TRANSACTION_READ_COMMITTED", catalog:"PUBLIC",
+                          connectionTestQuery:"SELECT 1 FROM INFORMATION_SCHEMA.SYSTEM_USERS"};
+    sql:ClientConnector testDB = create sql:ClientConnector("", "", 0, "", "SA", "", properties);
+
+    sql:Parameter[] parameters = [];
+    datatable dt = testDB.select ("SELECT  FirstName from Customers where registrationID = 1", parameters);
+    errors:TypeCastError err;
+    ResultCustomers rs;
+    while (datatables:hasNext(dt)) {
+        any dataStruct = datatables:next(dt);
+        rs, err = (ResultCustomers) dataStruct;
+        firstName = rs.FIRSTNAME;
+    }
+    testDB.close ();
+    return;
+}
+
+function testInvalidDBType () {
+    sql:ConnectionProperties properties = {maximumPoolSize:1};
+    sql:ClientConnector testDB = create sql:ClientConnector("TESTDB", "./target/tempdb/", 0, "TEST_SQL_CONNECTOR", "SA",
+                                                            "", properties);
+
+    sql:Parameter[] parameters = [];
+    testDB.update ("Insert into Customers(firstName) values ('James')",parameters);
+    testDB.close ();
+    return;
+}

--- a/modules/ballerina-native/src/test/resources/samples/sqlConnectorTest.bal
+++ b/modules/ballerina-native/src/test/resources/samples/sqlConnectorTest.bal
@@ -356,7 +356,7 @@ function testINParameters () (int) {
     return insertCount;
 }
 
-function testNullINParameters () (int) {
+function testNullINParameterValues () (int) {
     sql:ConnectionProperties properties = {maximumPoolSize:1};
     sql:ClientConnector testDB = create sql:ClientConnector(sql:HSQLDB_FILE, "./target/tempdb/", 0,
                                                             "TEST_SQL_CONNECTOR", "SA", "", properties);
@@ -382,6 +382,23 @@ function testNullINParameters () (int) {
     int insertCount = testDB.update ("INSERT INTO DataTypeTable (row_id, int_type, long_type,
             float_type, double_type, boolean_type, string_type, numeric_type, decimal_type, real_type, tinyint_type,
             smallint_type, clob_type, blob_type, binary_type) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)", parameters);
+    testDB.close ();
+    return insertCount;
+}
+
+
+function testNullINParameters () (int) {
+    sql:ConnectionProperties properties = {maximumPoolSize:1};
+    sql:ClientConnector testDB = create sql:ClientConnector(sql:HSQLDB_FILE, "./target/tempdb/", 0,
+                                                            "TEST_SQL_CONNECTOR", "SA", "", properties);
+
+    sql:Parameter paraID = {sqlType:"integer", value:10, direction:0};
+
+    sql:Parameter[] parameters = [paraID, null, null, null, null, null, null, null,
+                                  null, null, null, null, null, null, null];
+    int insertCount = testDB.update ("INSERT INTO DataTypeTable (row_id,int_type, long_type,
+    float_type, double_type, boolean_type, string_type, numeric_type, decimal_type, real_type, tinyint_type,
+    smallint_type, clob_type, blob_type, binary_type) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)", parameters);
     testDB.close ();
     return insertCount;
 }


### PR DESCRIPTION
Fix for #3220, #3264, #3263, #3342 and #3280

With this PR following changes are included for the SQL Connector.

- **Add support for parameter arrays**(#3220). 
Arrays as parameter enables to dynamically provide a set of values without knowing the size of the data set beforehand. This will be used for SQL queries with IN Clause.

.Ex:
   ```java
    int[] dataArray = [1,4343];
    sql:Parameter para0 = {sqlType:"varchar", value:"John", direction:0};
    sql:Parameter para1 = {sqlType:"integer", value:dataArray, direction:0};
    sql:Parameter[] parameters = [para0,para1];
    datatable dt = testDB.select ("SELECT  FirstName from Customers where FirstName = ? or registrationID in(?)", parameters);
```

- **Allow struct, array and time types as input parameters**(#3264)
Ex:
```java
        struct customtype {
		int i;
		float j;
		string s;
	}
	//Array parameter
	int[] intArray = [1,3,4];
        sql:Parameter para1 = {sqlType:"array", value:intArray};
	//Timestamp parameter
	time:Time currentTime = time:currentTime();
	sql:Parameter para2 = {sqlType:"timestamp", value:currentTime};
	//Struct parameter
	customtype customStruct = {i : 10, j : 2.3, s : "test"};
        sql:Parameter para3 = {sqlType:"struct", value:customStruct};
        sql:Parameter[] parameters = [para1, para2, para3];

        insertCount = testDB.update ("INSERT INTO ArrayTypes (int_array, time_type,struct_data) values (?,?,?)", parameters);
```

- **Allow null for connector properties and input parameters**(#3263)

Ex :
```java
         //For Connector
	 sql:ClientConnector testDB = create sql:ClientConnector(sql:MYSQL, "localhost", 0, "TESTDB", "SA", "", null);
	 //For parameter
	 sql:Parameter paraID = {sqlType:"integer", value:10};
         sql:Parameter[] parameters = [paraID, null];
         int insertCount = testDB.update ("INSERT INTO DataTypeTable (row_id,int_type) values (?,?)", parameters);
        //Or
       int insertCount = testDB.update ("INSERT INTO DataTypeTable (row_id,int_type) values (1,100)", null);
```

- **Improvements on distributed transaction connector initialization.**
New property boolean "isXA" is added to sql:ConnectionProperties to provide easy initialization for known DBs.

```java
//For known DBs
sql:ConnectionProperties props = {isXA:true, maximumPoolSize:1};
sql:ClientConnector testDB = create sql:ClientConnector(sql:MYSQL, "localhost", 3306, "testdb", "root", "", props);
//For custom DB
map datasourceProps = {"loginTimeout":8,"url" :"jdbc:customdb://localhost:1234/testdb"};
sql:ConnectionProperties props = {dataSourceClassName:"com.customdb.jdbc..CustomDBXADataSource",datasourceProperties:datasourceProps, maximumPoolSize:1};
sql:ClientConnector testDB = create sql:ClientConnector("", "", 0, "", "root", "root", props);
```

- **Fix issue in distributed transaction failures with retry attempts** (#3280)

- **Fix connection closing issue when exception occurred in actions which returns a datatable (select, call)** (#3342)