### PR TITLE
 Improvements for SQLConnector 

### DIFF
--- a/modules/ballerina-builtin/src/main/ballerina/ballerina/data/sql/natives.bal
+++ b/modules/ballerina-builtin/src/main/ballerina/ballerina/data/sql/natives.bal
@@ -3,15 +3,13 @@ package ballerina.data.sql;
 import ballerina.doc;
 
 @doc:Description { value: "Parameter struct represents a query parameter for the SQL queries specified in connector actions"}
-@doc:Field {value:"sqlType : The data type of the corresponding SQL parameter"}
+@doc:Field {value:"sqlType: The data type of the corresponding SQL parameter"}
 @doc:Field {value:"value: Value of paramter pass into the SQL query"}
 @doc:Field {value:"direction: Direction of the SQL Parameter 0 - IN, 1- OUT, 2 - INOUT"}
-@doc:Field {value:"structuredType: Underline SQL type to be used for parameter of SQL array type or custom structure type to be used with struct type"}
 public struct Parameter {
 	string sqlType;
 	any value;
 	int direction;
-	string structuredType;
 }
 
 @doc:Description { value: "ConnectionProperties structs represents the properties which are used to configure DB connection pool"}
@@ -27,6 +25,7 @@ public struct Parameter {
 @doc:Field {value:"isolateInternalQueries: Determines whether HikariCP isolates internal pool queries, such as the connection alive test, in their own transaction"}
 @doc:Field {value:"allowPoolSuspension: Whether the pool can be suspended and resumed through JMX"}
 @doc:Field {value:"readOnly:  Whether Connections obtained from the pool are in read-only mode by default"}
+@doc:Field {value:"isXA:  Whether Connections are used for a distributed transaction"}
 @doc:Field {value:"maximumPoolSize: Maximum size that the pool is allowed to reach, including both idle and in-use connections"}
 @doc:Field {value:"connectionTimeout: Maximum number of milliseconds that a client will wait for a connection from the pool"}
 @doc:Field {value:"idleTimeout: Maximum amount of time that a connection is allowed to sit idle in the pool"}
@@ -48,6 +47,7 @@ public struct ConnectionProperties {
 	boolean isolateInternalQueries;
 	boolean allowPoolSuspension;
 	boolean readOnly;
+	boolean isXA;
 	int maximumPoolSize = -1;
 	int connectionTimeout = -1;
 	int idleTimeout = -1;

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/Constants.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/Constants.java
@@ -78,6 +78,23 @@ public final class Constants {
     }
 
     /**
+     * XA Datasoruce for DB Types with first class support.
+     */
+    public static final class XADataSources {
+        public static final String MYSQL_5_XA_DATASOURCE = "com.mysql.jdbc.jdbc2.optional.MysqlXADataSource";
+        public static final String MYSQL_6_XA_DATASOURCE = "com.mysql.cj.jdbc.MysqlXADataSource";
+        public static final String SQLSERVER_XA_DATASOURCE = "com.microsoft.sqlserver.jdbc.SQLServerXADataSource";
+        public static final String ORACLE_XA_DATASOURCE  = "oracle.jdbc.xa.client.OracleXADataSource";
+        public static final String SYBASE_XA_DATASOURCE  = "com.sybase.jdbc3.jdbc.SybXADataSource";
+        public static final String POSTGRE_XA_DATASOURCE  = "org.postgresql.xa.PGXADataSource";
+        public static final String IBMDB2_XA_DATASOURCE  = "com.ibm.db2.jdbc.DB2XADataSource";
+        public static final String HSQLDB_XA_DATASOURCE  = "org.hsqldb.jdbc.pool.JDBCXADataSource";
+        public static final String H2_XA_DATASOURCE = "org.h2.jdbcx.JdbcDataSource";
+        public static final String DERBY_SERVER_XA_DATASOURCE = "org.apache.derby.jdbc.ClientXADataSource";
+        public static final String DERBY_FILE_XA_DATASOURCE = "org.apache.derby.jdbc.EmbeddedXADataSource";
+    }
+
+    /**
      * Constants default DB ports.
      */
     public static final class DefaultPort {
@@ -105,4 +122,10 @@ public final class Constants {
     public static final String CONNECTOR_NAME = "ClientConnector";
     public static final String DATASOURCE_KEY = "datasource_key";
     public static final String TIMEZONE_UTC = "UTC";
+    public static final String QUESTION_MARK = "?";
+    public static final String STRUCT_TIME = "Time";
+    public static final String STRUCT_TIME_PACKAGE = "ballerina.lang.time";
+    public static final String URL = "url";
+    public static final String USER = "user";
+    public static final String PASSWORD = "password";
 }

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/SQLTransactionContext.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/SQLTransactionContext.java
@@ -41,6 +41,10 @@ public class SQLTransactionContext implements BallerinaTransactionContext {
         return this.conn;
     }
 
+    public void updateConnection (Connection conn) {
+        this.conn = conn;
+    }
+
     @Override
     public void commit() {
         try {

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/client/AbstractSQLAction.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/client/AbstractSQLAction.java
@@ -20,12 +20,19 @@ package org.ballerinalang.nativeimpl.actions.data.sql.client;
 import org.ballerinalang.bre.BallerinaTransactionContext;
 import org.ballerinalang.bre.BallerinaTransactionManager;
 import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.BArrayType;
 import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.types.TypeTags;
+import org.ballerinalang.model.values.BBlob;
+import org.ballerinalang.model.values.BBlobArray;
 import org.ballerinalang.model.values.BBoolean;
+import org.ballerinalang.model.values.BBooleanArray;
 import org.ballerinalang.model.values.BDataTable;
 import org.ballerinalang.model.values.BFloat;
+import org.ballerinalang.model.values.BFloatArray;
 import org.ballerinalang.model.values.BIntArray;
 import org.ballerinalang.model.values.BInteger;
+import org.ballerinalang.model.values.BNewArray;
 import org.ballerinalang.model.values.BRefValueArray;
 import org.ballerinalang.model.values.BString;
 import org.ballerinalang.model.values.BStringArray;
@@ -36,6 +43,7 @@ import org.ballerinalang.nativeimpl.actions.data.sql.SQLDataIterator;
 import org.ballerinalang.nativeimpl.actions.data.sql.SQLDatasource;
 import org.ballerinalang.nativeimpl.actions.data.sql.SQLTransactionContext;
 import org.ballerinalang.natives.connectors.AbstractNativeAction;
+import org.ballerinalang.natives.exceptions.ArgumentOutOfRangeException;
 import org.ballerinalang.util.DistributedTxManagerProvider;
 import org.ballerinalang.util.exceptions.BallerinaException;
 
@@ -81,6 +89,14 @@ public abstract class AbstractSQLAction extends AbstractNativeAction {
         utcCalendar = Calendar.getInstance(TimeZone.getTimeZone(Constants.TIMEZONE_UTC));
     }
 
+    @Override
+    public BValue getRefArgument(Context context, int index) {
+        if (index > -1) {
+            return context.getControlStackNew().getCurrentFrame().getRefLocalVars()[index];
+        }
+        throw new ArgumentOutOfRangeException(index);
+    }
+
     protected void executeQuery(Context context, SQLDatasource datasource, String query, BRefValueArray parameters) {
         Connection conn = null;
         PreparedStatement stmt = null;
@@ -88,13 +104,14 @@ public abstract class AbstractSQLAction extends AbstractNativeAction {
         boolean isInTransaction = context.isInTransaction();
         try {
             conn = getDatabaseConnection(context, datasource, isInTransaction);
-            stmt = getPreparedStatement(conn, datasource, query);
+            String processedQuery = createProcessedQueryString(query, parameters);
+            stmt = getPreparedStatement(conn, datasource, processedQuery);
             createProcessedStatement(conn, stmt, parameters);
             rs = stmt.executeQuery();
             BDataTable dataTable = new BDataTable(new SQLDataIterator(conn, stmt, rs, utcCalendar),
                     getColumnDefinitions(rs));
             context.getControlStackNew().getCurrentFrame().returnValues[0] = dataTable;
-        } catch (SQLException e) {
+        } catch (Throwable e) {
             SQLDatasourceUtils.cleanupConnection(rs, stmt, conn, isInTransaction);
             throw new BallerinaException("execute query failed: " + e.getMessage(), e);
         }
@@ -106,7 +123,8 @@ public abstract class AbstractSQLAction extends AbstractNativeAction {
         boolean isInTransaction = context.isInTransaction();
         try {
             conn = getDatabaseConnection(context, datasource, isInTransaction);
-            stmt = conn.prepareStatement(query);
+            String processedQuery = createProcessedQueryString(query, parameters);
+            stmt = conn.prepareStatement(processedQuery);
             createProcessedStatement(conn, stmt, parameters);
             int count = stmt.executeUpdate();
             BInteger updatedCount = new BInteger(count);
@@ -126,6 +144,7 @@ public abstract class AbstractSQLAction extends AbstractNativeAction {
         boolean isInTransaction = context.isInTransaction();
         try {
             conn = getDatabaseConnection(context, datasource, isInTransaction);
+            String processedQuery = createProcessedQueryString(query, parameters);
             int keyColumnCount = 0;
             if (keyColumns != null) {
                 keyColumnCount = (int) keyColumns.size();
@@ -135,9 +154,9 @@ public abstract class AbstractSQLAction extends AbstractNativeAction {
                 for (int i = 0; i < keyColumnCount; i++) {
                     columnArray[i] = keyColumns.get(i);
                 }
-                stmt = conn.prepareStatement(query, columnArray);
+                stmt = conn.prepareStatement(processedQuery, columnArray);
             } else {
-                stmt = conn.prepareStatement(query, Statement.RETURN_GENERATED_KEYS);
+                stmt = conn.prepareStatement(processedQuery, Statement.RETURN_GENERATED_KEYS);
             }
             createProcessedStatement(conn, stmt, parameters);
             int count = stmt.executeUpdate();
@@ -176,7 +195,7 @@ public abstract class AbstractSQLAction extends AbstractNativeAction {
             } else {
                 SQLDatasourceUtils.cleanupConnection(null, stmt, conn, isInTransaction);
             }
-        } catch (SQLException e) {
+        } catch (Throwable e) {
             SQLDatasourceUtils.cleanupConnection(rs, stmt, conn, isInTransaction);
             throw new BallerinaException("execute stored procedure failed: " + e.getMessage(), e);
         }
@@ -192,10 +211,15 @@ public abstract class AbstractSQLAction extends AbstractNativeAction {
             conn = datasource.getSQLConnection();
             stmt = conn.prepareStatement(query);
             setConnectionAutoCommit(conn, false);
-            paramArrayCount = (int) parameters.size();
-            for (int index = 0; index < paramArrayCount; index++) {
-                BRefValueArray params = (BRefValueArray) parameters.get(index);
-                createProcessedStatement(conn, stmt, params);
+            if (parameters != null) {
+                paramArrayCount = (int) parameters.size();
+                for (int index = 0; index < paramArrayCount; index++) {
+                    BRefValueArray params = (BRefValueArray) parameters.get(index);
+                    createProcessedStatement(conn, stmt, params);
+                    stmt.addBatch();
+                }
+            } else {
+                createProcessedStatement(conn, stmt, null);
                 stmt.addBatch();
             }
             updatedCount = stmt.executeBatch();
@@ -221,6 +245,75 @@ public abstract class AbstractSQLAction extends AbstractNativeAction {
             }
         }
         context.getControlStackNew().getCurrentFrame().returnValues[0] = countArray;
+    }
+
+    /**
+     * If there are any arrays of parameter for types other than sql array, the given query is expanded by adding "?" s
+     * to match with the array size.
+     */
+    private String createProcessedQueryString(String query, BRefValueArray parameters) {
+        String currentQuery = query;
+        if (parameters != null) {
+            int start = 0;
+            Object[] vals;
+            int count;
+            int paramCount = (int) parameters.size();
+            for (int i = 0; i < paramCount; i++) {
+                BStruct paramValue = (BStruct) parameters.get(i);
+                if (paramValue != null) {
+                    BValue value = paramValue.getRefField(0);
+                    String sqlType = paramValue.getStringField(0);
+                    if (value != null && value.getType().getTag() == TypeTags.ARRAY_TAG &&
+                            !Constants.SQLDataTypes.ARRAY.equalsIgnoreCase(sqlType)) {
+                        count = (int) ((BNewArray) value).size();
+                    } else {
+                        count = 1;
+                    }
+                    vals = this.expandQuery(start, count, currentQuery);
+                    start = (Integer) vals[0];
+                    currentQuery = (String) vals[1];
+                }
+            }
+        }
+        return currentQuery;
+    }
+
+    /**
+     * Search for the first occurrence of "?" from the given starting point and replace it with given number of "?"'s.
+     */
+    private Object[] expandQuery(int start, int count, String query) {
+        StringBuilder result = new StringBuilder();
+        int n = query.length();
+        boolean doubleQuoteExists = false;
+        boolean singleQuoteExists = false;
+        int end = n;
+        for (int i = start; i < n; i++) {
+            if (query.charAt(i) == '\'') {
+                singleQuoteExists = !singleQuoteExists;
+            } else if (query.charAt(i) == '\"') {
+                doubleQuoteExists = !doubleQuoteExists;
+            } else if (query.charAt(i) == '?' && !(doubleQuoteExists || singleQuoteExists)) {
+                result.append(query.substring(0, i));
+                result.append(this.generateQuestionMarks(count));
+                end = result.length() + 1;
+                if (i + 1 < n) {
+                    result.append(query.substring(i + 1));
+                }
+                break;
+            }
+        }
+        return new Object[] { end, result.toString() };
+    }
+
+    private String generateQuestionMarks(int n) {
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < n; i++) {
+            builder.append(Constants.QUESTION_MARK);
+            if (i + 1 < n) {
+                builder.append(",");
+            }
+        }
+        return builder.toString();
     }
 
     private void setConnectionAutoCommit(Connection conn, boolean status) {
@@ -265,7 +358,7 @@ public abstract class AbstractSQLAction extends AbstractNativeAction {
             stmt = conn.prepareCall(query, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
             /* Only stream if there aren't any OUT parameters since can't use streaming result sets with callable
                statements that have output parameters */
-            if (!hasOutParams(parameters)) {
+            if (parameters != null && !hasOutParams(parameters)) {
                 stmt.setFetchSize(Integer.MIN_VALUE);
             }
         } else {
@@ -334,19 +427,59 @@ public abstract class AbstractSQLAction extends AbstractNativeAction {
     }
 
     private void createProcessedStatement(Connection conn, PreparedStatement stmt, BRefValueArray params) {
+        if (params == null) {
+            return;
+        }
         int paramCount = (int) params.size();
+        int currentOrdinal = 0;
         for (int index = 0; index < paramCount; index++) {
-            BStruct paramValue = (BStruct) params.get(index);
-            String sqlType = paramValue.getStringField(0);
-            BValue value = paramValue.getRefField(0);
-            int direction = (int) paramValue.getIntField(0);
-            String structuredSQLType = paramValue.getStringField(1);
-            setParameter(conn, stmt, sqlType, value, direction, index, structuredSQLType);
+            BStruct paramStruct = (BStruct) params.get(index);
+            if (paramStruct != null) {
+                String sqlType = paramStruct.getStringField(0);
+                BValue value = paramStruct.getRefField(0);
+                int direction = (int) paramStruct.getIntField(0);
+                //If the parameter is an array and sql type is not "array" then treat it as an array of parameters
+                if (value != null && value.getType().getTag() == TypeTags.ARRAY_TAG && !Constants.SQLDataTypes.ARRAY
+                        .equalsIgnoreCase(sqlType)) {
+                    int arrayLength = (int) ((BNewArray) value).size();
+                    int typeTag = ((BArrayType) value.getType()).getElementType().getTag();
+                    for (int i = 0; i < arrayLength; i++) {
+                        BValue paramValue;
+                        switch (typeTag) {
+                        case TypeTags.INT_TAG:
+                            paramValue = new BInteger(((BIntArray) value).get(i));
+                            break;
+                        case TypeTags.FLOAT_TAG:
+                            paramValue = new BFloat(((BFloatArray) value).get(i));
+                            break;
+                        case TypeTags.STRING_TAG:
+                            paramValue = new BString(((BStringArray) value).get(i));
+                            break;
+                        case TypeTags.BOOLEAN_TAG:
+                            paramValue = new BBoolean(((BBooleanArray) value).get(i) > 0);
+                            break;
+                        case TypeTags.BLOB_TAG:
+                            paramValue = new BBlob(((BBlobArray) value).get(i));
+                            break;
+                        default:
+                            throw new BallerinaException("unsupported array type for parameter index " + index);
+                        }
+                        setParameter(conn, stmt, sqlType, paramValue, direction, currentOrdinal);
+                        currentOrdinal++;
+                    }
+                } else {
+                    setParameter(conn, stmt, sqlType, value, direction, currentOrdinal);
+                    currentOrdinal++;
+                }
+            } else {
+                SQLDatasourceUtils.setNullObject(stmt, index);
+                currentOrdinal++;
+            }
         }
     }
 
     private void setParameter(Connection conn, PreparedStatement stmt, String sqlType, BValue value, int direction,
-            int index, String structuredSQLType) {
+            int index) {
         if (sqlType == null || sqlType.isEmpty()) {
             SQLDatasourceUtils.setStringValue(stmt, value, index, direction, Types.VARCHAR);
         } else {
@@ -426,11 +559,11 @@ public abstract class AbstractSQLAction extends AbstractNativeAction {
                 SQLDatasourceUtils.setNClobValue(stmt, value, index, direction, Types.NCLOB);
                 break;
             case Constants.SQLDataTypes.ARRAY:
-                SQLDatasourceUtils.setArrayValue(conn, stmt, value, index, direction, Types.ARRAY, structuredSQLType);
+                SQLDatasourceUtils.setArrayValue(conn, stmt, value, index, direction, Types.ARRAY);
                 break;
             case Constants.SQLDataTypes.STRUCT:
                 SQLDatasourceUtils
-                        .setUserDefinedValue(conn, stmt, value, index, direction, Types.STRUCT, structuredSQLType);
+                        .setUserDefinedValue(conn, stmt, value, index, direction, Types.STRUCT);
                 break;
             default:
                 throw new BallerinaException("unsupported datatype as parameter: " + sqlType + " index:" + index);
@@ -439,13 +572,21 @@ public abstract class AbstractSQLAction extends AbstractNativeAction {
     }
 
     private void setOutParameters(CallableStatement stmt, BRefValueArray params) {
+        if (params == null) {
+            return;
+        }
         int paramCount = (int) params.size();
         for (int index = 0; index < paramCount; index++) {
             BStruct paramValue = (BStruct) params.get(index);
-            String sqlType = paramValue.getStringField(0);
-            int direction = (int) paramValue.getIntField(0);
-            if (direction == Constants.QueryParamDirection.INOUT || direction == Constants.QueryParamDirection.OUT) {
-                setOutParameterValue(stmt, sqlType, index, paramValue);
+            if (paramValue != null) {
+                String sqlType = paramValue.getStringField(0);
+                int direction = (int) paramValue.getIntField(0);
+                if (direction == Constants.QueryParamDirection.INOUT
+                        || direction == Constants.QueryParamDirection.OUT) {
+                    setOutParameterValue(stmt, sqlType, index, paramValue);
+                }
+            } else {
+                throw new BallerinaException("out value cannot set for null parameter with index: " + index);
             }
         }
     }
@@ -600,19 +741,17 @@ public abstract class AbstractSQLAction extends AbstractNativeAction {
 
     private Connection getDatabaseConnection(Context context, SQLDatasource datasource, boolean isInTransaction)
             throws SQLException {
-        Connection conn;
+        Connection conn = null;
         if (!isInTransaction) {
             conn = datasource.getSQLConnection();
             return conn;
         }
-        BallerinaTransactionManager ballerinaTxManager = context.getBallerinaTransactionManager();
-        Object[] connInfo = createDatabaseConnection(datasource, ballerinaTxManager);
-        conn = (Connection) connInfo[0];
-        boolean newConnection = (Boolean) connInfo[1];
+        String connectorId = datasource.getConnectorId();
         boolean isXAConnection = datasource.isXAConnection();
-        if (newConnection) {
+        BallerinaTransactionManager ballerinaTxManager = context.getBallerinaTransactionManager();
+        BallerinaTransactionContext txContext = ballerinaTxManager.getTransactionContext(connectorId);
+        if (txContext == null) {
             if (isXAConnection) {
-                /* Atomikos transaction manager initialize only distributed transaction is present.*/
                 if (!ballerinaTxManager.hasXATransactionManager()) {
                     TransactionManager transactionManager = DistributedTxManagerProvider.getInstance()
                             .getTransactionManager();
@@ -628,35 +767,22 @@ public abstract class AbstractSQLAction extends AbstractNativeAction {
                         XAResource xaResource = xaConn.getXAResource();
                         tx.enlistResource(xaResource);
                         conn = xaConn.getConnection();
+                        txContext = new SQLTransactionContext(conn, datasource.isXAConnection());
+                        ballerinaTxManager.registerTransactionContext(connectorId, txContext);
                     }
-                } catch (SystemException | RollbackException e) {
+                } catch (SystemException | RollbackException | IllegalStateException e) {
                     throw new BallerinaException(
-                            "error in enlisting distributed transaction resources: " + e.getCause().getMessage(),
-                            e);
+                            "error in enlisting distributed transaction resources: " + e.getCause().getMessage(), e);
                 }
             } else {
-                if (conn != null) {
-                    conn.setAutoCommit(false);
-                }
+                conn = datasource.getSQLConnection();
+                conn.setAutoCommit(false);
+                txContext = new SQLTransactionContext(conn, datasource.isXAConnection());
+                ballerinaTxManager.registerTransactionContext(connectorId, txContext);
             }
-        }
-        return conn;
-    }
-
-    private Object[] createDatabaseConnection(SQLDatasource datasource, BallerinaTransactionManager ballerinaTxManager)
-            throws SQLException {
-        Connection conn;
-        boolean newConnection = false;
-        String connectorId = datasource.getConnectorId();
-        BallerinaTransactionContext txContext = ballerinaTxManager.getTransactionContext(connectorId);
-        if (txContext == null) {
-            conn = datasource.getSQLConnection();
-            txContext = new SQLTransactionContext(conn, datasource.isXAConnection());
-            ballerinaTxManager.registerTransactionContext(connectorId, txContext);
-            newConnection = true;
         } else {
             conn = ((SQLTransactionContext) txContext).getConnection();
         }
-        return new Object[] { conn, newConnection };
+        return conn;
     }
 }

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/client/SQLDatasourceUtils.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/client/SQLDatasourceUtils.java
@@ -17,10 +17,19 @@
  */
 package org.ballerinalang.nativeimpl.actions.data.sql.client;
 
+import org.ballerinalang.model.types.BArrayType;
+import org.ballerinalang.model.types.BStructType;
 import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.types.TypeTags;
 import org.ballerinalang.model.values.BBlob;
+import org.ballerinalang.model.values.BBlobArray;
+import org.ballerinalang.model.values.BBooleanArray;
+import org.ballerinalang.model.values.BFloatArray;
+import org.ballerinalang.model.values.BIntArray;
 import org.ballerinalang.model.values.BInteger;
 import org.ballerinalang.model.values.BString;
+import org.ballerinalang.model.values.BStringArray;
+import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.nativeimpl.actions.data.sql.Constants;
 import org.ballerinalang.util.exceptions.BallerinaException;
@@ -284,7 +293,7 @@ public class SQLDatasourceUtils {
                 throw new BallerinaException("invalid direction for the parameter with index: " + index);
             }
         } catch (SQLException e) {
-            throw new BallerinaException("error in set TinyInt value to statement: " + e.getMessage(), e);
+            throw new BallerinaException("error in set tinyint value to statement: " + e.getMessage(), e);
         }
     }
 
@@ -320,7 +329,7 @@ public class SQLDatasourceUtils {
                 throw new BallerinaException("Invalid direction for the parameter, index: " + index);
             }
         } catch (SQLException e) {
-            throw new BallerinaException("Error in set Small Int value to statement." + e.getMessage(), e);
+            throw new BallerinaException("error in set smallint value to statement." + e.getMessage(), e);
         }
     }
 
@@ -356,7 +365,7 @@ public class SQLDatasourceUtils {
                 throw new BallerinaException("invalid direction for the parameter with index: " + index);
             }
         } catch (SQLException e) {
-            throw new BallerinaException("error in set Big Int value to statement: " + e.getMessage(), e);
+            throw new BallerinaException("error in set bigint value to statement: " + e.getMessage(), e);
         }
     }
 
@@ -389,20 +398,25 @@ public class SQLDatasourceUtils {
             } else if (Constants.QueryParamDirection.OUT == direction) {
                 ((CallableStatement) stmt).registerOutParameter(index + 1, sqlType);
             } else {
-                throw new BallerinaException("Invalid direction for the parameter, index: " + index);
+                throw new BallerinaException("invalid direction for the parameter, index: " + index);
             }
         } catch (SQLException e) {
-            throw new BallerinaException("Error in set float value to statement." + e.getMessage(), e);
+            throw new BallerinaException("error in set float value to statement." + e.getMessage(), e);
         }
     }
 
     public static void setDateValue(PreparedStatement stmt, BValue value, int index, int direction, int sqlType) {
         Date val = null;
         if (value != null) {
-            if (value instanceof BInteger) {
+            if (value instanceof BStruct && value.getType().getName().equals(Constants.STRUCT_TIME) && value
+                    .getType().getPackagePath().equals(Constants.STRUCT_TIME_PACKAGE)) {
+                val = new Date(((BStruct) value).getIntField(0));
+            } else if (value instanceof BInteger) {
                 val = new Date(((BInteger) value).intValue());
             } else if (value instanceof BString) {
                 val = SQLDatasourceUtils.convertToDate(value.stringValue());
+            } else {
+                throw new BallerinaException("invalid input type for date parameter with index: " + index);
             }
         }
         try {
@@ -433,10 +447,15 @@ public class SQLDatasourceUtils {
             Calendar utcCalendar) {
         Timestamp val = null;
         if (value != null) {
-            if (value instanceof BInteger) {
+            if (value instanceof BStruct && value.getType().getName().equals(Constants.STRUCT_TIME) && value
+                    .getType().getPackagePath().equals(Constants.STRUCT_TIME_PACKAGE)) {
+                val = new Timestamp(((BStruct) value).getIntField(0));
+            } else if (value instanceof BInteger) {
                 val = new Timestamp(((BInteger) value).intValue());
             } else if (value instanceof BString) {
                 val = SQLDatasourceUtils.convertToTimeStamp(value.stringValue());
+            } else {
+                throw new BallerinaException("invalid input type for timestamp parameter with index: " + index);
             }
         }
         try {
@@ -459,7 +478,7 @@ public class SQLDatasourceUtils {
                 throw new BallerinaException("invalid direction for the parameter, index: " + index);
             }
         } catch (SQLException e) {
-            throw new BallerinaException("error in set Timestamp value to statement: " + e.getMessage(), e);
+            throw new BallerinaException("error in set timestamp value to statement: " + e.getMessage(), e);
         }
     }
 
@@ -467,7 +486,10 @@ public class SQLDatasourceUtils {
             Calendar utcCalendar) {
         Time val = null;
         if (value != null) {
-            if (value instanceof BInteger) {
+            if (value instanceof BStruct && value.getType().getName().equals(Constants.STRUCT_TIME) && value
+                    .getType().getPackagePath().equals(Constants.STRUCT_TIME_PACKAGE)) {
+                val = new Time(((BStruct) value).getIntField(0));
+            } else if (value instanceof BInteger) {
                 val = new Time(((BInteger) value).intValue());
             } else if (value instanceof BString) {
                 val = SQLDatasourceUtils.convertToTime(value.stringValue());
@@ -493,7 +515,7 @@ public class SQLDatasourceUtils {
                 throw new BallerinaException("invalid direction for the parameter with index: " + index);
             }
         } catch (SQLException e) {
-            throw new BallerinaException("error in set Timestamp value to statement: " + e.getMessage(), e);
+            throw new BallerinaException("error in set timestamp value to statement: " + e.getMessage(), e);
         }
     }
 
@@ -622,25 +644,23 @@ public class SQLDatasourceUtils {
     }
 
     public static void setArrayValue(Connection conn, PreparedStatement stmt, BValue value, int index, int direction,
-            int sqlType, String structuredSQLType) {
-        Object[] val = null;
-        if (value != null) {
-            val = value.stringValue().split(",");
-        }
-
+            int sqlType) {
+        Object[] arrayData = getArrayData(value);
+        Object[] arrayValue = (Object[]) arrayData[0];
+        String structuredSQLType = (String) arrayData[1];
         try {
             if (Constants.QueryParamDirection.IN == direction) {
-                if (value == null) {
+                if (arrayValue == null) {
                     stmt.setNull(index + 1, sqlType);
                 } else {
-                    Array array = conn.createArrayOf(structuredSQLType, val);
+                    Array array = conn.createArrayOf(structuredSQLType, arrayValue);
                     stmt.setArray(index + 1, array);
                 }
             } else if (Constants.QueryParamDirection.INOUT == direction) {
-                if (value == null) {
+                if (arrayValue == null) {
                     stmt.setNull(index + 1, sqlType);
                 } else {
-                    Array array = conn.createArrayOf(structuredSQLType, val);
+                    Array array = conn.createArrayOf(structuredSQLType, arrayValue);
                     stmt.setArray(index + 1, array);
                 }
                 ((CallableStatement) stmt).registerOutParameter(index + 1, sqlType, structuredSQLType);
@@ -654,27 +674,80 @@ public class SQLDatasourceUtils {
         }
     }
 
-    public static void setUserDefinedValue(Connection conn, PreparedStatement stmt, BValue value, int index,
-            int direction, int sqlType, String structuredSQLType) {
-        structuredSQLType = structuredSQLType.toUpperCase(Locale.getDefault());
-        Object[] val = null;
-        if (value != null) {
-            val = value.stringValue().split(",");
+    public static void setNullObject(PreparedStatement stmt, int index) {
+        try {
+            stmt.setObject(index + 1, null);
+        } catch (SQLException e) {
+            throw new BallerinaException("error in set null to parameter with index: " + index);
         }
+    }
 
+    private static Object[] getArrayData(BValue value) {
+        if (value == null || value.getType().getTag() != TypeTags.ARRAY_TAG) {
+            return new Object[] { null, null };
+        }
+        int typeTag = ((BArrayType) value.getType()).getElementType().getTag();
+        Object[] arrayData;
+        int arrayLength;
+        switch (typeTag) {
+        case TypeTags.INT_TAG:
+            arrayLength = (int) ((BIntArray) value).size();
+            arrayData = new Long[arrayLength];
+            for (int i = 0; i < arrayLength; i++) {
+                arrayData[i] = ((BIntArray) value).get(i);
+            }
+            return new Object[] { arrayData, Constants.SQLDataTypes.BIGINT };
+        case TypeTags.FLOAT_TAG:
+            arrayLength = (int) ((BFloatArray) value).size();
+            arrayData = new Double[arrayLength];
+            for (int i = 0; i < arrayLength; i++) {
+                arrayData[i] = ((BFloatArray) value).get(i);
+            }
+            return new Object[] { arrayData, Constants.SQLDataTypes.DOUBLE };
+        case TypeTags.STRING_TAG:
+            arrayLength = (int) ((BStringArray) value).size();
+            arrayData = new String[arrayLength];
+            for (int i = 0; i < arrayLength; i++) {
+                arrayData[i] = ((BStringArray) value).get(i);
+            }
+            return new Object[] { arrayData, Constants.SQLDataTypes.VARCHAR };
+        case TypeTags.BOOLEAN_TAG:
+            arrayLength = (int) ((BBooleanArray) value).size();
+            arrayData = new Boolean[arrayLength];
+            for (int i = 0; i < arrayLength; i++) {
+                arrayData[i] = ((BBooleanArray) value).get(i) > 0;
+            }
+            return new Object[] { arrayData, Constants.SQLDataTypes.BOOLEAN };
+        case TypeTags.BLOB_TAG:
+            arrayLength = (int) ((BBlobArray) value).size();
+            arrayData = new Blob[arrayLength];
+            for (int i = 0; i < arrayLength; i++) {
+                arrayData[i] = ((BBlobArray) value).get(i);
+            }
+            return new Object[] { arrayData, Constants.SQLDataTypes.BLOB };
+        default:
+            throw new BallerinaException("unsupported data type for array parameter");
+        }
+    }
+
+    public static void setUserDefinedValue(Connection conn, PreparedStatement stmt, BValue value, int index,
+            int direction, int sqlType) {
+        Object[] structData = getStructData(value);
+        Object[] dataArray = (Object[]) structData[0];
+        String structuredSQLType = (String) structData[1];
         try {
             if (Constants.QueryParamDirection.IN == direction) {
-                if (value == null) {
+                if (dataArray == null) {
                     stmt.setNull(index + 1, sqlType);
                 } else {
-                    Struct struct = conn.createStruct(structuredSQLType, val);
+                    Struct struct = conn.createStruct(structuredSQLType, dataArray);
                     stmt.setObject(index + 1, struct);
                 }
             } else if (Constants.QueryParamDirection.INOUT == direction) {
-                if (value == null) {
+                if (dataArray == null) {
                     stmt.setNull(index + 1, sqlType);
                 } else {
-                    Struct struct = conn.createStruct(structuredSQLType, val);
+                    Struct struct = conn.createStruct(structuredSQLType, dataArray);
                     stmt.setObject(index + 1, struct);
                 }
                 ((CallableStatement) stmt)
@@ -687,6 +760,50 @@ public class SQLDatasourceUtils {
         } catch (SQLException e) {
             throw new BallerinaException("error in set struct value to statement: " + e.getMessage(), e);
         }
+    }
+
+    private static Object[] getStructData(BValue value) {
+        if (value == null || value.getType().getTag() != TypeTags.STRUCT_TAG) {
+            return new Object[] { null, null };
+        }
+        String structuredSQLType = value.getType().getName().toUpperCase(Locale.getDefault());
+        BStructType.StructField[] structFields = ((BStructType) value.getType()).getStructFields();
+        int fieldCount = structFields.length;
+        Object[] structData = new Object[fieldCount];
+        int intFieldIndex = 0;
+        int floatFieldIndex = 0;
+        int stringFieldIndex = 0;
+        int booleanFieldIndex = 0;
+        int blobFieldIndex = 0;
+        for (int i = 0; i < fieldCount; ++i) {
+            BStructType.StructField field = structFields[i];
+            int typeTag = field.getFieldType().getTag();
+            switch (typeTag) {
+            case TypeTags.INT_TAG:
+                structData[i] = ((BStruct) value).getIntField(intFieldIndex);
+                ++intFieldIndex;
+                break;
+            case TypeTags.FLOAT_TAG:
+                structData[i] = ((BStruct) value).getFloatField(floatFieldIndex);
+                ++floatFieldIndex;
+                break;
+            case TypeTags.STRING_TAG:
+                structData[i] = ((BStruct) value).getStringField(stringFieldIndex);
+                ++stringFieldIndex;
+                break;
+            case TypeTags.BOOLEAN_TAG:
+                structData[i] = ((BStruct) value).getBooleanField(booleanFieldIndex) > 0;
+                ++booleanFieldIndex;
+                break;
+            case TypeTags.BLOB_TAG:
+                structData[i] = ((BStruct) value).getBlobField(blobFieldIndex);
+                ++blobFieldIndex;
+                break;
+            default:
+                throw new BallerinaException("unsupported data type for struct parameter: " + structuredSQLType);
+            }
+        }
+        return new Object[] { structData, structuredSQLType };
     }
 
     /**
@@ -779,7 +896,7 @@ public class SQLDatasourceUtils {
             }
             return sb.toString();
         } catch (IOException | SQLException e) {
-            throw new BallerinaException("error occurred while reading CLOB value: " + e.getMessage(), e);
+            throw new BallerinaException("error occurred while reading clob value: " + e.getMessage(), e);
         }
     }
 
@@ -803,7 +920,7 @@ public class SQLDatasourceUtils {
                     new String(data.getBytes(1L, (int) data.length()), Charset.defaultCharset()));
             return new String(encode, Charset.defaultCharset());
         } catch (SQLException e) {
-            throw new BallerinaException("error occurred while reading BLOB value", e);
+            throw new BallerinaException("error occurred while reading blob value", e);
         }
     }
 

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/bre/BallerinaTransactionManager.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/bre/BallerinaTransactionManager.java
@@ -98,6 +98,8 @@ public class BallerinaTransactionManager {
         if (transactionLevel == 1) {
             rollbackNonXAConnections();
             rollbackXATransaction();
+            closeAllConnections();
+            transactionContextStore.clear();
         }
     }
 

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BLangVM.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BLangVM.java
@@ -2541,7 +2541,7 @@ public class BLangVM {
             } else if (status == -1) { //Transaction failed
                 ballerinaTransactionManager.setTransactionError(true);
                 ballerinaTransactionManager.rollbackTransactionBlock();
-            } else { //status = 1 Transaction aborted
+            } else { //status = 1 Transaction end
                 ballerinaTransactionManager.endTransactionBlock();
                 if (ballerinaTransactionManager.isOuterTransaction()) {
                     context.setBallerinaTransactionManager(null);

--- a/modules/ballerina-test/src/test/java/org/ballerinalang/test/connectors/sql/SQLActionsTest.java
+++ b/modules/ballerina-test/src/test/java/org/ballerinalang/test/connectors/sql/SQLActionsTest.java
@@ -338,6 +338,17 @@ public class SQLActionsTest {
     }
 
     @Test(groups = "ConnectorTest")
+    public void testBatchUpdateWithFailure() {
+        BValue[] returns = BTestUtils.invoke(result, "testBatchUpdateWithFailure");
+        BIntArray retValue = (BIntArray) returns[0];
+        Assert.assertEquals(retValue.get(0), 1);
+        Assert.assertEquals(retValue.get(1), 1);
+        Assert.assertEquals(retValue.get(2), -3);
+        Assert.assertEquals(retValue.get(3), -3);
+        Assert.assertEquals(((BInteger) returns[1]).intValue(), 2);
+    }
+
+    @Test(groups = "ConnectorTest")
     public void testInsertTimeData() {
         BValue[] args = {};
         BValue[] returns = BTestUtils.invoke(result, "testDateTimeInParameters", args);

--- a/modules/ballerina-test/src/test/java/org/ballerinalang/test/connectors/sql/SQLActionsTest.java
+++ b/modules/ballerina-test/src/test/java/org/ballerinalang/test/connectors/sql/SQLActionsTest.java
@@ -34,6 +34,11 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.util.Calendar;
 
+/**
+ * Test class for SQL Connector actions test.
+ *
+ * @since 0.8.0
+ */
 public class SQLActionsTest {
 
     private static final double DELTA = 0.01;
@@ -154,6 +159,14 @@ public class SQLActionsTest {
     }
 
     @Test(groups = "ConnectorTest")
+    public void testArrayofQueryParameters() {
+        BValue[] returns = BTestUtils.invoke(result, "testArrayofQueryParameters");
+        BString retValue = (BString) returns[0];
+        final String expected = "Peter";
+        Assert.assertEquals(retValue.stringValue(), expected);
+    }
+
+    @Test(groups = "ConnectorTest")
     public void testOutParameters() {
         BValue[] args = {};
         BValue[] returns = BTestUtils.invoke(result, "testOutParameters", args);
@@ -199,6 +212,13 @@ public class SQLActionsTest {
     public void testINParameters() {
         BValue[] args = {};
         BValue[] returns = BTestUtils.invoke(result, "testINParameters", args);
+        BInteger retValue = (BInteger) returns[0];
+        Assert.assertEquals(retValue.intValue(), 1);
+    }
+
+    @Test(groups = "ConnectorTest")
+    public void testNullINParameterValues() {
+        BValue[] returns = BTestUtils.invoke(result, "testNullINParameterValues");
         BInteger retValue = (BInteger) returns[0];
         Assert.assertEquals(retValue.intValue(), 1);
     }
@@ -274,15 +294,15 @@ public class SQLActionsTest {
 
         Assert.assertTrue(returns[2] instanceof BMap);
         BMap<BString, BInteger> longArray = (BMap) returns[2];
-        Assert.assertEquals(longArray.get(new BString("0")).intValue(), 10000000);
-        Assert.assertEquals(longArray.get(new BString("1")).intValue(), 20000000);
-        Assert.assertEquals(longArray.get(new BString("2")).intValue(), 30000000);
+        Assert.assertEquals(longArray.get(new BString("0")).intValue(), 1503383034226L);
+        Assert.assertEquals(longArray.get(new BString("1")).intValue(), 1503383034224L);
+        Assert.assertEquals(longArray.get(new BString("2")).intValue(), 1503383034225L);
 
         Assert.assertTrue(returns[3] instanceof BMap);
         BMap<BString, BFloat> doubleArray = (BMap) returns[3];
-        Assert.assertEquals(doubleArray.get(new BString("0")).floatValue(), 245.23);
-        Assert.assertEquals(doubleArray.get(new BString("1")).floatValue(), 5559.49);
-        Assert.assertEquals(doubleArray.get(new BString("2")).floatValue(), 8796.123);
+        Assert.assertEquals(doubleArray.get(new BString("0")).floatValue(), 1503383034226.23D);
+        Assert.assertEquals(doubleArray.get(new BString("1")).floatValue(), 1503383034224.43D);
+        Assert.assertEquals(doubleArray.get(new BString("2")).floatValue(), 1503383034225.123D);
 
         Assert.assertTrue(returns[4] instanceof BMap);
         BMap<BString, BString> stringArray = (BMap) returns[4];
@@ -355,6 +375,7 @@ public class SQLActionsTest {
         BIntArray retValue = (BIntArray) returns[0];
         Assert.assertEquals((int) retValue.get(0), 1);
         Assert.assertEquals((int) retValue.get(1), 1);
+        Assert.assertEquals((int) retValue.get(2), 1);
     }
 
     @Test(groups = "ConnectorTest")
@@ -390,11 +411,12 @@ public class SQLActionsTest {
         Assert.assertEquals(((BInteger) returns[0]).intValue(), 1);
     }
 
-    @Test(expectedExceptions = RuntimeException.class,
-          expectedExceptionsMessageRegExp = ".*error in sql connector configuration.*")
-    public void testInvalidDBType() {
-        BValue[] args = {};
-        BValue[] returns = BTestUtils.invoke(result, "testInvalidDBType", args);
+    @Test(groups = "ConnectorTest")
+    public void testStructOutParameters() {
+        BValue[] returns = BTestUtils.invoke(result, "testStructOutParameters");
+        BString retValue = (BString) returns[0];
+        String expected = "10";
+        Assert.assertEquals(retValue.stringValue(), expected);
     }
 
     @Test(dependsOnGroups = "ConnectorTest")

--- a/modules/ballerina-test/src/test/java/org/ballerinalang/test/connectors/sql/SQLConnectorInitTest.java
+++ b/modules/ballerina-test/src/test/java/org/ballerinalang/test/connectors/sql/SQLConnectorInitTest.java
@@ -41,9 +41,40 @@ public class SQLConnectorInitTest {
     }
 
     @Test
-    public void testConnectorWithDataSource() {
-        BValue[] args = {};
-        BValue[] returns = BTestUtils.invoke(result, "testConnectorWithDataSource", args);
+    public void testConnectorWithDefaultPropertiesForListedDB() {
+         BValue[] returns = BTestUtils.invoke(result, "testConnectorWithDefaultPropertiesForListedDB");
+         BString retValue = (BString) returns[0];
+         final String expected = "Peter";
+         Assert.assertEquals(retValue.stringValue(), expected);
+     }
+
+    @Test
+    public void testConnectorWithDirectUrl() {
+        BValue[] returns = BTestUtils.invoke(result, "testConnectorWithDirectUrl");
+        BString retValue = (BString) returns[0];
+        final String expected = "Peter";
+        Assert.assertEquals(retValue.stringValue(), expected);
+    }
+
+    @Test
+    public void testConnectorWithDataSourceClass() {
+        BValue[] returns = BTestUtils.invoke(result, "testConnectorWithDataSourceClass");
+        BString retValue = (BString) returns[0];
+        final String expected = "Peter";
+        Assert.assertEquals(retValue.stringValue(), expected);
+    }
+
+    @Test
+    public void testConnectorWithDataSourceClassWithoutURL() {
+        BValue[] returns = BTestUtils.invoke(result, "testConnectorWithDataSourceClassWithoutURL");
+        BString retValue = (BString) returns[0];
+        final String expected = "Peter";
+        Assert.assertEquals(retValue.stringValue(), expected);
+    }
+
+    @Test
+    public void testConnectorWithDataSourceClassURLPriority() {
+        BValue[] returns = BTestUtils.invoke(result, "testConnectorWithDataSourceClassURLPriority");
         BString retValue = (BString) returns[0];
         final String expected = "Peter";
         Assert.assertEquals(retValue.stringValue(), expected);
@@ -57,6 +88,15 @@ public class SQLConnectorInitTest {
         final String expected = "Peter";
         Assert.assertEquals(retValue.stringValue(), expected);
     }
+
+    @Test(expectedExceptions = RuntimeException.class,
+          expectedExceptionsMessageRegExp =
+                  ".*error in sql connector configuration: cannot generate url for unknown database type : TESTDB.*")
+    public void testInvalidDBType() {
+        BValue[] args = {};
+        BValue[] returns = BTestUtils.invoke(result, "testInvalidDBType", args);
+    }
+
 
     @AfterSuite
     public void cleanup() {

--- a/modules/ballerina-test/src/test/resources/datafiles/SQLConnectorDataFile.sql
+++ b/modules/ballerina-test/src/test/resources/datafiles/SQLConnectorDataFile.sql
@@ -169,4 +169,24 @@ CREATE PROCEDURE TestArrayINOutParams (IN id INT, OUT insertedCount INTEGER, INO
   SELECT string_array INTO varcharArray FROM ArrayTypes where row_id = 1;
   END
 /
+CREATE TYPE customtype AS INTEGER;
+/
+CREATE TABLE structdatatable(id INTEGER, structdata customtype);
+/
+INSERT INTO structdatatable(id,structdata) VALUES (1,10);
+/
+CREATE PROCEDURE TestStructOut (OUT var customtype)
+  READS SQL DATA
+  BEGIN ATOMIC
+  SELECT structdata INTO var from structdatatable where id = 1;
+  END
+/
+CREATE PROCEDURE TestStructInOut (OUT countVal INTEGER, INOUT var customtype)
+  MODIFIES SQL DATA
+  BEGIN ATOMIC
+  INSERT INTO structdatatable(id,structdata) VALUES (2,var);
+  select count(*) into countVal from structdatatable where id = 2;
+ SELECT structdata INTO var from structdatatable where id = 1;
+  END
+/
 

--- a/modules/ballerina-test/src/test/resources/test-src/connectors/sql/sql-actions.bal
+++ b/modules/ballerina-test/src/test/resources/test-src/connectors/sql/sql-actions.bal
@@ -356,6 +356,67 @@ function testBatchUpdate () (int[]) {
     return updateCount;
 }
 
+function testBatchUpdateWithFailure () (int[] updateCount, int count) {
+    sql:ClientConnector testDB = create sql:ClientConnector(sql:HSQLDB_FILE, "./target/tempdb/",
+                                                            0, "TEST_SQL_CONNECTOR", "SA", "", {maximumPoolSize:1});
+
+    //Batch 1
+    sql:Parameter para0 = {sqlType:"integer", value:111, direction:0};
+    sql:Parameter para1 = {sqlType:"varchar", value:"Alex", direction:0};
+    sql:Parameter para2 = {sqlType:"varchar", value:"Smith", direction:0};
+    sql:Parameter para3 = {sqlType:"integer", value:20, direction:0};
+    sql:Parameter para4 = {sqlType:"double", value:3400.5, direction:0};
+    sql:Parameter para5 = {sqlType:"varchar", value:"Colombo", direction:0};
+    sql:Parameter[] parameters1 = [para0, para1, para2, para3, para4, para5];
+
+    //Batch 2
+    para0 = {sqlType:"integer", value:222, direction:0};
+    para1 = {sqlType:"varchar", value:"Alex", direction:0};
+    para2 = {sqlType:"varchar", value:"Smith", direction:0};
+    para3 = {sqlType:"integer", value:20, direction:0};
+    para4 = {sqlType:"double", value:3400.5, direction:0};
+    para5 = {sqlType:"varchar", value:"Colombo", direction:0};
+    sql:Parameter[] parameters2 = [para0, para1, para2, para3, para4, para5];
+
+
+    //Batch 3
+    para0 = {sqlType:"integer", value:222, direction:0};
+    para1 = {sqlType:"varchar", value:"Alex", direction:0};
+    para2 = {sqlType:"varchar", value:"Smith", direction:0};
+    para3 = {sqlType:"integer", value:20, direction:0};
+    para4 = {sqlType:"double", value:3400.5, direction:0};
+    para5 = {sqlType:"varchar", value:"Colombo", direction:0};
+    sql:Parameter[] parameters3 = [para0, para1, para2, para3, para4, para5];
+
+    //Batch 4
+    para0 = {sqlType:"integer", value:333, direction:0};
+    para1 = {sqlType:"varchar", value:"Alex", direction:0};
+    para2 = {sqlType:"varchar", value:"Smith", direction:0};
+    para3 = {sqlType:"integer", value:20, direction:0};
+    para4 = {sqlType:"double", value:3400.5, direction:0};
+    para5 = {sqlType:"varchar", value:"Colombo", direction:0};
+    sql:Parameter[] parameters4 = [para0, para1, para2, para3, para4, para5];
+
+    sql:Parameter[][] parameters = [parameters1, parameters2, parameters3,parameters4];
+
+    updateCount = testDB.batchUpdate("Insert into Customers (customerId, firstName,lastName,registrationID,creditLimit,
+        country) values (?,?,?,?,?,?)", parameters);
+
+
+    sql:Parameter[] params = [];
+    datatable dt = testDB.select ("SELECT count(*) as countval from Customers where customerId in (111,222,333)",
+                                  params);
+    ResultCount rs;
+    while (datatables:hasNext(dt)) {
+        any dataStruct = datatables:getNext(dt);
+        rs, _ = (ResultCount) dataStruct;
+        count = rs.COUNTVAL;
+    }
+
+    testDB.close();
+    return updateCount, count;
+}
+
 function testDateTimeInParameters () (int[]) {
     sql:ClientConnector testDB = create sql:ClientConnector(sql:HSQLDB_FILE, "./target/tempdb/",
                                                             0, "TEST_SQL_CONNECTOR", "SA", "", {maximumPoolSize:1});

--- a/modules/ballerina-test/src/test/resources/test-src/connectors/sql/sql-connector-init.bal
+++ b/modules/ballerina-test/src/test/resources/test-src/connectors/sql/sql-connector-init.bal
@@ -5,29 +5,6 @@ struct ResultCustomers {
     string FIRSTNAME;
 }
 
-
-function testConnectorWithDataSource () (string firstName) {
-    sql:ClientConnector testDB;
-    map propertiesMap = {"user":"SA", "password":"", "loginTimeout":0,
-                            "url":"jdbc:hsqldb:file:./target/tempdb/TEST_SQL_CONNECTOR"};
-    sql:ConnectionProperties properties = {dataSourceClassName:"org.hsqldb.jdbc.JDBCDataSource",
-                                              datasourceProperties:propertiesMap};
-    testDB = create sql:ClientConnector(sql:HSQLDB_FILE, "", 0, "", "", "", properties);
-
-    sql:Parameter[] parameters = [];
-    datatable dt = testDB.select ("SELECT  FirstName from Customers where registrationID = 1", parameters);
-    TypeCastError err;
-    ResultCustomers rs;
-    while (datatables:hasNext(dt)) {
-        any dataStruct = datatables:getNext(dt);
-        rs, err = (ResultCustomers) dataStruct;
-        firstName = rs.FIRSTNAME;
-    }
-    testDB.close ();
-    return;
-}
-
-
 function testConnectionPoolProperties () (string firstName) {
     sql:ClientConnector testDB;
     sql:ConnectionProperties properties = {url:"jdbc:hsqldb:file:./target/tempdb/TEST_SQL_CONNECTOR",
@@ -50,5 +27,111 @@ function testConnectionPoolProperties () (string firstName) {
         firstName = rs.FIRSTNAME;
     }
     testDB.close ();
+    return;
+}
+
+function testConnectorWithDefaultPropertiesForListedDB () (string firstName) {
+    sql:ClientConnector testDB = create sql:ClientConnector(sql:HSQLDB_FILE, "./target/tempdb/", 0,
+                                                            "TEST_SQL_CONNECTOR", "SA", "", null);
+
+    sql:Parameter[] parameters = [];
+    datatable dt = testDB.select("SELECT  FirstName from Customers where registrationID = 1", parameters);
+    TypeCastError err;
+    ResultCustomers rs;
+    while (datatables:hasNext(dt)) {
+        any dataStruct = datatables:getNext(dt);
+        rs, err = (ResultCustomers)dataStruct;
+        firstName = rs.FIRSTNAME;
+    }
+    testDB.close();
+    return;
+}
+
+
+function testConnectorWithDirectUrl () (string firstName) {
+    sql:ClientConnector testDB;
+    sql:ConnectionProperties Properties = {url:"jdbc:hsqldb:file:./target/tempdb/TEST_SQL_CONNECTOR"};
+    testDB = create sql:ClientConnector("", "", 0, "", "SA", "", Properties);
+
+    sql:Parameter[] parameters = [];
+    datatable dt = testDB.select("SELECT  FirstName from Customers where registrationID = 1", parameters);
+    TypeCastError err;
+    ResultCustomers rs;
+    while (datatables:hasNext(dt)) {
+        any dataStruct = datatables:getNext(dt);
+        rs, err = (ResultCustomers)dataStruct;
+        firstName = rs.FIRSTNAME;
+    }
+    testDB.close();
+    return;
+}
+
+function testConnectorWithDataSourceClass () (string firstName) {
+    sql:ClientConnector testDB;
+    map propertiesMap = {"loginTimeout":109, "url":"jdbc:hsqldb:file:./target/tempdb/TEST_SQL_CONNECTOR"};
+    sql:ConnectionProperties properties = {dataSourceClassName:"org.hsqldb.jdbc.JDBCDataSource",
+                                              datasourceProperties:propertiesMap};
+    testDB = create sql:ClientConnector("", "", 0, "", "SA", "", properties);
+
+    sql:Parameter[] parameters = [];
+    datatable dt = testDB.select("SELECT  FirstName from Customers where registrationID = 1", parameters);
+    TypeCastError err;
+    ResultCustomers rs;
+    while (datatables:hasNext(dt)) {
+        any dataStruct = datatables:getNext(dt);
+        rs, err = (ResultCustomers)dataStruct;
+        firstName = rs.FIRSTNAME;
+    }
+    testDB.close();
+    return;
+}
+
+function testConnectorWithDataSourceClassWithoutURL () (string firstName) {
+    sql:ClientConnector testDB;
+    sql:ConnectionProperties properties = {dataSourceClassName:"org.hsqldb.jdbc.JDBCDataSource"};
+    testDB = create sql:ClientConnector(sql:HSQLDB_FILE, "./target/tempdb/", 0,
+                                                            "TEST_SQL_CONNECTOR", "SA", "", properties);
+
+    sql:Parameter[] parameters = [];
+    datatable dt = testDB.select("SELECT  FirstName from Customers where registrationID = 1", parameters);
+    TypeCastError err;
+    ResultCustomers rs;
+    while (datatables:hasNext(dt)) {
+        any dataStruct = datatables:getNext(dt);
+        rs, err = (ResultCustomers)dataStruct;
+        firstName = rs.FIRSTNAME;
+    }
+    testDB.close();
+    return;
+}
+
+function testConnectorWithDataSourceClassURLPriority () (string firstName) {
+    sql:ClientConnector testDB;
+    map propertiesMap = {"url":"jdbc:hsqldb:file:./target/tempdb/TEST_SQL_CONNECTOR"};
+    sql:ConnectionProperties properties = {dataSourceClassName:"org.hsqldb.jdbc.JDBCDataSource",
+                                              datasourceProperties:propertiesMap};
+    testDB = create sql:ClientConnector(sql:HSQLDB_FILE, "./target/tempdb/", 0,
+                                        "INVALID_DB_NAME", "SA", "", properties);
+
+    sql:Parameter[] parameters = [];
+    datatable dt = testDB.select("SELECT  FirstName from Customers where registrationID = 1", parameters);
+    TypeCastError err;
+    ResultCustomers rs;
+    while (datatables:hasNext(dt)) {
+        any dataStruct = datatables:getNext(dt);
+        rs, err = (ResultCustomers)dataStruct;
+        firstName = rs.FIRSTNAME;
+    }
+    testDB.close();
+    return;
+}
+
+function testInvalidDBType () (string firstName) {
+    sql:ClientConnector testDB = create sql:ClientConnector("TESTDB", "./target/tempdb/",
+                                                            0, "TEST_SQL_CONNECTOR", "SA", "", {maximumPoolSize:1});
+
+    sql:Parameter[] parameters = [];
+    testDB.update("Insert into Customers(firstName) values ('James')", parameters);
+    testDB.close();
     return;
 }


### PR DESCRIPTION
Fix for #3220, #3264, #3263, #3342, #3240 and #3280

With this PR following changes are included for the SQL Connector.

- **Add support for parameter arrays**(#3220). 
Arrays as parameter enables to dynamically provide a set of values without knowing the size of the data set beforehand. This will be used for SQL queries with IN Clause.

.Ex:
   ```java
    int[] dataArray = [1,4343];
    sql:Parameter para0 = {sqlType:"varchar", value:"John", direction:0};
    sql:Parameter para1 = {sqlType:"integer", value:dataArray, direction:0};
    sql:Parameter[] parameters = [para0,para1];
    datatable dt = testDB.select ("SELECT  FirstName from Customers where FirstName = ? or registrationID in(?)", parameters);
```

- **Allow struct, array and time types as input parameters**(#3264)
Ex:
```java
        struct customtype {
		int i;
		float j;
		string s;
	}
	//Array parameter
	int[] intArray = [1,3,4];
        sql:Parameter para1 = {sqlType:"array", value:intArray};
	//Timestamp parameter
	time:Time currentTime = time:currentTime();
	sql:Parameter para2 = {sqlType:"timestamp", value:currentTime};
	//Struct parameter
	customtype customStruct = {i : 10, j : 2.3, s : "test"};
        sql:Parameter para3 = {sqlType:"struct", value:customStruct};
        sql:Parameter[] parameters = [para1, para2, para3];

        insertCount = testDB.update ("INSERT INTO ArrayTypes (int_array, time_type,struct_data) values (?,?,?)", parameters);
```

- **Allow null for connector properties and input parameters**(#3263)

Ex :
```java
         //For Connector
	 sql:ClientConnector testDB = create sql:ClientConnector(sql:MYSQL, "localhost", 0, "TESTDB", "SA", "", null);
	 //For parameter
	 sql:Parameter paraID = {sqlType:"integer", value:10};
         sql:Parameter[] parameters = [paraID, null];
         int insertCount = testDB.update ("INSERT INTO DataTypeTable (row_id,int_type) values (?,?)", parameters);
        //Or
       int insertCount = testDB.update ("INSERT INTO DataTypeTable (row_id,int_type) values (1,100)", null);
```

- **Improvements on distributed transaction connector initialization.**
New property boolean "isXA" is added to sql:ConnectionProperties to provide easy initialization for known DBs.

```java
//For known DBs
sql:ConnectionProperties props = {isXA:true, maximumPoolSize:1};
sql:ClientConnector testDB = create sql:ClientConnector(sql:MYSQL, "localhost", 3306, "testdb", "root", "", props);
//For custom DB
map datasourceProps = {"loginTimeout":8,"url" :"jdbc:customdb://localhost:1234/testdb"};
sql:ConnectionProperties props = {dataSourceClassName:"com.customdb.jdbc..CustomDBXADataSource",datasourceProperties:datasourceProps, maximumPoolSize:1};
sql:ClientConnector testDB = create sql:ClientConnector("", "", 0, "", "root", "root", props);
```

- **Fix issue in distributed transaction failures with retry attempts** (#3280)

- **Fix connection closing issue when exception occurred in actions which returns a datatable (select, call)** (#3342)

- **Add return count support for failed batch updates** (#3240)