### PR TITLE
Add a catch clause for BallerinaException in Main.java

### DIFF
--- a/modules/launcher/src/main/java/org/ballerinalang/launcher/Main.java
+++ b/modules/launcher/src/main/java/org/ballerinalang/launcher/Main.java
@@ -25,6 +25,7 @@ import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
 import org.ballerinalang.logging.BLogManager;
 import org.ballerinalang.util.exceptions.BLangRuntimeException;
+import org.ballerinalang.util.exceptions.BallerinaException;
 import org.ballerinalang.util.exceptions.ParserException;
 import org.ballerinalang.util.exceptions.SemanticException;
 import org.slf4j.Logger;
@@ -65,13 +66,12 @@ public class Main {
         } catch (BLauncherException e) {
             LauncherUtils.printLauncherException(e, outStream);
             Runtime.getRuntime().exit(1);
+        } catch (BallerinaException e) {
+            outStream.println("ballerina: " + LauncherUtils.makeFirstLetterLowerCase(e.getMessage()));
+            breLog.error(e.getMessage(), e);
+            Runtime.getRuntime().exit(1);
         } catch (Throwable e) {
-            String msg = e.getMessage();
-            if (msg == null) {
-                msg = "ballerina: internal error occurred";
-            } else {
-                msg = "ballerina: " + LauncherUtils.makeFirstLetterLowerCase(msg);
-            }
+            String msg = "ballerina: internal error occurred";
             outStream.println(msg);
             breLog.error(msg, e);
             Runtime.getRuntime().exit(1);


### PR DESCRIPTION
This PR is to fix the current issue we have with some errors printed to the console not being meaningful nor useful. This can be fixed by adding a catch clause for `BallerinaException`. Since the Ballerina developer is responsible for creating and throwing `BallerinaException` type exceptions, we can expect to see a meaningful error message which can be presented to the Ballerina user. All other Java throwables are caught by the catch clause for `Throwable` and for all of these the common error message shown is `internal error occurred` since these are considered to have occurred due to Ballerina developer error. 

Fixes issue #3333 