### PR TITLE
Improvements to transform statement input and output detection

### DIFF
--- a/modules/ballerina-lang/src/main/java/org/ballerinalang/model/tree/statements/TransformNode.java
+++ b/modules/ballerina-lang/src/main/java/org/ballerinalang/model/tree/statements/TransformNode.java
@@ -17,9 +17,7 @@
 */
 package org.ballerinalang.model.tree.statements;
 
-import org.ballerinalang.model.tree.expressions.ExpressionNode;
-
-import java.util.List;
+import java.util.Set;
 
 /**
  * transform {
@@ -30,8 +28,8 @@ import java.util.List;
 public interface TransformNode extends StatementNode {
     BlockNode getBody();
     void setBody(BlockNode body);
-    List<? extends ExpressionNode> getInputExpressions();
-    List<? extends ExpressionNode> getOutputExpressions();
-    void addInputExpression(ExpressionNode expressionNode);
-    void addOutputExpression(ExpressionNode expressionNode);
+    Set<String> getInputs();
+    Set<String> getOutputs();
+    void addInput(String name);
+    void addOutput(String name);
 }

--- a/modules/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/modules/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -102,7 +102,6 @@ import org.wso2.ballerinalang.compiler.util.diagnotic.DiagnosticPos;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -319,11 +318,11 @@ public class CodeAnalyzer extends BLangNodeVisitor {
             this.dlog.error(transformNode.pos, DiagnosticCode.TRANSFORM_STATEMENT_EMPTY_BODY);
         }
         this.checkStatementExecutionValidity(transformNode);
-        Map<String, BLangExpression> inputs = new HashMap<>(); // right hand expressions by variable
-        Map<String, BLangExpression> outputs = new HashMap<>(); //left hand expressions by variable
+        Set<String> inputs = new HashSet<>();
+        Set<String> outputs = new HashSet<>();
         validateTransformStatementBody(transformNode.body, inputs, outputs);
-        inputs.forEach((k, v) -> transformNode.addInputExpression(v));
-        outputs.forEach((k, v) -> transformNode.addOutputExpression(v));
+        inputs.forEach((k) -> transformNode.addInput(k));
+        outputs.forEach((k) -> transformNode.addOutput(k));
     }
 
     public void visit(BLangPackageDeclaration pkgDclNode) {
@@ -553,27 +552,28 @@ public class CodeAnalyzer extends BLangNodeVisitor {
      * @param inputs    input variable reference expressions map
      * @param outputs   output variable reference expressions map
      */
-    private void validateTransformStatementBody(BLangBlockStmt blockStmt,
-            Map<String, BLangExpression> inputs, Map<String, BLangExpression> outputs) {
+    private void validateTransformStatementBody(BLangBlockStmt blockStmt, Set<String> inputs, Set<String> outputs) {
         Set<String> innerVars = new HashSet<>();
         for (BLangStatement statement : blockStmt.getStatements()) {
             if (statement.getKind() == NodeKind.VARIABLE_DEF) {
                 BLangVariableDef variableDefStmt = (BLangVariableDef) statement;
                 BLangVariable variable = variableDefStmt.var;
-                String varName = variable.getName().getValue();
+                String varName = variable.name.value;
 
-                if (!(variable.getInitialExpression() instanceof BLangLiteral)) {
+                //variables defined in transform scope, cannot be used as output
+                if (outputs.contains(varName)) {
+                    this.dlog.error(variableDefStmt.pos, DiagnosticCode.TRANSFORM_STATEMENT_INVALID_INPUT_OUTPUT);
+                    continue;
+                }
+
+                if (variable.expr.getKind() != NodeKind.LITERAL) {
                     // if the variable does not hold a constant value, it is a temporary variable and hence not an input
                     innerVars.add(varName);
                 }
 
-                //variables defined in transform scope, cannot be used as output
-                if (outputs.get(varName) != null) {
-                    this.dlog.error(variableDefStmt.pos, DiagnosticCode.TRANSFORM_STATEMENT_INVALID_INPUT_OUTPUT);
-                    continue;
-                }
                 //if variable has not been used as an output before
-                inputs.putIfAbsent(varName, variable.expr);
+                inputs.add(varName);
+
                 continue;
             }
             if (statement.getKind() == NodeKind.ASSIGNMENT) {
@@ -581,19 +581,19 @@ public class CodeAnalyzer extends BLangNodeVisitor {
                 for (BLangExpression lExpr : assignStmt.varRefs) {
                     BLangExpression[] varRefExpressions = getVariableReferencesFromExpression(lExpr);
                     for (BLangExpression exp : varRefExpressions) {
-                        String varName = ((BLangSimpleVarRef) exp).variableName.getValue();
-                        if (assignStmt.isDeclaredWithVar()) {
+                        String varName = ((BLangSimpleVarRef) exp).variableName.value;
+                        if (assignStmt.declaredWithVar) {
                             innerVars.add(varName);
                         } else {
                             // if lhs is declared with var, they not considered as output variables since they are
                             // only available in transform statement scope
-                            if (inputs.get(varName) != null) {
+                            if (inputs.contains(varName)) {
                                 this.dlog
                                         .error(assignStmt.pos, DiagnosticCode.TRANSFORM_STATEMENT_INVALID_INPUT_OUTPUT);
                                 continue;
                             }
                             //if variable has not been used as an input before
-                            outputs.putIfAbsent(varName, exp);
+                            outputs.add(varName);
                         }
                     }
                 }
@@ -601,13 +601,13 @@ public class CodeAnalyzer extends BLangNodeVisitor {
                 BLangExpression[] varRefExpressions = getVariableReferencesFromExpression(rExpr);
                 for (BLangExpression exp : varRefExpressions) {
                     String varName = ((BLangSimpleVarRef) exp).variableName.getValue();
-                    if (outputs.get(varName) != null) {
+                    if (outputs.contains(varName)) {
                         this.dlog.error(((BLangSimpleVarRef) exp).pos,
                                 DiagnosticCode.TRANSFORM_STATEMENT_INVALID_INPUT_OUTPUT);
                         continue;
                     }
                     //if variable has not been used as an output before
-                    inputs.putIfAbsent(varName, exp);
+                    inputs.add(varName);
                 }
             }
         }

--- a/modules/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/statements/BLangTransform.java
+++ b/modules/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/statements/BLangTransform.java
@@ -18,26 +18,24 @@
 package org.wso2.ballerinalang.compiler.tree.statements;
 
 import org.ballerinalang.model.tree.NodeKind;
-import org.ballerinalang.model.tree.expressions.ExpressionNode;
 import org.ballerinalang.model.tree.statements.BlockNode;
 import org.ballerinalang.model.tree.statements.TransformNode;
 import org.wso2.ballerinalang.compiler.tree.BLangNodeVisitor;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangExpression;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * @since 0.94
  */
 public class BLangTransform extends BLangStatement implements TransformNode {
     public BLangBlockStmt body;
-    public List<BLangExpression> inputExprs;
-    public List<BLangExpression> outputExprs;
+    public Set<String> inputs;
+    public Set<String> outputs;
 
     public BLangTransform() {
-        this.inputExprs = new ArrayList<>();
-        this.outputExprs = new ArrayList<>();
+        this.inputs = new HashSet<>();
+        this.outputs = new HashSet<>();
     }
 
     @Override
@@ -51,23 +49,23 @@ public class BLangTransform extends BLangStatement implements TransformNode {
     }
 
     @Override
-    public List<BLangExpression> getInputExpressions() {
-        return inputExprs;
+    public Set<String> getInputs() {
+        return inputs;
     }
 
     @Override
-    public void addInputExpression(ExpressionNode expressionNode) {
-        this.inputExprs.add((BLangExpression) expressionNode);
+    public void addInput(String name) {
+        this.inputs.add(name);
     }
 
     @Override
-    public List<BLangExpression> getOutputExpressions() {
-        return outputExprs;
+    public Set<String> getOutputs() {
+        return outputs;
     }
 
     @Override
-    public void addOutputExpression(ExpressionNode expressionNode) {
-        this.outputExprs.add((BLangExpression) expressionNode);
+    public void addOutput(String name) {
+        this.outputs.add(name);
     }
 
     @Override


### PR DESCRIPTION
Tests are not added yet due to the ongoing migration. Do not merge.

This PR includes fixes for : 

- Detecting inputs from binary and unary expressions
- Remove temporary variables from inputs
- Add variable definitions as inputs