### PR TITLE
Improve constant detection in transform statement

### DIFF
--- a/modules/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/modules/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -635,7 +635,11 @@ public class CodeAnalyzer extends BLangNodeVisitor {
                 }
 
                 // a variable defined in transform scope is a inner variable
-                if (variable.expr.getKind() != NodeKind.LITERAL) {
+                if ((variable.expr.getKind() != NodeKind.LITERAL)
+                        && (variable.expr.getKind() != NodeKind.RECORD_LITERAL_EXPR)
+                        && (variable.expr.getKind() != NodeKind.XML_ELEMENT_LITERAL)
+                        && (variable.expr.getKind() != NodeKind.ARRAY_LITERAL_EXPR)
+                        && (variable.expr.getKind() != NodeKind.STRING_TEMPLATE_LITERAL)) {
                     // a variable defined in transform scope is a inner variable
                     // if the variable does not hold a constant value, it is a temporary variable and hence not an input
                     innerVars.add(varName);

--- a/modules/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/modules/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -635,11 +635,7 @@ public class CodeAnalyzer extends BLangNodeVisitor {
                 }
 
                 // a variable defined in transform scope is a inner variable
-                if ((variable.expr.getKind() != NodeKind.LITERAL)
-                        && (variable.expr.getKind() != NodeKind.RECORD_LITERAL_EXPR)
-                        && (variable.expr.getKind() != NodeKind.XML_ELEMENT_LITERAL)
-                        && (variable.expr.getKind() != NodeKind.ARRAY_LITERAL_EXPR)
-                        && (variable.expr.getKind() != NodeKind.STRING_TEMPLATE_LITERAL)) {
+                if (isLiteralExpression(variable.expr)) {
                     // a variable defined in transform scope is a inner variable
                     // if the variable does not hold a constant value, it is a temporary variable and hence not an input
                     innerVars.add(varName);
@@ -698,6 +694,13 @@ public class CodeAnalyzer extends BLangNodeVisitor {
             }
         }
         innerVars.forEach(var -> inputs.remove(var));
+    }
+
+    private boolean isLiteralExpression(BLangExpression expression) {
+        NodeKind expressionKind = expression.getKind();
+        return ((expressionKind != NodeKind.LITERAL) && (expressionKind != NodeKind.RECORD_LITERAL_EXPR)
+               && (expressionKind != NodeKind.XML_ELEMENT_LITERAL) && (expressionKind != NodeKind.ARRAY_LITERAL_EXPR)
+               && (expressionKind != NodeKind.STRING_TEMPLATE_LITERAL));
     }
 
     private BLangExpression[] getVariableReferencesFromExpression(BLangExpression expression) {

--- a/modules/ballerina-test/src/test/java/org/ballerinalang/test/statements/transform/TransformStmtTest.java
+++ b/modules/ballerina-test/src/test/java/org/ballerinalang/test/statements/transform/TransformStmtTest.java
@@ -165,5 +165,26 @@ public class TransformStmtTest {
                 "input and output variables cannot be interchanged in transform statement", 21, 9);
         BTestUtils.validateError(resultNegative, 1,
                                  "input and output variables cannot be interchanged in transform statement", 34, 9);
+
+        resultNegative = BTestUtils
+                .compile("test-src/statements/transform/transform-stmt-literals-negative.bal");
+        Assert.assertEquals(resultNegative.getErrorCount(), 8);
+        BTestUtils.validateError(resultNegative, 0,
+                                "input and output variables cannot be interchanged in transform statement", 25, 9);
+        BTestUtils.validateError(resultNegative, 1,
+                                 "input and output variables cannot be interchanged in transform statement", 26, 9);
+        BTestUtils.validateError(resultNegative, 2,
+                                 "input and output variables cannot be interchanged in transform statement", 27, 9);
+        BTestUtils.validateError(resultNegative, 3,
+                                 "input and output variables cannot be interchanged in transform statement", 28, 9);
+        BTestUtils.validateError(resultNegative, 4,
+                                 "input and output variables cannot be interchanged in transform statement", 29, 9);
+        BTestUtils.validateError(resultNegative, 5,
+                                 "input and output variables cannot be interchanged in transform statement", 30, 9);
+        BTestUtils.validateError(resultNegative, 6,
+                                 "input and output variables cannot be interchanged in transform statement", 31, 9);
+        BTestUtils.validateError(resultNegative, 7,
+                                 "input and output variables cannot be interchanged in transform statement", 32, 9);
+
     }
 }

--- a/modules/ballerina-test/src/test/resources/test-src/statements/transform/transform-stmt-literals-negative.bal
+++ b/modules/ballerina-test/src/test/resources/test-src/statements/transform/transform-stmt-literals-negative.bal
@@ -1,0 +1,39 @@
+struct Person {
+    string name;
+    int age;
+}
+
+function testConstantsInTransform () {
+    string str1 = "Sherlock Holmes";
+    boolean flag1 = true;
+    xml x1 = xml`<book>The Lost World</book>`;
+    json json1 = {name:"Alice"};
+    string[] arr1 = [];
+    map map1 = {};
+    Person p1 = {};
+    json<Person> jsonP1 = {name:"Alice", age:30};
+
+    transform {
+        string str2 = "Sherlock Holmes";
+        boolean flag2 = true;
+        xml x2 = xml`<book>The Lost World</book>`;
+        json json2 = {name:"Alice"};
+        string[] arr2 = [];
+        map map2 = {};
+        Person p2 = {};
+        json<Person> jsonP2 = {name:"Alice", age:30};
+        str2 = getPrefixedName(str1);
+        flag2 = flag1;
+        x2 = x1;
+        json2 = json1;
+        arr2 = arr1;
+        map2 = map1;
+        p2 = p1;
+        jsonP2 = jsonP1;
+    }
+}
+
+
+function getPrefixedName(string name) (string) {
+    return "Mr." + name;
+}


### PR DESCRIPTION
When a variable is declared in the transform statement, if the value is a literal (static), we consider them as constants, which become inputs. This PR extends the constant detection from literals to xml, json, map and array.