### PR TITLE
Fix extract path related issue on windows

### DIFF
--- a/modules/ballerina-lang/src/main/java/org/ballerinalang/repository/fs/ClasspathPackageRepository.java
+++ b/modules/ballerina-lang/src/main/java/org/ballerinalang/repository/fs/ClasspathPackageRepository.java
@@ -17,6 +17,8 @@
 */
 package org.ballerinalang.repository.fs;
 
+import org.apache.commons.lang3.SystemUtils;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -46,6 +48,10 @@ public class ClasspathPackageRepository extends GeneralFSPackageRepository {
         try {
             URI classURI = providerClassRef.getProtectionDomain().getCodeSource().getLocation().toURI();
             String classPath = classURI.getPath();
+            // TODO Fix this properly for other platforms too
+            if (SystemUtils.IS_OS_WINDOWS) {
+                classPath = classPath.replace(" ", "%20");
+            }
             URI pathUri;
             if (classPath.endsWith(".jar")) {
                 pathUri = URI.create("jar:file:" + classPath + "!" + basePath);


### PR DESCRIPTION
When the ballerina executable is extraced
to a path which contains spaces, it throws
Exceptions when try to run a program.