### PR TITLE
Changing attributes with 'version' of swagger.

### DIFF
--- a/modules/ballerina-http/src/main/ballerina/ballerina/net/http/swagger/annotation.bal
+++ b/modules/ballerina-http/src/main/ballerina/ballerina/net/http/swagger/annotation.bal
@@ -2,7 +2,7 @@ package ballerina.net.http.swagger;
 
 public annotation ServiceInfo attach service {
     string title;
-    string version;
+    string serviceVersion;
     string description;
     string termsOfService;
     Contact contact;
@@ -45,7 +45,7 @@ public annotation Developer {
 }
 
 public annotation Swagger attach service {
-    string version;
+    string swaggerVersion;
     SwaggerExtension[] extension;
 }
 


### PR DESCRIPTION
Changing the 'version' attributes in swagger annotation definitions as 'version' is now a keyword.