### PR TITLE
Fixes #2843 and introduce getAttributes() native method

### DIFF
--- a/modules/ballerina-http/src/main/ballerina/ballerina/net/http/natives.bal
+++ b/modules/ballerina-http/src/main/ballerina/ballerina/net/http/natives.bal
@@ -274,6 +274,11 @@ public native function <Session session> setAttribute (string attributeKey, any 
 @Return { value:"string[]: HTTPSession attribute name array" }
 public native function <Session session> getAttributeNames () (string[]);
 
+@Description { value:"Gets the session attribute key value pairs as a map" }
+@Param { value:"session: A session struct" }
+@Return { value:"The map of session attributes key value pairs" }
+public native function <Session session> getAttributes () (map);
+
 @Description { value:"Gets the session attribute" }
 @Param { value:"session: A session struct" }
 public native function <Session session> invalidate ();

--- a/modules/ballerina-http/src/main/ballerina/ballerina/net/http/natives.bal
+++ b/modules/ballerina-http/src/main/ballerina/ballerina/net/http/natives.bal
@@ -274,6 +274,11 @@ public native function <Session session> setAttribute (string attributeKey, any 
 @Return { value:"Session attribute names array" }
 public native function <Session session> getAttributeNames () (string[]);
 
+@Description { value:"Gets the session attribute key value pairs as a map" }
+@Param { value:"session: A session struct" }
+@Return { value:"The map of session attributes key value pairs" }
+public native function <Session session> getAttributes () (map);
+
 @Description { value:"Invalidates the session and it will no longer be accessible from the request" }
 @Param { value:"session: A Session struct" }
 public native function <Session session> invalidate ();

--- a/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/session/GetAttributes.java
+++ b/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/session/GetAttributes.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.net.http.nativeimpl.session;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BStruct;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.Receiver;
+import org.ballerinalang.natives.annotations.ReturnType;
+import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.session.Session;
+import org.ballerinalang.util.exceptions.BallerinaException;
+
+/**
+ * Native function to get session attribute key value pairs as a map.
+ *
+ * @since 0.95.1
+ */
+@BallerinaFunction(
+        packageName = "ballerina.net.http",
+        functionName = "getAttributes",
+        receiver = @Receiver(type = TypeKind.STRUCT, structType = "Session",
+                structPackage = "ballerina.net.http"),
+        returnType = {@ReturnType(type = TypeKind.MAP, elementType = TypeKind.STRING)},
+        isPublic = true
+)
+public class GetAttributes extends AbstractNativeFunction {
+    @Override
+    public BValue[] execute(Context context) {
+        try {
+            BStruct sessionStruct = ((BStruct) getRefArgument(context, 0));
+            Session session = (Session) sessionStruct.getNativeData(Constants.HTTP_SESSION);
+            if (session != null && session.isValid()) {
+                return getBValues(session.getAttributes());
+            } else {
+                throw new IllegalStateException("Failed to get attribute map: No such session in progress");
+            }
+        } catch (IllegalStateException e) {
+            throw new BallerinaException(e.getMessage(), e);
+        }
+    }
+}

--- a/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/session/HTTPSession.java
+++ b/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/session/HTTPSession.java
@@ -74,10 +74,7 @@ public class HTTPSession implements Session, Serializable {
 
     @Override
     public BMap<String, BValue> getAttributes() {
-        if (!attributeMap.isEmpty()) {
-            return attributeMap;
-        }
-        return null;
+        return attributeMap;
     }
 
     @Override

--- a/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/session/HTTPSession.java
+++ b/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/session/HTTPSession.java
@@ -26,7 +26,7 @@ import org.wso2.carbon.transport.http.netty.message.HTTPCarbonMessage;
 import java.io.Serializable;
 
 /**
- * HTTPSession represents a Java session object.
+ * HTTPSession represents the Java session object.
  *
  * @since 0.89
  */

--- a/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/session/HTTPSession.java
+++ b/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/session/HTTPSession.java
@@ -18,16 +18,15 @@
 
 package org.ballerinalang.net.http.session;
 
+import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.net.http.Constants;
 import org.wso2.carbon.transport.http.netty.message.HTTPCarbonMessage;
 
 import java.io.Serializable;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * HTTPSession represents a session.
+ * HTTPSession represents a Java session object.
  *
  * @since 0.89
  */
@@ -36,9 +35,10 @@ public class HTTPSession implements Session, Serializable {
     private final String sessionPath;
     private String id;
     private Long createTime;
+    private Long accessedTime;
     private Long lastAccessedTime;
     private int maxInactiveInterval;
-    private Map<String, BValue> attributeMap = new ConcurrentHashMap<>();
+    private BMap<String, BValue> attributeMap = new BMap<>();
     private SessionManager sessionManager;
     private boolean isValid = true;
     private boolean isNew = true;
@@ -47,7 +47,8 @@ public class HTTPSession implements Session, Serializable {
         this.id = id;
         this.maxInactiveInterval = maxInactiveInterval;
         createTime = System.currentTimeMillis();
-        lastAccessedTime = createTime;
+        accessedTime = createTime;
+        lastAccessedTime = accessedTime;
         this.sessionPath = path;
     }
 
@@ -58,22 +59,26 @@ public class HTTPSession implements Session, Serializable {
 
     @Override
     public void setAttribute(String attributeKey, BValue attributeValue) {
-        checkValidity();
         attributeMap.put(attributeKey, attributeValue);
     }
 
     @Override
     public BValue getAttributeValue(String attributeKey) {
-        checkValidity();
         return attributeMap.get(attributeKey);
     }
 
     @Override
     public String[] getAttributeNames() {
-        checkValidity();
         return attributeMap.keySet().toArray(new String[attributeMap.size()]);
     }
 
+    @Override
+    public BMap<String, BValue> getAttributes() {
+        if (!attributeMap.isEmpty()) {
+            return attributeMap;
+        }
+        return null;
+    }
 
     @Override
     public Session setNew(boolean isNew) {
@@ -88,7 +93,6 @@ public class HTTPSession implements Session, Serializable {
 
     @Override
     public void removeAttribute(String name) {
-        checkValidity();
         attributeMap.remove(name);
     }
 
@@ -115,14 +119,15 @@ public class HTTPSession implements Session, Serializable {
     @Override
     public void invalidate() {
         sessionManager.invalidateSession(this);
-        attributeMap.clear();
+        attributeMap = new BMap<>();
         isValid = false;
     }
 
     @Override
     public Session setAccessed() {
         checkValidity();
-        lastAccessedTime = System.currentTimeMillis();
+        lastAccessedTime = this.accessedTime;
+        accessedTime = System.currentTimeMillis();
         return this;
     }
 

--- a/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/session/Session.java
+++ b/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/session/Session.java
@@ -83,7 +83,7 @@ public interface Session {
     /**
      * Get attribute name list.
      *
-     * @return array of keys.
+     * @return array of attribute names.
      */
     String[]  getAttributeNames();
 

--- a/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/session/Session.java
+++ b/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/session/Session.java
@@ -18,6 +18,7 @@
 
 package org.ballerinalang.net.http.session;
 
+import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BValue;
 import org.wso2.carbon.transport.http.netty.message.HTTPCarbonMessage;
 
@@ -82,9 +83,16 @@ public interface Session {
     /**
      * Get attribute name list.
      *
-     * @return name array.
+     * @return array of keys.
      */
     String[]  getAttributeNames();
+
+    /**
+     * Get attribute key value map.
+     *
+     * @return map of key value pairs.
+     */
+    BMap<String, BValue> getAttributes();
 
     /**
      * Remove attribute from session.

--- a/modules/ballerina-test/src/test/java/org/ballerinalang/test/services/session/HTTPSessionEssentialMethodsTest.java
+++ b/modules/ballerina-test/src/test/java/org/ballerinalang/test/services/session/HTTPSessionEssentialMethodsTest.java
@@ -372,6 +372,41 @@ public class HTTPSessionEssentialMethodsTest {
         Assert.assertEquals(stringDataSource.getValue(), "0");
     }
 
+    @Test(description = "Test for getAttributes function")
+    public void testGetAttributesFunction() {
+        HTTPCarbonMessage cMsg = MessageUtils.generateHTTPMessage("/sample2/map", "GET");
+        HTTPCarbonMessage response = Services.invokeNew(cMsg);
+        Assert.assertNotNull(response);
+
+        StringDataSource stringDataSource = (StringDataSource) response.getMessageDataSource();
+        Assert.assertNotNull(stringDataSource);
+        Assert.assertEquals(stringDataSource.getValue(), "Name:chamil");
+
+        String cookie = response.getHeader(RESPONSE_COOKIE_HEADER);
+        String sessionId = cookie.substring(SESSION_ID.length(), cookie.length() - 14);
+
+        cMsg = MessageUtils.generateHTTPMessage("/sample2/map", "GET");
+        cMsg.setHeader(COOKIE_HEADER, SESSION_ID + sessionId);
+        cMsg.setHeader("counter", "1");
+        response = Services.invokeNew(cMsg);
+        Assert.assertNotNull(response);
+
+        stringDataSource = (StringDataSource) response.getMessageDataSource();
+        Assert.assertNotNull(stringDataSource);
+        Assert.assertEquals(stringDataSource.getValue(), "Lang:ballerina");
+    }
+
+    @Test(description = "Test for null attribute map from getAttributes function")
+    public void testNullGetAttributesFunction() {
+        HTTPCarbonMessage cMsg = MessageUtils.generateHTTPMessage("/sample2/map2", "GET");
+        HTTPCarbonMessage response = Services.invokeNew(cMsg);
+        Assert.assertNotNull(response);
+
+        StringDataSource stringDataSource = (StringDataSource) response.getMessageDataSource();
+        Assert.assertNotNull(stringDataSource);
+        Assert.assertEquals(stringDataSource.getValue(), "value:map not present");
+    }
+
     @Test(description = "Test for removeAttribute function")
     public void testRemoveAttributeFunction() {
         HTTPCarbonMessage cMsg = MessageUtils.generateHTTPMessage("/sample2/names3", "GET");

--- a/modules/ballerina-test/src/test/java/org/ballerinalang/test/services/session/HTTPSessionSubMethodsTest.java
+++ b/modules/ballerina-test/src/test/java/org/ballerinalang/test/services/session/HTTPSessionSubMethodsTest.java
@@ -165,7 +165,17 @@ public class HTTPSessionSubMethodsTest {
         stringDataSource = (StringDataSource) response.getMessageDataSource();
         Assert.assertNotNull(stringDataSource);
         long secondAccess = Long.parseLong(stringDataSource.getValue());
-        Assert.assertTrue(firstAccess <= secondAccess);
+        Assert.assertTrue(firstAccess == secondAccess);
+
+        cMsg = MessageUtils.generateHTTPMessage("/sample2/new4", "GET");
+        cMsg.setHeader(COOKIE_HEADER, SESSION_ID + sessionId);
+        response = Services.invokeNew(cMsg);
+        Assert.assertNotNull(response);
+
+        stringDataSource = (StringDataSource) response.getMessageDataSource();
+        Assert.assertNotNull(stringDataSource);
+        long thirdAccess = Long.parseLong(stringDataSource.getValue());
+        Assert.assertTrue(firstAccess <= thirdAccess);
     }
 
     @Test(description = "Test for GetLastAccessed Function error")

--- a/modules/ballerina-test/src/test/resources/test-src/services/session/httpSessionTest.bal
+++ b/modules/ballerina-test/src/test/resources/test-src/services/session/httpSessionTest.bal
@@ -334,7 +334,7 @@ service<http> sample2 {
         http:Session session = req.createSessionIfAbsent();
         map attributes = session.getAttributes();
         string v0 = "map not present";
-        if (attributes != null) {
+        if (attributes.length() != 0) {
             string[] arr = attributes.keys();
             v0,_ = (string)attributes[arr[0]];
         }

--- a/modules/ballerina-test/src/test/resources/test-src/services/session/httpSessionTest.bal
+++ b/modules/ballerina-test/src/test/resources/test-src/services/session/httpSessionTest.bal
@@ -117,7 +117,6 @@ service<http> sample {
         any attribute = session.getAttribute("name");
         if (attribute != null) {
             result, err = (string)attribute;
-
         } else {
             session.setAttribute("name", result);
         }
@@ -295,6 +294,51 @@ service<http> sample2 {
         string[] arr = session.getAttributeNames();
         int arrsize = lengthof arr;
         res.setStringPayload(<string>(arrsize));
+        res.send();
+    }
+
+    @http:resourceConfig {
+        methods:["GET"],
+        path:"/map"
+    }
+    resource getmap (http:Request req, http:Response res) {
+
+        http:Session session = req.createSessionIfAbsent();
+        string value;
+        boolean available;
+        value,available = req.getHeader("counter");
+        if (!available) {
+            session.setAttribute("Name", "chamil");
+            session.setAttribute("Lang", "ballerina");
+            map attributes = session.getAttributes();
+            string[] arr = attributes.keys();
+            string v0;
+            v0,_ = (string)attributes[arr[0]];
+            res.setStringPayload(arr[0] + ":" + v0);
+        } else {
+            map attributes = session.getAttributes();
+            string[] arr = attributes.keys();
+            string v1;
+            v1,_ = (string)attributes[arr[1]];
+            res.setStringPayload(arr[1] + ":" + v1);
+        }
+        res.send();
+    }
+
+    @http:resourceConfig {
+        methods:["GET"],
+        path:"/map2"
+    }
+    resource getmap2 (http:Request req, http:Response res) {
+
+        http:Session session = req.createSessionIfAbsent();
+        map attributes = session.getAttributes();
+        string v0 = "map not present";
+        if (attributes != null) {
+            string[] arr = attributes.keys();
+            v0,_ = (string)attributes[arr[0]];
+        }
+        res.setStringPayload("value" + ":" + v0);
         res.send();
     }
 


### PR DESCRIPTION
- Fix #2843

- Introduce getAttributes native method to HTTP session API which returns attribute key-value pairs as a map. This is requested during Session API review discussion
```ballerina
native function <Session session> getAttributes () (map);
```