### PR TITLE
 Fix extract path related issue on windows 

### DIFF
--- a/modules/ballerina-lang/src/main/java/org/ballerinalang/repository/fs/ClasspathPackageRepository.java
+++ b/modules/ballerina-lang/src/main/java/org/ballerinalang/repository/fs/ClasspathPackageRepository.java
@@ -45,7 +45,7 @@ public class ClasspathPackageRepository extends GeneralFSPackageRepository {
     private static Path generatePath(Class<? extends Object> providerClassRef, String basePath) {
         try {
             URI classURI = providerClassRef.getProtectionDomain().getCodeSource().getLocation().toURI();
-            String classPath = classURI.getPath().replace(" ", "%20");
+            String classPath = classURI.getPath().replaceAll("\\s", "%20");
             URI pathUri;
             if (classPath.endsWith(".jar")) {
                 pathUri = URI.create("jar:file:" + classPath + "!" + basePath);

--- a/modules/ballerina-lang/src/main/java/org/ballerinalang/repository/fs/ClasspathPackageRepository.java
+++ b/modules/ballerina-lang/src/main/java/org/ballerinalang/repository/fs/ClasspathPackageRepository.java
@@ -45,7 +45,7 @@ public class ClasspathPackageRepository extends GeneralFSPackageRepository {
     private static Path generatePath(Class<? extends Object> providerClassRef, String basePath) {
         try {
             URI classURI = providerClassRef.getProtectionDomain().getCodeSource().getLocation().toURI();
-            String classPath = classURI.getPath();
+            String classPath = classURI.getPath().replace(" ", "%20");
             URI pathUri;
             if (classPath.endsWith(".jar")) {
                 pathUri = URI.create("jar:file:" + classPath + "!" + basePath);


### PR DESCRIPTION
When the ballerina executable is extraced
to a path which contains spaces, it throws
Exceptions when try to run a program.