### PR TITLE
Improve ballerina Math API

### DIFF
--- a/modules/ballerina-builtin/src/main/ballerina/ballerina/lang/math/natives.bal
+++ b/modules/ballerina-builtin/src/main/ballerina/ballerina/lang/math/natives.bal
@@ -27,3 +27,201 @@ public native function randomInRange (int start, int end) (int);
 @doc:Param { value:"val: value to get square root" }
 @doc:Return { value:"float: square root value" }
 public native function sqrt (float val) (float);
+
+@doc:Description { value:"Returns the absolute value of a float value"}
+@doc:Param { value:"val: value to get absolute value" }
+@doc:Return { value:"float: absolute value" }
+public native function absFloat (float val) (float);
+
+@doc:Description { value:"Returns the absolute value of an int value"}
+@doc:Param { value:"val: value to get the absolute value" }
+@doc:Return { value:"int: absolute value" }
+public native function absInt (int val) (int);
+
+@doc:Description { value:"Returns the arc cosine of a value; the returned angle is in the range 0.0 through pi"}
+@doc:Param { value:"val: value to get the arc cosine" }
+@doc:Return { value:"float: arc cosine value" }
+public native function acos (float val) (float);
+
+@doc:Description { value:"Returns the arc sine of a value"}
+@doc:Param { value:"val: value to get the arc sine" }
+@doc:Return { value:"float: arc sine value" }
+public native function asin (float val) (float);
+
+@doc:Description { value:"Returns the arc tangent of a value"}
+@doc:Param { value:"val: value to get the arc tangent" }
+@doc:Return { value:"float: arc tangent value" }
+public native function atan (float val) (float);
+
+@doc:Description { value:"Returns the angle theta from the conversion of rectangular coordinates (a, b) to polar
+coordinates (r, theta)"}
+@doc:Param { value:"a: the ordinate coordinate" }
+@doc:Param { value:"b: the abscissa coordinate" }
+@doc:Return { value:"float: the result" }
+public native function atan2 (float a, float b) (float);
+
+@doc:Description { value:"Returns the cube root of a float value"}
+@doc:Param { value:"val: value to get the cube root" }
+@doc:Return { value:"float: cube root value" }
+public native function cbrt (float val) (float);
+
+@doc:Description { value:"Returns the smallest (closest to negative infinity) double value that is greater than or
+equal to the argument and is equal to a mathematical integer"}
+@doc:Param { value:"val: value to get the ceil" }
+@doc:Return { value:"float: the result" }
+public native function ceil (float val) (float);
+
+@doc:Description { value:"Returns the first floating-point argument with the sign of the second floating-point
+argument"}
+@doc:Param { value:"magnitude: the parameter providing the magnitude of the result" }
+@doc:Param { value:"sign: the parameter providing the sign of the result" }
+@doc:Return { value:"float: the result" }
+public native function copySign (float a, float b) (float);
+
+@doc:Description { value:"Returns the trigonometric cosine of an angle"}
+@doc:Param { value:"val: value to get the trigonometric cosine" }
+@doc:Return { value:"float: the result" }
+public native function cos (float val) (float);
+
+@doc:Description { value:"Returns the hyperbolic cosine of a float value"}
+@doc:Param { value:"val: The number whose hyperbolic cosine is to be returned" }
+@doc:Return { value:"float: The hyperbolic cosine of given float value" }
+public native function cosh (float val) (float);
+
+@doc:Description { value:"Returns (e to the power of x) -1"}
+@doc:Param { value:"val: The exponent to raise e to in the computation" }
+@doc:Return { value:"float: the result" }
+public native function expm1 (float val) (float);
+
+@doc:Description { value:"Returns the largest (closest to positive infinity) float value that is less than or equal
+to the argument and is equal to a mathematical integer"}
+@doc:Param { value:"val: a float value" }
+@doc:Return { value:"float: the result" }
+public native function floor (float val) (float);
+
+@doc:Description { value:"Returns the largest (closest to positive infinity) int value that is less than or equal
+to the algebraic quotient"}
+@doc:Param { value:"a: the dividend" }
+@doc:Param { value:"b: the divisor" }
+@doc:Return { value:"int: the result" }
+public native function floorDiv (int a, int b) (int);
+
+@doc:Description { value:"Returns the floor modulus of the long arguments"}
+@doc:Param { value:"a: the dividend" }
+@doc:Param { value:"b: the divisor" }
+@doc:Return { value:"int: the result" }
+public native function floorMod (int a, int b) (int);
+
+@doc:Description { value:"Returns the unbiased exponent used in the representation of a float"}
+@doc:Param { value:"val: float value" }
+@doc:Return { value:"int: the unbiased exponent of the argument" }
+public native function getExponent (float val) (int);
+
+@doc:Description { value:"Returns sqrt(a squared +b squared) without intermediate overflow or underflow"}
+@doc:Param { value:"a: float value" }
+@doc:Param { value:"b: float value" }
+@doc:Return { value:"float: the result" }
+public native function hypot (float a, float b) (float);
+
+@doc:Description { value:"Computes the remainder operation on two arguments as prescribed by the IEEE 754 standard"}
+@doc:Param { value:"a: the dividend" }
+@doc:Param { value:"b: the divisor" }
+@doc:Return { value:"float: the remainder when a is divided by b" }
+public native function IEEEremainder (float a, float b) (float);
+
+@doc:Description { value:"Returns the natural logarithm (base e) of a float value"}
+@doc:Param { value:"val: a float value" }
+@doc:Return { value:"float: the result" }
+public native function log (float val) (float);
+
+@doc:Description { value:"Returns the base 10 logarithm of a float value"}
+@doc:Param { value:"val: a float value" }
+@doc:Return { value:"float: the base 10 logarithm of a given float value" }
+public native function log10 (float val) (float);
+
+@doc:Description { value:"Returns the natural logarithm of the sum of the argument and 1"}
+@doc:Param { value:"val: a float value" }
+@doc:Return { value:"float: the natural log of x + 1" }
+public native function log1p (float val) (float);
+
+@doc:Description { value:"Returns the negation of the argument"}
+@doc:Param { value:"val: the value to negate" }
+@doc:Return { value:"int: the result" }
+public native function negateExact (int val) (int);
+
+@doc:Description { value:"Returns the floating-point number adjacent to the first argument in the direction of the
+second argument"}
+@doc:Param { value:"a: starting floating-point value" }
+@doc:Param { value:"b: value indicating which of start's neighbors or start should be returned" }
+@doc:Return { value:"float: the result" }
+public native function nextAfter (float a, float b) (float);
+
+@doc:Description { value:"Returns the adjacent floating-point value closer to negative infinity"}
+@doc:Param { value:"val: starting floating-point value" }
+@doc:Return { value:"float: the result" }
+public native function nextDown (float val) (float);
+
+@doc:Description { value:"Returns the adjacent floating-point value closer to positive infinity"}
+@doc:Param { value:"val: starting floating-point value" }
+@doc:Return { value:"float: the result" }
+public native function nextUp (float val) (float);
+
+@doc:Description { value:"Returns the double value that is closest in value to the argument and is equal to a
+mathematical integer"}
+@doc:Param { value:"val: a float value" }
+@doc:Return { value:"float: the result" }
+public native function rint (float val) (float);
+
+@doc:Description { value:"Returns the closest int to the argument, with ties rounding to positive infinity"}
+@doc:Param { value:"val: a floating-point value to be rounded to an integer" }
+@doc:Return { value:"int: the value of the argument rounded to the nearest int value" }
+public native function round (float val) (int);
+
+@doc:Description { value:"Returns a × (2 to the power of scaleFactor) rounded as if performed by a single correctly
+rounded floating-point  multiply to a member of the float value set"}
+@doc:Param { value:"a: number to be scaled by a power of two" }
+@doc:Param { value:"scaleFactor: power of 2 used to scale a" }
+@doc:Return { value:"float: the result" }
+public native function scalb (float a, int b) (float);
+
+@doc:Description { value:"Returns the signum function of the argument"}
+@doc:Param { value:"val: the floating-point value whose signum is to be returned" }
+@doc:Return { value:"float: the signum function of the argument" }
+public native function signum (float val) (float);
+
+@doc:Description { value:"Returns the trigonometric sine of an angle"}
+@doc:Param { value:"val: an angle, in radians" }
+@doc:Return { value:"float: the sine of the argument" }
+public native function sin (float val) (float);
+
+@doc:Description { value:"Returns the hyperbolic sine of a float value"}
+@doc:Param { value:"val: the number whose hyperbolic sine is to be returned" }
+@doc:Return { value:"float: the hyperbolic sine of a given float" }
+public native function sinh (float val) (float);
+
+@doc:Description { value:"Returns the trigonometric tangent of an angle"}
+@doc:Param { value:"val: an angle, in radians" }
+@doc:Return { value:"float: the tangent of the argument" }
+public native function tan (float val) (float);
+
+@doc:Description { value:"Returns the hyperbolic tangent of a double value"}
+@doc:Param { value:"val: the number whose hyperbolic tangent is to be returned" }
+@doc:Return { value:"float: the hyperbolic tangent of x" }
+public native function tanh (float val) (float);
+
+@doc:Description { value:"Converts an angle measured in radians to an approximately equivalent angle measured in
+degrees"}
+@doc:Param { value:"val: an angle, in radians" }
+@doc:Return { value:"float: the measurement of the angle angrad in degrees" }
+public native function toDegrees (float val) (float);
+
+@doc:Description { value:"Converts an angle measured in degrees to an approximately equivalent angle measured in
+radians"}
+@doc:Param { value:"val: an angle, in degrees" }
+@doc:Return { value:"float: the measurement of the angle angdeg in radians" }
+public native function toRadians (float val) (float);
+
+@doc:Description { value:"Returns the size of an ulp of the argument"}
+@doc:Param { value:"val: the floating-point value whose ulp is to be returned" }
+@doc:Return { value:"float: the size of an ulp of the argument" }
+public native function ulp (float val) (float);

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/AbsFloat.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/AbsFloat.java
@@ -1,0 +1,47 @@
+/*
+*   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.ballerinalang.nativeimpl.lang.math;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BFloat;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+/**
+ * Native function ballerina.lang.math:absFloat.
+ *
+ * @since 0.95
+ */
+@BallerinaFunction(
+        packageName = "ballerina.lang.math",
+        functionName = "absFloat",
+        args = {@Argument(name = "val", type = TypeKind.FLOAT)},
+        returnType = {@ReturnType(type = TypeKind.FLOAT)},
+        isPublic = true
+)
+public class AbsFloat extends AbstractNativeFunction {
+
+    public BValue[] execute(Context ctx) {
+        double value = getFloatArgument(ctx, 0);
+        return getBValues(new BFloat(Math.abs(value)));
+    }
+}

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/AbsInt.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/AbsInt.java
@@ -1,0 +1,47 @@
+/*
+*   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.ballerinalang.nativeimpl.lang.math;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BInteger;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+/**
+ * Native function ballerina.lang.math:absInt.
+ *
+ * @since 0.95
+ */
+@BallerinaFunction(
+        packageName = "ballerina.lang.math",
+        functionName = "absInt",
+        args = {@Argument(name = "val", type = TypeKind.INT)},
+        returnType = {@ReturnType(type = TypeKind.INT)},
+        isPublic = true
+)
+public class AbsInt extends AbstractNativeFunction {
+
+    public BValue[] execute(Context ctx) {
+        long value = getIntArgument(ctx, 0);
+        return getBValues(new BInteger(Math.abs(value)));
+    }
+}

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Acos.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Acos.java
@@ -1,0 +1,47 @@
+/*
+*   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.ballerinalang.nativeimpl.lang.math;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BFloat;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+/**
+ * Native function ballerina.lang.math:acos.
+ *
+ * @since 0.95
+ */
+@BallerinaFunction(
+        packageName = "ballerina.lang.math",
+        functionName = "acos",
+        args = {@Argument(name = "val", type = TypeKind.FLOAT)},
+        returnType = {@ReturnType(type = TypeKind.FLOAT)},
+        isPublic = true
+)
+public class Acos extends AbstractNativeFunction {
+
+    public BValue[] execute(Context ctx) {
+        double value = getFloatArgument(ctx, 0);
+        return getBValues(new BFloat(Math.acos(value)));
+    }
+}

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Asin.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Asin.java
@@ -1,0 +1,47 @@
+/*
+*   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.ballerinalang.nativeimpl.lang.math;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BFloat;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+/**
+ * Native function ballerina.lang.math:asin.
+ *
+ * @since 0.95
+ */
+@BallerinaFunction(
+        packageName = "ballerina.lang.math",
+        functionName = "asin",
+        args = {@Argument(name = "val", type = TypeKind.FLOAT)},
+        returnType = {@ReturnType(type = TypeKind.FLOAT)},
+        isPublic = true
+)
+public class Asin extends AbstractNativeFunction {
+
+    public BValue[] execute(Context ctx) {
+        double value = getFloatArgument(ctx, 0);
+        return getBValues(new BFloat(Math.asin(value)));
+    }
+}

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Atan.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Atan.java
@@ -1,0 +1,47 @@
+/*
+*   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.ballerinalang.nativeimpl.lang.math;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BFloat;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+/**
+ * Native function ballerina.lang.math:atan.
+ *
+ * @since 0.95
+ */
+@BallerinaFunction(
+        packageName = "ballerina.lang.math",
+        functionName = "atan",
+        args = {@Argument(name = "val", type = TypeKind.FLOAT)},
+        returnType = {@ReturnType(type = TypeKind.FLOAT)},
+        isPublic = true
+)
+public class Atan extends AbstractNativeFunction {
+
+    public BValue[] execute(Context ctx) {
+        double value = getFloatArgument(ctx, 0);
+        return getBValues(new BFloat(Math.atan(value)));
+    }
+}

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Atan2.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Atan2.java
@@ -1,0 +1,49 @@
+/*
+*   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.ballerinalang.nativeimpl.lang.math;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BFloat;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+/**
+ * Native function ballerina.lang.math:atan2.
+ *
+ * @since 0.95
+ */
+@BallerinaFunction(
+        packageName = "ballerina.lang.math",
+        functionName = "atan2",
+        args = {@Argument(name = "a", type = TypeKind.FLOAT),
+                @Argument(name = "b", type = TypeKind.FLOAT)},
+        returnType = {@ReturnType(type = TypeKind.FLOAT)},
+        isPublic = true
+)
+public class Atan2 extends AbstractNativeFunction {
+
+    public BValue[] execute(Context ctx) {
+        double a = getFloatArgument(ctx, 0);
+        double b = getFloatArgument(ctx, 1);
+        return getBValues(new BFloat(Math.atan2(a, b)));
+    }
+}

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Cbrt.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Cbrt.java
@@ -1,0 +1,47 @@
+/*
+*   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.ballerinalang.nativeimpl.lang.math;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BFloat;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+/**
+ * Native function ballerina.lang.math:cbrt.
+ *
+ * @since 0.95
+ */
+@BallerinaFunction(
+        packageName = "ballerina.lang.math",
+        functionName = "cbrt",
+        args = {@Argument(name = "val", type = TypeKind.FLOAT)},
+        returnType = {@ReturnType(type = TypeKind.FLOAT)},
+        isPublic = true
+)
+public class Cbrt extends AbstractNativeFunction {
+
+    public BValue[] execute(Context ctx) {
+        double value = getFloatArgument(ctx, 0);
+        return getBValues(new BFloat(Math.cbrt(value)));
+    }
+}

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Ceil.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Ceil.java
@@ -1,0 +1,47 @@
+/*
+*   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.ballerinalang.nativeimpl.lang.math;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BFloat;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+/**
+ * Native function ballerina.lang.math:ceil.
+ *
+ * @since 0.95
+ */
+@BallerinaFunction(
+        packageName = "ballerina.lang.math",
+        functionName = "ceil",
+        args = {@Argument(name = "val", type = TypeKind.FLOAT)},
+        returnType = {@ReturnType(type = TypeKind.FLOAT)},
+        isPublic = true
+)
+public class Ceil extends AbstractNativeFunction {
+
+    public BValue[] execute(Context ctx) {
+        double value = getFloatArgument(ctx, 0);
+        return getBValues(new BFloat(Math.ceil(value)));
+    }
+}

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/CopySign.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/CopySign.java
@@ -1,0 +1,49 @@
+/*
+*   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.ballerinalang.nativeimpl.lang.math;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BFloat;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+/**
+ * Native function ballerina.lang.math:copySign.
+ *
+ * @since 0.95
+ */
+@BallerinaFunction(
+        packageName = "ballerina.lang.math",
+        functionName = "copySign",
+        args = {@Argument(name = "magnitude", type = TypeKind.FLOAT),
+                @Argument(name = "sign", type = TypeKind.FLOAT)},
+        returnType = {@ReturnType(type = TypeKind.FLOAT)},
+        isPublic = true
+)
+public class CopySign extends AbstractNativeFunction {
+
+    public BValue[] execute(Context ctx) {
+        double a = getFloatArgument(ctx, 0);
+        double b = getFloatArgument(ctx, 1);
+        return getBValues(new BFloat(Math.copySign(a, b)));
+    }
+}

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Cos.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Cos.java
@@ -1,0 +1,47 @@
+/*
+*   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.ballerinalang.nativeimpl.lang.math;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BFloat;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+/**
+ * Native function ballerina.lang.math:cos.
+ *
+ * @since 0.95
+ */
+@BallerinaFunction(
+        packageName = "ballerina.lang.math",
+        functionName = "cos",
+        args = {@Argument(name = "val", type = TypeKind.FLOAT)},
+        returnType = {@ReturnType(type = TypeKind.FLOAT)},
+        isPublic = true
+)
+public class Cos extends AbstractNativeFunction {
+
+    public BValue[] execute(Context ctx) {
+        double value = getFloatArgument(ctx, 0);
+        return getBValues(new BFloat(Math.cos(value)));
+    }
+}

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Cosh.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Cosh.java
@@ -1,0 +1,47 @@
+/*
+*   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.ballerinalang.nativeimpl.lang.math;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BFloat;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+/**
+ * Native function ballerina.lang.math:cosh.
+ *
+ * @since 0.95
+ */
+@BallerinaFunction(
+        packageName = "ballerina.lang.math",
+        functionName = "cosh",
+        args = {@Argument(name = "val", type = TypeKind.FLOAT)},
+        returnType = {@ReturnType(type = TypeKind.FLOAT)},
+        isPublic = true
+)
+public class Cosh extends AbstractNativeFunction {
+
+    public BValue[] execute(Context ctx) {
+        double value = getFloatArgument(ctx, 0);
+        return getBValues(new BFloat(Math.cosh(value)));
+    }
+}

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Expm1.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Expm1.java
@@ -1,0 +1,47 @@
+/*
+*   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.ballerinalang.nativeimpl.lang.math;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BFloat;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+/**
+ * Native function ballerina.lang.math:expm1.
+ *
+ * @since 0.95
+ */
+@BallerinaFunction(
+        packageName = "ballerina.lang.math",
+        functionName = "expm1",
+        args = {@Argument(name = "val", type = TypeKind.FLOAT)},
+        returnType = {@ReturnType(type = TypeKind.FLOAT)},
+        isPublic = true
+)
+public class Expm1 extends AbstractNativeFunction {
+
+    public BValue[] execute(Context ctx) {
+        double value = getFloatArgument(ctx, 0);
+        return getBValues(new BFloat(Math.expm1(value)));
+    }
+}

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Exponent.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Exponent.java
@@ -1,0 +1,47 @@
+/*
+*   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.ballerinalang.nativeimpl.lang.math;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BInteger;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+/**
+ * Native function ballerina.lang.math:getExponent.
+ *
+ * @since 0.95
+ */
+@BallerinaFunction(
+        packageName = "ballerina.lang.math",
+        functionName = "getExponent",
+        args = {@Argument(name = "val", type = TypeKind.FLOAT)},
+        returnType = {@ReturnType(type = TypeKind.INT)},
+        isPublic = true
+)
+public class Exponent extends AbstractNativeFunction {
+
+    public BValue[] execute(Context ctx) {
+        double value = getFloatArgument(ctx, 0);
+        return getBValues(new BInteger(Math.getExponent(value)));
+    }
+}

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Floor.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Floor.java
@@ -1,0 +1,47 @@
+/*
+*   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.ballerinalang.nativeimpl.lang.math;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BFloat;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+/**
+ * Native function ballerina.lang.math:floor.
+ *
+ * @since 0.95
+ */
+@BallerinaFunction(
+        packageName = "ballerina.lang.math",
+        functionName = "floor",
+        args = {@Argument(name = "val", type = TypeKind.FLOAT)},
+        returnType = {@ReturnType(type = TypeKind.FLOAT)},
+        isPublic = true
+)
+public class Floor extends AbstractNativeFunction {
+
+    public BValue[] execute(Context ctx) {
+        double value = getFloatArgument(ctx, 0);
+        return getBValues(new BFloat(Math.floor(value)));
+    }
+}

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/FloorDiv.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/FloorDiv.java
@@ -1,0 +1,49 @@
+/*
+*   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.ballerinalang.nativeimpl.lang.math;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BInteger;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+/**
+ * Native function ballerina.lang.math:floorDiv.
+ *
+ * @since 0.95
+ */
+@BallerinaFunction(
+        packageName = "ballerina.lang.math",
+        functionName = "floorDiv",
+        args = {@Argument(name = "a", type = TypeKind.INT),
+                @Argument(name = "b", type = TypeKind.INT)},
+        returnType = {@ReturnType(type = TypeKind.INT)},
+        isPublic = true
+)
+public class FloorDiv extends AbstractNativeFunction {
+
+    public BValue[] execute(Context ctx) {
+        long a = getIntArgument(ctx, 0);
+        long b = getIntArgument(ctx, 1);
+        return getBValues(new BInteger(Math.floorDiv(a, b)));
+    }
+}

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/FloorMod.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/FloorMod.java
@@ -1,0 +1,49 @@
+/*
+*   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.ballerinalang.nativeimpl.lang.math;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BInteger;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+/**
+ * Native function ballerina.lang.math:floorMod.
+ *
+ * @since 0.95
+ */
+@BallerinaFunction(
+        packageName = "ballerina.lang.math",
+        functionName = "floorMod",
+        args = {@Argument(name = "a", type = TypeKind.INT),
+                @Argument(name = "b", type = TypeKind.INT)},
+        returnType = {@ReturnType(type = TypeKind.INT)},
+        isPublic = true
+)
+public class FloorMod extends AbstractNativeFunction {
+
+    public BValue[] execute(Context ctx) {
+        long a = getIntArgument(ctx, 0);
+        long b = getIntArgument(ctx, 1);
+        return getBValues(new BInteger(Math.floorMod(a, b)));
+    }
+}

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Hypot.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Hypot.java
@@ -1,0 +1,49 @@
+/*
+*   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.ballerinalang.nativeimpl.lang.math;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BFloat;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+/**
+ * Native function ballerina.lang.math:hypot.
+ *
+ * @since 0.95
+ */
+@BallerinaFunction(
+        packageName = "ballerina.lang.math",
+        functionName = "hypot",
+        args = {@Argument(name = "a", type = TypeKind.FLOAT),
+                @Argument(name = "b", type = TypeKind.FLOAT)},
+        returnType = {@ReturnType(type = TypeKind.FLOAT)},
+        isPublic = true
+)
+public class Hypot extends AbstractNativeFunction {
+
+    public BValue[] execute(Context ctx) {
+        double a = getFloatArgument(ctx, 0);
+        double b = getFloatArgument(ctx, 1);
+        return getBValues(new BFloat(Math.hypot(a, b)));
+    }
+}

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/IEEERemainder.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/IEEERemainder.java
@@ -1,0 +1,49 @@
+/*
+*   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.ballerinalang.nativeimpl.lang.math;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BFloat;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+/**
+ * Native function ballerina.lang.math:IEEEremainder.
+ *
+ * @since 0.95
+ */
+@BallerinaFunction(
+        packageName = "ballerina.lang.math",
+        functionName = "IEEEremainder",
+        args = {@Argument(name = "a", type = TypeKind.FLOAT),
+                @Argument(name = "b", type = TypeKind.FLOAT)},
+        returnType = {@ReturnType(type = TypeKind.FLOAT)},
+        isPublic = true
+)
+public class IEEERemainder extends AbstractNativeFunction {
+
+    public BValue[] execute(Context ctx) {
+        double a = getFloatArgument(ctx, 0);
+        double b = getFloatArgument(ctx, 1);
+        return getBValues(new BFloat(Math.IEEEremainder(a, b)));
+    }
+}

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Log.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Log.java
@@ -1,0 +1,47 @@
+/*
+*   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.ballerinalang.nativeimpl.lang.math;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BFloat;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+/**
+ * Native function ballerina.lang.math:log.
+ *
+ * @since 0.95
+ */
+@BallerinaFunction(
+        packageName = "ballerina.lang.math",
+        functionName = "log",
+        args = {@Argument(name = "val", type = TypeKind.FLOAT)},
+        returnType = {@ReturnType(type = TypeKind.FLOAT)},
+        isPublic = true
+)
+public class Log extends AbstractNativeFunction {
+
+    public BValue[] execute(Context ctx) {
+        double value = getFloatArgument(ctx, 0);
+        return getBValues(new BFloat(Math.log(value)));
+    }
+}

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Log10.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Log10.java
@@ -1,0 +1,47 @@
+/*
+*   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.ballerinalang.nativeimpl.lang.math;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BFloat;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+/**
+ * Native function ballerina.lang.math:log10.
+ *
+ * @since 0.95
+ */
+@BallerinaFunction(
+        packageName = "ballerina.lang.math",
+        functionName = "log10",
+        args = {@Argument(name = "val", type = TypeKind.FLOAT)},
+        returnType = {@ReturnType(type = TypeKind.FLOAT)},
+        isPublic = true
+)
+public class Log10 extends AbstractNativeFunction {
+
+    public BValue[] execute(Context ctx) {
+        double value = getFloatArgument(ctx, 0);
+        return getBValues(new BFloat(Math.log10(value)));
+    }
+}

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Log1p.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Log1p.java
@@ -1,0 +1,47 @@
+/*
+*   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.ballerinalang.nativeimpl.lang.math;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BFloat;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+/**
+ * Native function ballerina.lang.math:log1p.
+ *
+ * @since 0.95
+ */
+@BallerinaFunction(
+        packageName = "ballerina.lang.math",
+        functionName = "log1p",
+        args = {@Argument(name = "val", type = TypeKind.FLOAT)},
+        returnType = {@ReturnType(type = TypeKind.FLOAT)},
+        isPublic = true
+)
+public class Log1p extends AbstractNativeFunction {
+
+    public BValue[] execute(Context ctx) {
+        double value = getFloatArgument(ctx, 0);
+        return getBValues(new BFloat(Math.log1p(value)));
+    }
+}

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/NegateExact.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/NegateExact.java
@@ -1,0 +1,47 @@
+/*
+*   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.ballerinalang.nativeimpl.lang.math;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BInteger;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+/**
+ * Native function ballerina.lang.math:negateExact.
+ *
+ * @since 0.95
+ */
+@BallerinaFunction(
+        packageName = "ballerina.lang.math",
+        functionName = "negateExact",
+        args = {@Argument(name = "val", type = TypeKind.INT)},
+        returnType = {@ReturnType(type = TypeKind.INT)},
+        isPublic = true
+)
+public class NegateExact extends AbstractNativeFunction {
+
+    public BValue[] execute(Context ctx) {
+        long value = getIntArgument(ctx, 0);
+        return getBValues(new BInteger(Math.negateExact(value)));
+    }
+}

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/NextAfter.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/NextAfter.java
@@ -1,0 +1,49 @@
+/*
+*   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.ballerinalang.nativeimpl.lang.math;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BFloat;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+/**
+ * Native function ballerina.lang.math:nextAfter.
+ *
+ * @since 0.95
+ */
+@BallerinaFunction(
+        packageName = "ballerina.lang.math",
+        functionName = "nextAfter",
+        args = {@Argument(name = "a", type = TypeKind.FLOAT),
+                @Argument(name = "b", type = TypeKind.FLOAT)},
+        returnType = {@ReturnType(type = TypeKind.FLOAT)},
+        isPublic = true
+)
+public class NextAfter extends AbstractNativeFunction {
+
+    public BValue[] execute(Context ctx) {
+        double a = getFloatArgument(ctx, 0);
+        double b = getFloatArgument(ctx, 1);
+        return getBValues(new BFloat(Math.nextAfter(a, b)));
+    }
+}

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/NextDown.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/NextDown.java
@@ -1,0 +1,47 @@
+/*
+*   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.ballerinalang.nativeimpl.lang.math;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BFloat;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+/**
+ * Native function ballerina.lang.math:nextDown.
+ *
+ * @since 0.95
+ */
+@BallerinaFunction(
+        packageName = "ballerina.lang.math",
+        functionName = "nextDown",
+        args = {@Argument(name = "val", type = TypeKind.FLOAT)},
+        returnType = {@ReturnType(type = TypeKind.FLOAT)},
+        isPublic = true
+)
+public class NextDown extends AbstractNativeFunction {
+
+    public BValue[] execute(Context ctx) {
+        double value = getFloatArgument(ctx, 0);
+        return getBValues(new BFloat(Math.nextDown(value)));
+    }
+}

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/NextUp.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/NextUp.java
@@ -1,0 +1,47 @@
+/*
+*   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.ballerinalang.nativeimpl.lang.math;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BFloat;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+/**
+ * Native function ballerina.lang.math:nextUp.
+ *
+ * @since 0.95
+ */
+@BallerinaFunction(
+        packageName = "ballerina.lang.math",
+        functionName = "nextUp",
+        args = {@Argument(name = "val", type = TypeKind.FLOAT)},
+        returnType = {@ReturnType(type = TypeKind.FLOAT)},
+        isPublic = true
+)
+public class NextUp extends AbstractNativeFunction {
+
+    public BValue[] execute(Context ctx) {
+        double value = getFloatArgument(ctx, 0);
+        return getBValues(new BFloat(Math.nextUp(value)));
+    }
+}

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Rint.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Rint.java
@@ -1,0 +1,47 @@
+/*
+*   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.ballerinalang.nativeimpl.lang.math;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BFloat;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+/**
+ * Native function ballerina.lang.math:rint.
+ *
+ * @since 0.95
+ */
+@BallerinaFunction(
+        packageName = "ballerina.lang.math",
+        functionName = "rint",
+        args = {@Argument(name = "val", type = TypeKind.FLOAT)},
+        returnType = {@ReturnType(type = TypeKind.FLOAT)},
+        isPublic = true
+)
+public class Rint extends AbstractNativeFunction {
+
+    public BValue[] execute(Context ctx) {
+        double value = getFloatArgument(ctx, 0);
+        return getBValues(new BFloat(Math.rint(value)));
+    }
+}

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Round.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Round.java
@@ -1,0 +1,47 @@
+/*
+*   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.ballerinalang.nativeimpl.lang.math;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BInteger;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+/**
+ * Native function ballerina.lang.math:round.
+ *
+ * @since 0.95
+ */
+@BallerinaFunction(
+        packageName = "ballerina.lang.math",
+        functionName = "round",
+        args = {@Argument(name = "val", type = TypeKind.FLOAT)},
+        returnType = {@ReturnType(type = TypeKind.INT)},
+        isPublic = true
+)
+public class Round extends AbstractNativeFunction {
+
+    public BValue[] execute(Context ctx) {
+        double value = getFloatArgument(ctx, 0);
+        return getBValues(new BInteger(Math.round(value)));
+    }
+}

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Scalb.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Scalb.java
@@ -1,0 +1,50 @@
+/*
+*   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.ballerinalang.nativeimpl.lang.math;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BFloat;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+/**
+ * Native function ballerina.lang.math:scalb.
+ *
+ * @since 0.95
+ */
+@BallerinaFunction(
+        packageName = "ballerina.lang.math",
+        functionName = "scalb",
+        args = {@Argument(name = "a", type = TypeKind.FLOAT),
+                @Argument(name = "scaleFactor", type = TypeKind.INT)},
+        returnType = {@ReturnType(type = TypeKind.FLOAT)},
+        isPublic = true
+)
+public class Scalb extends AbstractNativeFunction {
+
+    public BValue[] execute(Context ctx) {
+        double a = getFloatArgument(ctx, 0);
+        long b = getIntArgument(ctx, 0);
+        int intVal = ((Long) b).intValue();
+        return getBValues(new BFloat(Math.scalb(a, intVal)));
+    }
+}

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Signum.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Signum.java
@@ -1,0 +1,47 @@
+/*
+*   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.ballerinalang.nativeimpl.lang.math;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BFloat;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+/**
+ * Native function ballerina.lang.math:signum.
+ *
+ * @since 0.95
+ */
+@BallerinaFunction(
+        packageName = "ballerina.lang.math",
+        functionName = "signum",
+        args = {@Argument(name = "val", type = TypeKind.FLOAT)},
+        returnType = {@ReturnType(type = TypeKind.FLOAT)},
+        isPublic = true
+)
+public class Signum extends AbstractNativeFunction {
+
+    public BValue[] execute(Context ctx) {
+        double value = getFloatArgument(ctx, 0);
+        return getBValues(new BFloat(Math.signum(value)));
+    }
+}

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Sin.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Sin.java
@@ -1,0 +1,47 @@
+/*
+*   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.ballerinalang.nativeimpl.lang.math;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BFloat;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+/**
+ * Native function ballerina.lang.math:sin.
+ *
+ * @since 0.95
+ */
+@BallerinaFunction(
+        packageName = "ballerina.lang.math",
+        functionName = "sin",
+        args = {@Argument(name = "val", type = TypeKind.FLOAT)},
+        returnType = {@ReturnType(type = TypeKind.FLOAT)},
+        isPublic = true
+)
+public class Sin extends AbstractNativeFunction {
+
+    public BValue[] execute(Context ctx) {
+        double value = getFloatArgument(ctx, 0);
+        return getBValues(new BFloat(Math.sin(value)));
+    }
+}

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Sinh.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Sinh.java
@@ -1,0 +1,47 @@
+/*
+*   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.ballerinalang.nativeimpl.lang.math;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BFloat;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+/**
+ * Native function ballerina.lang.math:sinh.
+ *
+ * @since 0.95
+ */
+@BallerinaFunction(
+        packageName = "ballerina.lang.math",
+        functionName = "sinh",
+        args = {@Argument(name = "val", type = TypeKind.FLOAT)},
+        returnType = {@ReturnType(type = TypeKind.FLOAT)},
+        isPublic = true
+)
+public class Sinh extends AbstractNativeFunction {
+
+    public BValue[] execute(Context ctx) {
+        double value = getFloatArgument(ctx, 0);
+        return getBValues(new BFloat(Math.sinh(value)));
+    }
+}

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Tan.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Tan.java
@@ -1,0 +1,47 @@
+/*
+*   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.ballerinalang.nativeimpl.lang.math;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BFloat;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+/**
+ * Native function ballerina.lang.math:tan.
+ *
+ * @since 0.95
+ */
+@BallerinaFunction(
+        packageName = "ballerina.lang.math",
+        functionName = "tan",
+        args = {@Argument(name = "val", type = TypeKind.FLOAT)},
+        returnType = {@ReturnType(type = TypeKind.FLOAT)},
+        isPublic = true
+)
+public class Tan extends AbstractNativeFunction {
+
+    public BValue[] execute(Context ctx) {
+        double value = getFloatArgument(ctx, 0);
+        return getBValues(new BFloat(Math.tan(value)));
+    }
+}

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Tanh.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Tanh.java
@@ -1,0 +1,47 @@
+/*
+*   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.ballerinalang.nativeimpl.lang.math;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BFloat;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+/**
+ * Native function ballerina.lang.math:tanh.
+ *
+ * @since 0.95
+ */
+@BallerinaFunction(
+        packageName = "ballerina.lang.math",
+        functionName = "tanh",
+        args = {@Argument(name = "val", type = TypeKind.FLOAT)},
+        returnType = {@ReturnType(type = TypeKind.FLOAT)},
+        isPublic = true
+)
+public class Tanh extends AbstractNativeFunction {
+
+    public BValue[] execute(Context ctx) {
+        double value = getFloatArgument(ctx, 0);
+        return getBValues(new BFloat(Math.tanh(value)));
+    }
+}

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/ToDegrees.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/ToDegrees.java
@@ -1,0 +1,47 @@
+/*
+*   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.ballerinalang.nativeimpl.lang.math;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BFloat;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+/**
+ * Native function ballerina.lang.math:toDegrees.
+ *
+ * @since 0.95
+ */
+@BallerinaFunction(
+        packageName = "ballerina.lang.math",
+        functionName = "toDegrees",
+        args = {@Argument(name = "val", type = TypeKind.FLOAT)},
+        returnType = {@ReturnType(type = TypeKind.FLOAT)},
+        isPublic = true
+)
+public class ToDegrees extends AbstractNativeFunction {
+
+    public BValue[] execute(Context ctx) {
+        double value = getFloatArgument(ctx, 0);
+        return getBValues(new BFloat(Math.toDegrees(value)));
+    }
+}

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/ToRadians.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/ToRadians.java
@@ -1,0 +1,47 @@
+/*
+*   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.ballerinalang.nativeimpl.lang.math;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BFloat;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+/**
+ * Native function ballerina.lang.math:toRadians.
+ *
+ * @since 0.95
+ */
+@BallerinaFunction(
+        packageName = "ballerina.lang.math",
+        functionName = "toRadians",
+        args = {@Argument(name = "val", type = TypeKind.FLOAT)},
+        returnType = {@ReturnType(type = TypeKind.FLOAT)},
+        isPublic = true
+)
+public class ToRadians extends AbstractNativeFunction {
+
+    public BValue[] execute(Context ctx) {
+        double value = getFloatArgument(ctx, 0);
+        return getBValues(new BFloat(Math.toRadians(value)));
+    }
+}

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Ulp.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/lang/math/Ulp.java
@@ -1,0 +1,47 @@
+/*
+*   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.ballerinalang.nativeimpl.lang.math;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BFloat;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+/**
+ * Native function ballerina.lang.math:ulp.
+ *
+ * @since 0.95
+ */
+@BallerinaFunction(
+        packageName = "ballerina.lang.math",
+        functionName = "ulp",
+        args = {@Argument(name = "val", type = TypeKind.FLOAT)},
+        returnType = {@ReturnType(type = TypeKind.FLOAT)},
+        isPublic = true
+)
+public class Ulp extends AbstractNativeFunction {
+
+    public BValue[] execute(Context ctx) {
+        double value = getFloatArgument(ctx, 0);
+        return getBValues(new BFloat(Math.ulp(value)));
+    }
+}

--- a/modules/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/MathTest.java
+++ b/modules/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/MathTest.java
@@ -34,7 +34,7 @@ import org.testng.annotations.Test;
 public class MathTest {
 
     private CompileResult compileResult;
-    private static final double DELTA = 0.01;
+    private static final double DELTA = 0.0000000001;
 
     @BeforeClass
     public void setup() {
@@ -43,7 +43,7 @@ public class MathTest {
 
     @Test(description = "Test 'exp' function in ballerina.lang.math package")
     public void testMathExp() {
-        BValue[] args = {new BFloat(5.0)};
+        BValue[] args = { new BFloat(5.0) };
         BValue[] returns = BTestUtils.invoke(compileResult, "expTest", args);
 
         Assert.assertEquals(returns.length, 1);
@@ -52,7 +52,7 @@ public class MathTest {
 
     @Test(description = "Test 'pow' function in ballerina.lang.math package")
     public void testMathPow() {
-        BValue[] args = {new BFloat(5.0), new BFloat(5.0)};
+        BValue[] args = { new BFloat(5.0), new BFloat(5.0) };
         BValue[] returns = BTestUtils.invoke(compileResult, "powTest", args);
 
         Assert.assertEquals(returns.length, 1);
@@ -70,7 +70,7 @@ public class MathTest {
 
     @Test(description = "Test 'sqrt' function in ballerina.lang.math package")
     public void testMathSqrt() {
-        BValue[] args = {new BFloat(25.0)};
+        BValue[] args = { new BFloat(25.0) };
         BValue[] returns = BTestUtils.invoke(compileResult, "sqrtTest", args);
 
         Assert.assertEquals(returns.length, 1);
@@ -79,10 +79,334 @@ public class MathTest {
 
     @Test(description = "Test 'randomRange' function in ballerina.lang.math package")
     public void testRandomRange() {
-        BValue[] args = {new BInteger(5), new BInteger(10)};
+        BValue[] args = { new BInteger(5), new BInteger(10) };
         BValue[] returns = BTestUtils.invoke(compileResult, "randomInRangeTest", args);
 
         Assert.assertEquals(returns.length, 1);
         Assert.assertTrue(((BInteger) returns[0]).floatValue() >= 5 && ((BInteger) returns[0]).floatValue() < 10);
+    }
+
+    @Test(description = "Test 'absFloat' function in ballerina.lang.math package")
+    public void testAbsFloat() {
+        BValue[] args = { new BFloat(-152.2544) };
+        BValue[] returns = BTestUtils.invoke(compileResult, "absFloatTest", args);
+
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BFloat) returns[0]).floatValue(), 152.2544, DELTA);
+    }
+
+    @Test(description = "Test 'absInt' function in ballerina.lang.math package")
+    public void testAbsInt() {
+        BValue[] args = { new BInteger(-152) };
+        BValue[] returns = BTestUtils.invoke(compileResult, "absIntTest", args);
+
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BInteger) returns[0]).intValue(), 152);
+    }
+
+    @Test(description = "Test 'acos' function in ballerina.lang.math package")
+    public void testAcos() {
+        BValue[] args = { new BFloat(0.027415567780803774) };
+        BValue[] returns = BTestUtils.invoke(compileResult, "acosTest", args);
+
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BFloat) returns[0]).floatValue(), 1.5433773235341761, DELTA);
+    }
+
+    @Test(description = "Test 'asin' function in ballerina.lang.math package")
+    public void testAsin() {
+        BValue[] args = { new BFloat(0.027415567780803774) };
+        BValue[] returns = BTestUtils.invoke(compileResult, "asinTest", args);
+
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BFloat) returns[0]).floatValue(), 0.02741900326072046, DELTA);
+    }
+
+    @Test(description = "Test 'atan' function in ballerina.lang.math package")
+    public void testAtan() {
+        BValue[] args = { new BFloat(0.027415567780803774) };
+        BValue[] returns = BTestUtils.invoke(compileResult, "atanTest", args);
+
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BFloat) returns[0]).floatValue(), 0.0274087022410345, DELTA);
+    }
+
+    @Test(description = "Test 'atan2' function in ballerina.lang.math package")
+    public void testAtan2() {
+        BValue[] args = { new BFloat(45.0), new BFloat(30.0) };
+        BValue[] returns = BTestUtils.invoke(compileResult, "atan2Test", args);
+
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BFloat) returns[0]).floatValue(), 0.982793723247329, DELTA);
+    }
+
+    @Test(description = "Test 'cbrt' function in ballerina.lang.math package")
+    public void testCbrt() {
+        BValue[] args = { new BFloat(-27) };
+        BValue[] returns = BTestUtils.invoke(compileResult, "cbrtTest", args);
+
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BFloat) returns[0]).floatValue(), -3.0, DELTA);
+    }
+
+    @Test(description = "Test 'ceil' function in ballerina.lang.math package")
+    public void testCeil() {
+        BValue[] args = { new BFloat(-100.675) };
+        BValue[] returns = BTestUtils.invoke(compileResult, "ceilTest", args);
+
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BFloat) returns[0]).floatValue(), -100.0, DELTA);
+    }
+
+    @Test(description = "Test 'copySign' function in ballerina.lang.math package")
+    public void testCopySign() {
+        BValue[] args = { new BFloat(-0.4873), new BFloat(125.9) };
+        BValue[] returns = BTestUtils.invoke(compileResult, "copySignTest", args);
+
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BFloat) returns[0]).floatValue(), 0.4873, DELTA);
+    }
+
+    @Test(description = "Test 'cos' function in ballerina.lang.math package")
+    public void testCos() {
+        BValue[] args = { new BFloat(3.141592653589793) };
+        BValue[] returns = BTestUtils.invoke(compileResult, "cosTest", args);
+
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BFloat) returns[0]).floatValue(), -1.0, DELTA);
+    }
+
+    @Test(description = "Test 'cosh' function in ballerina.lang.math package")
+    public void testCosh() {
+        BValue[] args = { new BFloat(3.141592653589793) };
+        BValue[] returns = BTestUtils.invoke(compileResult, "coshTest", args);
+
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BFloat) returns[0]).floatValue(), 11.591953275521519, DELTA);
+    }
+
+    @Test(description = "Test 'expm1' function in ballerina.lang.math package")
+    public void testExpm1() {
+        BValue[] args = { new BFloat(0.5) };
+        BValue[] returns = BTestUtils.invoke(compileResult, "expm1Test", args);
+
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BFloat) returns[0]).floatValue(), 0.6487212707001282, DELTA);
+    }
+
+    @Test(description = "Test 'floor' function in ballerina.lang.math package")
+    public void testFloor() {
+        BValue[] args = { new BFloat(-100.675) };
+        BValue[] returns = BTestUtils.invoke(compileResult, "floorTest", args);
+
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BFloat) returns[0]).floatValue(), -101.0, DELTA);
+    }
+
+    @Test(description = "Test 'floorDiv' function in ballerina.lang.math package")
+    public void testFloorDiv() {
+        BValue[] args = { new BInteger(-4), new BInteger(3) };
+        BValue[] returns = BTestUtils.invoke(compileResult, "floorDivTest", args);
+
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BInteger) returns[0]).intValue(), -2);
+    }
+
+    @Test(description = "Test 'floorMod' function in ballerina.lang.math package")
+    public void testFloorMod() {
+        BValue[] args = { new BInteger(-4), new BInteger(3) };
+        BValue[] returns = BTestUtils.invoke(compileResult, "floorModTest", args);
+
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BInteger) returns[0]).intValue(), 2);
+    }
+
+    @Test(description = "Test 'getExponent' function in ballerina.lang.math package")
+    public void testGetExponent() {
+        BValue[] args = { new BFloat(60984.1) };
+        BValue[] returns = BTestUtils.invoke(compileResult, "getExponentTest", args);
+
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BInteger) returns[0]).intValue(), 15);
+    }
+
+    @Test(description = "Test 'hypot' function in ballerina.lang.math package")
+    public void testHypot() {
+        BValue[] args = { new BFloat(60984.1), new BFloat(-497.99) };
+        BValue[] returns = BTestUtils.invoke(compileResult, "hypotTest", args);
+
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BFloat) returns[0]).floatValue(), 60986.133234122164, DELTA);
+    }
+
+    @Test(description = "Test 'IEEEremainder' function in ballerina.lang.math package")
+    public void testIEEEremainder() {
+        BValue[] args = { new BFloat(60984.1), new BFloat(-497.99) };
+        BValue[] returns = BTestUtils.invoke(compileResult, "IEEEremainderTest", args);
+
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BFloat) returns[0]).floatValue(), 229.31999999999744, DELTA);
+    }
+
+    @Test(description = "Test 'log' function in ballerina.lang.math package")
+    public void testLog() {
+        BValue[] args = { new BFloat(60984.1) };
+        BValue[] returns = BTestUtils.invoke(compileResult, "logTest", args);
+
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BFloat) returns[0]).floatValue(), 11.018368453441132, DELTA);
+    }
+
+    @Test(description = "Test 'log10' function in ballerina.lang.math package")
+    public void testLog10() {
+        BValue[] args = { new BFloat(60984.1) };
+        BValue[] returns = BTestUtils.invoke(compileResult, "log10Test", args);
+
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BFloat) returns[0]).floatValue(), 4.78521661890635, DELTA);
+    }
+
+    @Test(description = "Test 'log1p' function in ballerina.lang.math package")
+    public void testLog1p() {
+        BValue[] args = { new BFloat(1000) };
+        BValue[] returns = BTestUtils.invoke(compileResult, "log1pTest", args);
+
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BFloat) returns[0]).floatValue(), 6.90875477931522, DELTA);
+    }
+
+    @Test(description = "Test 'negateExact' function in ballerina.lang.math package")
+    public void testNegateExact() {
+        BValue[] args = { new BInteger(-4) };
+        BValue[] returns = BTestUtils.invoke(compileResult, "negateExactTest", args);
+
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BInteger) returns[0]).intValue(), 4);
+    }
+
+    @Test(description = "Test 'nextAfter' function in ballerina.lang.math package")
+    public void testNextAfter() {
+        BValue[] args = { new BFloat(98759.765), new BFloat(154.28764) };
+        BValue[] returns = BTestUtils.invoke(compileResult, "nextAfterTest", args);
+
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BFloat) returns[0]).floatValue(), 98759.76499999998, DELTA);
+    }
+
+    @Test(description = "Test 'nextDown' function in ballerina.lang.math package")
+    public void testNextDown() {
+        BValue[] args = { new BFloat(60984.1) };
+        BValue[] returns = BTestUtils.invoke(compileResult, "nextDownTest", args);
+
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BFloat) returns[0]).floatValue(), 60984.09999999999, DELTA);
+    }
+
+    @Test(description = "Test 'nextUp' function in ballerina.lang.math package")
+    public void testNextUp() {
+        BValue[] args = { new BFloat(-100.675) };
+        BValue[] returns = BTestUtils.invoke(compileResult, "nextUpTest", args);
+
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BFloat) returns[0]).floatValue(), -100.67499999999998, DELTA);
+    }
+
+    @Test(description = "Test 'rint' function in ballerina.lang.math package")
+    public void testRint() {
+        BValue[] args = { new BFloat(2.50) };
+        BValue[] returns = BTestUtils.invoke(compileResult, "rintTest", args);
+
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BFloat) returns[0]).floatValue(), 2.0, DELTA);
+    }
+
+    @Test(description = "Test 'round' function in ballerina.lang.math package")
+    public void testRound() {
+        BValue[] args = { new BFloat(2.50) };
+        BValue[] returns = BTestUtils.invoke(compileResult, "roundTest", args);
+
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BInteger) returns[0]).intValue(), 3);
+    }
+
+    @Test(description = "Test 'scalb' function in ballerina.lang.math package")
+    public void testScalb() {
+        BValue[] args = { new BFloat(50.14), new BInteger(4) };
+        BValue[] returns = BTestUtils.invoke(compileResult, "scalbTest", args);
+
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BFloat) returns[0]).floatValue(), 802.24, DELTA);
+    }
+
+    @Test(description = "Test 'signum' function in ballerina.lang.math package")
+    public void testSignum() {
+        BValue[] args = { new BFloat(50.14) };
+        BValue[] returns = BTestUtils.invoke(compileResult, "signumTest", args);
+
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BFloat) returns[0]).floatValue(), 1.0, DELTA);
+    }
+
+    @Test(description = "Test 'sin' function in ballerina.lang.math package")
+    public void testSin() {
+        BValue[] args = { new BFloat(0.7853981633974483) };
+        BValue[] returns = BTestUtils.invoke(compileResult, "sinTest", args);
+
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BFloat) returns[0]).floatValue(), 0.7071067811865475, DELTA);
+    }
+
+    @Test(description = "Test 'sinh' function in ballerina.lang.math package")
+    public void testSinh() {
+        BValue[] args = { new BFloat(-3.141592653589793) };
+        BValue[] returns = BTestUtils.invoke(compileResult, "sinhTest", args);
+
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BFloat) returns[0]).floatValue(), -11.548739357257748, DELTA);
+    }
+
+    @Test(description = "Test 'tan' function in ballerina.lang.math package")
+    public void testTan() {
+        BValue[] args = { new BFloat(0.7853981633974483) };
+        BValue[] returns = BTestUtils.invoke(compileResult, "tanTest", args);
+
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BFloat) returns[0]).floatValue(), 0.9999999999999999, DELTA);
+    }
+
+    @Test(description = "Test 'tanh' function in ballerina.lang.math package")
+    public void testTanh() {
+        BValue[] args = { new BFloat(-3.141592653589793) };
+        BValue[] returns = BTestUtils.invoke(compileResult, "tanhTest", args);
+
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BFloat) returns[0]).floatValue(), -0.99627207622075, DELTA);
+    }
+
+    @Test(description = "Test 'toDegrees' function in ballerina.lang.math package")
+    public void testToDegrees() {
+        BValue[] args = { new BFloat(2578.3100780887044) };
+        BValue[] returns = BTestUtils.invoke(compileResult, "toDegreesTest", args);
+
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BFloat) returns[0]).floatValue(), 147726.28575052848, DELTA);
+    }
+
+    @Test(description = "Test 'toRadians' function in ballerina.lang.math package")
+    public void testToRadians() {
+        BValue[] args = { new BFloat(45.0) };
+        BValue[] returns = BTestUtils.invoke(compileResult, "toRadiansTest", args);
+
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BFloat) returns[0]).floatValue(), 0.7853981633974483, DELTA);
+    }
+
+    @Test(description = "Test 'ulp' function in ballerina.lang.math package")
+    public void testUlp() {
+        BValue[] args = { new BFloat(956.294) };
+        BValue[] returns = BTestUtils.invoke(compileResult, "ulpTest", args);
+
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertEquals(((BFloat) returns[0]).floatValue(), 1.1368683772161603E-13, DELTA);
     }
 }

--- a/modules/ballerina-test/src/test/resources/test-src/nativeimpl/functions/math.bal
+++ b/modules/ballerina-test/src/test/resources/test-src/nativeimpl/functions/math.bal
@@ -19,3 +19,147 @@ function sqrtTest(float val) (float) {
 function randomInRangeTest(int a, int b) (int) {
     return math:randomInRange(a, b);
 }
+
+function absFloatTest(float a) (float) {
+    return math:absFloat(a);
+}
+
+function absIntTest(int a) (int) {
+    return math:absInt(a);
+}
+
+function acosTest(float a) (float) {
+    return math:acos(a);
+}
+
+function asinTest(float a) (float) {
+    return math:asin(a);
+}
+
+function atanTest(float a) (float) {
+    return math:atan(a);
+}
+
+function atan2Test(float a, float b) (float) {
+    return math:atan2(a, b);
+}
+
+function cbrtTest(float value) (float) {
+    return math:cbrt(value);
+}
+
+function ceilTest(float value) (float) {
+    return math:ceil(value);
+}
+
+function copySignTest(float a, float b) (float) {
+    return math:copySign(a, b);
+}
+
+function cosTest(float value) (float) {
+    return math:cos(value);
+}
+
+function coshTest(float value) (float) {
+    return math:cosh(value);
+}
+
+function expm1Test(float value) (float) {
+    return math:expm1(value);
+}
+
+function floorTest(float value) (float) {
+    return math:floor(value);
+}
+
+function floorDivTest(int a, int b) (int) {
+    return math:floorDiv(a, b);
+}
+
+function floorModTest(int a, int b) (int) {
+    return math:floorMod(a, b);
+}
+
+function getExponentTest(float val) (int) {
+    return math:getExponent(val);
+}
+
+function hypotTest(float a, float b) (float) {
+    return math:hypot(a, b);
+}
+
+function IEEEremainderTest(float a, float b) (float) {
+    return math:IEEEremainder(a, b);
+}
+
+function logTest(float value) (float) {
+    return math:log(value);
+}
+
+function log10Test(float value) (float) {
+    return math:log10(value);
+}
+
+function log1pTest(float value) (float) {
+    return math:log1p(value);
+}
+
+function negateExactTest(int value) (int) {
+    return math:negateExact(value);
+}
+
+function nextAfterTest(float a, float b) (float) {
+    return math:nextAfter(a, b);
+}
+
+function nextDownTest(float value) (float) {
+    return math:nextDown(value);
+}
+
+function nextUpTest(float value) (float) {
+    return math:nextUp(value);
+}
+
+function rintTest(float value) (float) {
+    return math:rint(value);
+}
+
+function roundTest(float value) (int) {
+    return math:round(value);
+}
+
+function scalbTest(float a, int b) (float) {
+    return math:scalb(a, b);
+}
+
+function signumTest(float value) (float) {
+    return math:signum(value);
+}
+
+function sinTest(float value) (float) {
+    return math:sin(value);
+}
+
+function sinhTest(float value) (float) {
+    return math:sinh(value);
+}
+
+function tanTest(float value) (float) {
+    return math:tan(value);
+}
+
+function tanhTest(float value) (float) {
+    return math:tanh(value);
+}
+
+function toDegreesTest(float value) (float) {
+    return math:toDegrees(value);
+}
+
+function toRadiansTest(float value) (float) {
+    return math:toRadians(value);
+}
+
+function ulpTest(float value) (float) {
+    return math:ulp(value);
+}


### PR DESCRIPTION
## Purpose
> Support Java Math functions in ballerina Math API

## Goals
> Include ballerina native functions to do numerical operations 

## Approach
> Used Java Math API for implementation. 


## Automation tests
 - Unit tests 
  Line converage - 100%
