### PR TITLE
Fix an edge case in type cast expression

### DIFF
--- a/modules/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/modules/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -301,9 +301,9 @@ public class Types {
     }
 
     public BSymbol getCastOperator(BType sourceType, BType targetType) {
-        if (sourceType.tag == TypeTags.ERROR || targetType.tag == TypeTags.ERROR) {
-            return createCastOperatorSymbol(sourceType, targetType, true, InstructionCodes.NOP);
-        } else if (sourceType == targetType) {
+        if (sourceType.tag == TypeTags.ERROR ||
+                targetType.tag == TypeTags.ERROR ||
+                sourceType == targetType) {
             return createCastOperatorSymbol(sourceType, targetType, true, InstructionCodes.NOP);
         }
 
@@ -311,9 +311,9 @@ public class Types {
     }
 
     public BSymbol getConversionOperator(BType sourceType, BType targetType) {
-        if (sourceType.tag == TypeTags.ERROR || targetType.tag == TypeTags.ERROR) {
-            return createConversionOperatorSymbol(sourceType, targetType, true, InstructionCodes.NOP);
-        } else if (sourceType == targetType) {
+        if (sourceType.tag == TypeTags.ERROR ||
+                targetType.tag == TypeTags.ERROR ||
+                sourceType == targetType) {
             return createConversionOperatorSymbol(sourceType, targetType, true, InstructionCodes.NOP);
         }
 

--- a/modules/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/modules/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -302,7 +302,7 @@ public class Types {
 
     public BSymbol getCastOperator(BType sourceType, BType targetType) {
         if (sourceType.tag == TypeTags.ERROR || targetType.tag == TypeTags.ERROR) {
-            return createCastOperatorSymbol(sourceType, targetType, false, InstructionCodes.NOP);
+            return createCastOperatorSymbol(sourceType, targetType, true, InstructionCodes.NOP);
         } else if (sourceType == targetType) {
             return createCastOperatorSymbol(sourceType, targetType, true, InstructionCodes.NOP);
         }
@@ -312,7 +312,7 @@ public class Types {
 
     public BSymbol getConversionOperator(BType sourceType, BType targetType) {
         if (sourceType.tag == TypeTags.ERROR || targetType.tag == TypeTags.ERROR) {
-            return createConversionOperatorSymbol(sourceType, targetType, false, InstructionCodes.NOP);
+            return createConversionOperatorSymbol(sourceType, targetType, true, InstructionCodes.NOP);
         } else if (sourceType == targetType) {
             return createConversionOperatorSymbol(sourceType, targetType, true, InstructionCodes.NOP);
         }

--- a/modules/ballerina-test/src/test/java/org/ballerinalang/test/statements/assign/AssignStmtTest.java
+++ b/modules/ballerina-test/src/test/java/org/ballerinalang/test/statements/assign/AssignStmtTest.java
@@ -200,5 +200,7 @@ public class AssignStmtTest {
         BAssertUtil.validateError(result, 18, "assignment count mismatch: expected 3 values, but found 2", 42, 19);
         BAssertUtil.validateError(result, 19, "assignment count mismatch: expected 3 values, but found 2", 46, 19);
         BAssertUtil.validateError(result, 20, "assignment count mismatch: expected 3 values, but found 2", 51, 19);
+        BAssertUtil.validateError(result, 21, "unknown type 'Foo'", 55, 14);
+        BAssertUtil.validateError(result, 22, "undefined symbol 'bar'", 55, 19);
     }
 }

--- a/modules/ballerina-test/src/test/resources/test-src/statements/assign/var-negative.bal
+++ b/modules/ballerina-test/src/test/resources/test-src/statements/assign/var-negative.bal
@@ -50,3 +50,8 @@ function test9(){
     any a = 1;
     var p, q, r = (string) a;
 }
+
+function test10 () {
+    var x = (Foo) bar;
+    string result1 = x + ex;
+}


### PR DESCRIPTION
error ex;

function test10 () {
    var x = (Foo) bar;
    string result1 = x + ex;
}

In this case, we should get only following two compilation errors

error: foo.bal:4:14: unknown type 'Foo'
error: foo.bal:4:19: undefined symbol 'bar'
