### PR TITLE
Add a BType parameter to BRefValueArray constructor

### DIFF
--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/file/ListFiles.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/file/ListFiles.java
@@ -67,7 +67,7 @@ public class ListFiles extends AbstractNativeFunction {
 
         try {
             Files.list(Paths.get(path)).forEach(p -> structList.add(createFileStruct(context, p.toString())));
-            filesList = new BRefValueArray(structList.toArray(new BRefType[0]));
+            filesList = new BRefValueArray(structList.toArray(new BRefType[0]), fileStruct.getType());
         } catch (IOException e) {
             String msg = "Error occurred while opening directory: " + path;
             log.error(msg, e);

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/model/values/BRefValueArray.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/model/values/BRefValueArray.java
@@ -31,8 +31,9 @@ public class BRefValueArray extends BNewArray {
 
     private BRefType[] values;
 
-    public BRefValueArray(BRefType[] values) {
+    public BRefValueArray(BRefType[] values, BType type) {
         this.values = values;
+        this.arrayType = type;
         this.size = values.length;
     }
 
@@ -67,9 +68,8 @@ public class BRefValueArray extends BNewArray {
 
     @Override
     public BValue copy() {
-        BRefValueArray refValueArray = new BRefValueArray(Arrays.copyOf(values, values.length));
+        BRefValueArray refValueArray = new BRefValueArray(Arrays.copyOf(values, values.length), arrayType);
         refValueArray.size = this.size;
-        refValueArray.arrayType = this.arrayType;
         return refValueArray;
     }
     

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/model/values/BXMLItem.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/model/values/BXMLItem.java
@@ -536,7 +536,7 @@ public final class BXMLItem extends BXML<OMNode> {
                 break;
         }
 
-        return new BXMLSequence(new BRefValueArray(descendants.toArray(new BXML[descendants.size()])));
+        return new BXMLSequence(new BRefValueArray(descendants.toArray(new BXML[descendants.size()]), BTypes.typeXML));
     }
     
     // Methods from Datasource impl

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/model/values/BXMLSequence.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/model/values/BXMLSequence.java
@@ -341,7 +341,7 @@ public final class BXMLSequence extends BXML<BRefValueArray> {
             }
         }
 
-        return new BXMLSequence(new BRefValueArray(descendants.toArray(new BXML[descendants.size()])));
+        return new BXMLSequence(new BRefValueArray(descendants.toArray(new BXML[descendants.size()]), BTypes.typeXML));
     }
 
     // Methods from Datasource impl
@@ -400,7 +400,7 @@ public final class BXMLSequence extends BXML<BRefValueArray> {
         for (int i = 0; i < sequence.size(); i++) {
             copiedVals[i] = ((BXML<?>) sequence.get(i)).copy();
         }
-        return new BXMLSequence(new BRefValueArray(copiedVals));
+        return new BXMLSequence(new BRefValueArray(copiedVals, BTypes.typeXML));
     }
 
     /**

--- a/modules/ballerina-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayTest.java
+++ b/modules/ballerina-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayTest.java
@@ -20,6 +20,7 @@ package org.ballerinalang.test.statements.arrays;
 import org.ballerinalang.launcher.util.BCompileUtil;
 import org.ballerinalang.launcher.util.BRunUtil;
 import org.ballerinalang.launcher.util.CompileResult;
+import org.ballerinalang.model.types.BTypes;
 import org.ballerinalang.model.util.JSONUtils;
 import org.ballerinalang.model.values.BBooleanArray;
 import org.ballerinalang.model.values.BFloatArray;
@@ -457,7 +458,7 @@ public class ArrayTest {
         Assert.assertEquals(bBooleanArray.stringValue(), "[true, true, false]");
 
         BXMLItem[] xmlArray = { new BXMLItem("<foo/>"), new BXMLItem("<bar>hello</bar>") };
-        BRefValueArray bXmlArray = new BRefValueArray(xmlArray);
+        BRefValueArray bXmlArray = new BRefValueArray(xmlArray, BTypes.typeXML);
         Assert.assertEquals(bXmlArray.stringValue(), "[<foo/>, <bar>hello</bar>]");
     }
 }


### PR DESCRIPTION
Refactored the constructor because it allowed to create arrays with the type set to null. This causes NPE when using the `lengthof` operator. 