### PR TITLE
Remove getEnv from systemlib

### DIFF
--- a/modules/ballerina-builtin/src/main/ballerina/ballerina/builtin/systemlib.bal
+++ b/modules/ballerina-builtin/src/main/ballerina/ballerina/builtin/systemlib.bal
@@ -11,8 +11,3 @@ public native function println (any a);
 @Description { value:"Halt the current thread for the specified time period"}
 @Param { value:"int: Sleep time in milliseconds" }
 public native function sleep (int t);
-
-@Description { value:"Gets the value of the specified environment variable."}
-@Param { value:"key: The environment variable" }
-@Return { value:"string): The value of the specified environment variable" }
-public native function getEnv (string key) (string);

--- a/modules/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/SystemTest.java
+++ b/modules/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/SystemTest.java
@@ -188,19 +188,6 @@ public class SystemTest {
 
     }
 
-    @Test
-    public void testGetEnv() throws IOException {
-        try (ByteArrayOutputStream outContent = new ByteArrayOutputStream()) {
-            System.setOut(new PrintStream(outContent));
-            final String pathValue = System.getenv("PATH");
-            BValueType[] args = {new BString("PATH")};
-            BRunUtil.invoke(compileResult, "getEnvVar", args);
-            Assert.assertEquals(outContent.toString(), pathValue);
-        } finally {
-            System.setOut(original);
-        }
-    }
-
 //    @Test(expectedExceptions = BallerinaException.class)
 //    public void testGetEnvNonExisting() throws IOException {
 //        try (ByteArrayOutputStream outContent = new ByteArrayOutputStream()) {

--- a/modules/ballerina-test/src/test/resources/test-src/nativeimpl/functions/systemTest.bal
+++ b/modules/ballerina-test/src/test/resources/test-src/nativeimpl/functions/systemTest.bal
@@ -52,8 +52,3 @@ function printNewline() {
 function testSleep(int timeoutv) {
     sleep(timeoutv);
 }
-
-function getEnvVar(string varName) {
-    string pathValue = getEnv(varName);
-    print(pathValue);
-}

--- a/modules/ballerina-test/src/test/resources/test-src/types/constant/constant-assignment.bal
+++ b/modules/ballerina-test/src/test/resources/test-src/types/constant/constant-assignment.bal
@@ -1,6 +1,6 @@
-import ballerina.lang.strings;
+import ballerina.os;
 
-const string envVar = getEnv("env_var");
+const string envVar = os:getEnv("env_var");
 const string varFunc = dummyStringFunction();
 const string str = "ballerina is $$$";
 const string varNativeFunc = str.replace("$$$","awesome");


### PR DESCRIPTION
This commit removes getEnv function from systemlib since this function is available in os package.