### PR TITLE
Prefix the log functions with 'print'

### DIFF
--- a/modules/ballerina-builtin/src/main/ballerina/ballerina/log/natives.bal
+++ b/modules/ballerina-builtin/src/main/ballerina/ballerina/log/natives.bal
@@ -2,25 +2,25 @@ package ballerina.log;
 
 @Description {value: "Logs the specified value at debug level."}
 @Param {value: "msg: The message to be logged."}
-public native function debug(string msg);
+public native function printDebug(string msg);
 
 @Description {value: "Logs the specified message at error level."}
 @Param {value: "msg: The message to be logged."}
-public native function error(string msg);
+public native function printError(string msg);
 
 @Description {value: "Logs the specified message at error level."}
 @Param {value: "msg: The message to be logged."}
 @Param {value: "err: The error to be logged."}
-public native function errorCause(string msg, error err);
+public native function printErrorCause(string msg, error err);
 
 @Description {value: "Logs the specified message at info level."}
 @Param {value: "msg: The message to be logged."}
-public native function info(string msg);
+public native function printInfo(string msg);
 
 @Description {value: "Logs the specified message at trace level."}
 @Param {value: "msg: The message to be logged."}
-public native function trace(string msg);
+public native function printTrace(string msg);
 
 @Description {value: "Logs the specified message at warn level."}
 @Param {value: "msg: The message to be logged."}
-public native function warn(string msg);
+public native function printWarn(string msg);

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/log/LogDebug.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/log/LogDebug.java
@@ -26,13 +26,13 @@ import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 
 /**
- * Native function ballerina.log:debug
+ * Native function ballerina.log:printDebug
  *
  * @since 0.89
  */
 @BallerinaFunction(
         packageName = "ballerina.log",
-        functionName = "debug",
+        functionName = "printDebug",
         args = {@Argument(name = "msg", type = TypeKind.STRING)},
         isPublic = true
 )

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/log/LogError.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/log/LogError.java
@@ -26,13 +26,13 @@ import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 
 /**
- * Native function ballerina.log:error
+ * Native function ballerina.log:printError
  *
  * @since 0.89
  */
 @BallerinaFunction(
         packageName = "ballerina.log",
-        functionName = "error",
+        functionName = "printError",
         args = {@Argument(name = "msg", type = TypeKind.STRING)},
         isPublic = true
 )

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/log/LogErrorCause.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/log/LogErrorCause.java
@@ -27,13 +27,13 @@ import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 
 /**
- * Native function ballerina.log:error
+ * Native function ballerina.log:printErrorCause
  *
- * @since 0.89
+ * @since 0.95.0
  */
 @BallerinaFunction(
         packageName = "ballerina.log",
-        functionName = "errorCause",
+        functionName = "printErrorCause",
         args = {@Argument(name = "msg", type = TypeKind.STRING), @Argument(name = "err", type = TypeKind.STRUCT)},
         isPublic = true
 )

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/log/LogInfo.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/log/LogInfo.java
@@ -26,13 +26,13 @@ import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 
 /**
- * Native function ballerina.log:info
+ * Native function ballerina.log:printInfo
  *
  * @since 0.89
  */
 @BallerinaFunction(
         packageName = "ballerina.log",
-        functionName = "info",
+        functionName = "printInfo",
         args = {@Argument(name = "msg", type = TypeKind.STRING)},
         isPublic = true
 )

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/log/LogTrace.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/log/LogTrace.java
@@ -26,13 +26,13 @@ import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 
 /**
- * Native function ballerina.log:trace
+ * Native function ballerina.log:printTrace
  *
  * @since 0.89
  */
 @BallerinaFunction(
         packageName = "ballerina.log",
-        functionName = "trace",
+        functionName = "printTrace",
         args = {@Argument(name = "msg", type = TypeKind.STRING)},
         isPublic = true
 )

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/log/LogWarn.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/log/LogWarn.java
@@ -26,13 +26,13 @@ import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
 
 /**
- * Native function ballerina.log:warn
+ * Native function ballerina.log:printWarn
  *
  * @since 0.89
  */
 @BallerinaFunction(
         packageName = "ballerina.log",
-        functionName = "warn",
+        functionName = "printWarn",
         args = {@Argument(name = "msg", type = TypeKind.STRING)},
         isPublic = true
 )

--- a/modules/ballerina-test/src/test/resources/test-src/natives/utils/logger/log-api.bal
+++ b/modules/ballerina-test/src/test/resources/test-src/natives/utils/logger/log-api.bal
@@ -1,21 +1,21 @@
 import ballerina.log;
 
 function testError (string msg) {
-    log:error(msg);
+    log:printError(msg);
 }
 
 function testWarn (string msg) {
-    log:warn(msg);
+    log:printWarn(msg);
 }
 
 function testInfo (string msg) {
-    log:info(msg);
+    log:printInfo(msg);
 }
 
 function testDebug (string msg) {
-    log:debug(msg);
+    log:printDebug(msg);
 }
 
 function testTrace (string msg) {
-    log:trace(msg);
+    log:printTrace(msg);
 }

--- a/samples/ballerina-by-example/examples/log-api/log-api.bal
+++ b/samples/ballerina-by-example/examples/log-api/log-api.bal
@@ -1,11 +1,23 @@
 import ballerina.log;
 
-@Description {value: "The Ballerina log API provides functions to log at 5 levels: Debug, Error, Info, Trace and Warn."}
-@Description {value: "By default, all log messages are logged to the console at the Info level."}
 function main(string[] args) {
-    log:debug("debug log");
-    log:error("error log");
-    log:info("info log");
-    log:trace("trace log");
-    log:warn("warn log");
+    error err = {msg: "error occurred"};
+
+    // The Ballerina log API provides functions to log at 5 levels: DEBUG, ERROR, INFO, TRACE and WARN.
+    // By default, all log messages are logged to the console at the INFO level. In addition to these log levels,
+    // there are 2 additionals levels: OFF and ALL. OFF turns off logging and ALL allows all log levels.
+    // Log level can be configured through a Ballerina config file or CLI parameters. <br>
+
+    log:printDebug("debug log");
+    log:printError("error log");
+    log:printErrorCause("error log with cause", err);
+    log:printInfo("info log");
+    log:printTrace("trace log");
+    log:printWarn("warn log");
+    // To set the log level of the API use the CLI parameter: <br>
+    // -B[ballerina.log].level=[LOG_LEVEL] <br>
+
+    // To configure using a config file, place the entry given below in the file: <br>
+    // [ballerina.log] <br>
+    // level=[LOG_LEVEL]
 }

--- a/samples/ballerina-by-example/examples/log-api/log-api.sh
+++ b/samples/ballerina-by-example/examples/log-api/log-api.sh
@@ -1,5 +1,14 @@
 # As it can be seen from the output, only Info and higher level logs are logged
 $ ballerina run log-api.bal
-2017-07-01 12:30:27,488  ERROR [] - error log
-2017-07-01 12:30:27,491  INFO  [] - info log
-2017-07-01 12:30:27,492  WARN  [] - warn log
+2017-11-05 21:20:12,313 ERROR [] - error log
+2017-11-05 21:20:12,319 ERROR [] - error log with cause : {msg:"error occurred", cause:null, stackTrace:null}
+2017-11-05 21:20:12,320 INFO  [] - info log
+2017-11-05 21:20:12,321 WARN  [] - warn log
+
+$ ballerina run log-api.bal -B[ballerina.log].level=TRACE
+2017-11-05 21:21:35,394 DEBUG [] - debug log
+2017-11-05 21:21:35,400 ERROR [] - error log
+2017-11-05 21:21:35,402 ERROR [] - error log with cause : {msg:"error occurred", cause:null, stackTrace:null}
+2017-11-05 21:21:35,403 INFO  [] - info log
+2017-11-05 21:21:35,403 TRACE [] - trace log
+2017-11-05 21:21:35,404 WARN  [] - warn log 

--- a/samples/ballerina-by-example/examples/task-appointment/task-appointment.bal
+++ b/samples/ballerina-by-example/examples/task-appointment/task-appointment.bal
@@ -7,7 +7,7 @@ string app1Tid;
 
 function main (string[] args) {
     worker w1 {
-        log:info("------- Scheduling Appointments ----------------");
+        log:printInfo("------- Scheduling Appointments ----------------");
 
         function () returns (error) onTriggerFunction;
         function (error e) onErrorFunction;
@@ -57,10 +57,10 @@ function main (string[] args) {
 }
 
 function appointment1Cleanup() returns (error) {
-    log:info("Appointment#1 cleanup running...");
+    log:printInfo("Appointment#1 cleanup running...");
     app1Count = app1Count + 1;
     if(app1Count == 5) {
-        log:info("Stopping Appointment#1 cleanup task since it has run 5 times");
+        log:printInfo("Stopping Appointment#1 cleanup task since it has run 5 times");
         // This is how you stop a task.
         _ = task:stopTask(app1Tid);
     }
@@ -68,37 +68,37 @@ function appointment1Cleanup() returns (error) {
 }
 
 function appointment2Cleanup() returns (error){
-    log:info("Appointment#2 cleanup running...");
+    log:printInfo("Appointment#2 cleanup running...");
     return cleanup();
 }
 
 function appointment3Cleanup() returns (error){
-    log:info("Appointment#3 cleanup running...");
+    log:printInfo("Appointment#3 cleanup running...");
     return cleanup();
 }
 
 function appointment4Cleanup() returns (error){
-    log:info("Appointment#4 cleanup running...");
+    log:printInfo("Appointment#4 cleanup running...");
     return cleanup();
 }
 
 function appointment5Cleanup() returns (error){
-    log:info("Appointment#5 cleanup running...");
+    log:printInfo("Appointment#5 cleanup running...");
     return cleanup();
 }
 
 function appointment6Cleanup() returns (error){
-    log:info("Appointment#6 cleanup running...");
+    log:printInfo("Appointment#6 cleanup running...");
     return cleanup();
 }
 
 function appointment7Cleanup() returns (error){
-    log:info("Appointment#7 cleanup running...");
+    log:printInfo("Appointment#7 cleanup running...");
     return cleanup();
 }
 
 function cleanup() returns (error e) {
-    log:info("Cleaning up");
+    log:printInfo("Cleaning up");
     if(math:randomInRange(0, 10) == 5) {
         e = {msg:"Cleanup error"};
     }
@@ -106,6 +106,5 @@ function cleanup() returns (error e) {
 }
 
 function cleanupError(error e) {
-    log:info("[ERROR] cleanup failed");
-    log:info(e);
+    log:printErrorCause("[ERROR] cleanup failed", e);
 }


### PR DESCRIPTION
This is to fix the issue with `error()` causing problems with the builtin type `error`.