### PR TITLE
Introduce setSoapPayload to HTTP request/response

### DIFF
--- a/modules/ballerina-http/src/main/ballerina/ballerina/net/http/natives.bal
+++ b/modules/ballerina-http/src/main/ballerina/ballerina/net/http/natives.bal
@@ -108,6 +108,11 @@ public native function <Request req> removeAllHeaders ();
 @Param { value:"payload: The XML payload object" }
 public native function <Request req> setXmlPayload (xml payload);
 
+@Description { value:"Sets the message payload using a SOAP object"}
+@Param { value:"req: A request message" }
+@Param { value:"payload: The XML payload object" }
+public native function <Request req> setSoapPayload (xml payload);
+
 @Description { value:"Clones and creates a new instance of a request message"}
 @Param { value:"req: A request message" }
 @Return { value:"request: The new instance of the request message" }
@@ -222,6 +227,11 @@ public native function <Response res> removeAllHeaders ();
 @Param { value:"res: The response message" }
 @Param { value:"payload: The XML payload object" }
 public native function <Response res> setXmlPayload (xml payload);
+
+@Description { value:"Sets the response payload using a SOAP object"}
+@Param { value:"res: The response message" }
+@Param { value:"payload: The XML payload object" }
+public native function <Response res> setSoapPayload (xml payload);
 
 @Description { value:"Clones and creates a new instance of a response message"}
 @Param { value:"res: The response message" }

--- a/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/Constants.java
+++ b/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/Constants.java
@@ -178,6 +178,11 @@ public class Constants {
     public static final String APPLICATION_XML = "application/xml";
 
     /**
+     * HTTP content-type text/xml.
+     */
+    public static final String TEXT_XML = "text/xml";
+
+    /**
      * HTTP content-type text/plain.
      */
     public static final String TEXT_PLAIN = "text/plain";

--- a/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpUtil.java
+++ b/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpUtil.java
@@ -386,6 +386,23 @@ public class HttpUtil {
         return AbstractNativeFunction.VOID_RETURN;
     }
 
+    public static BValue[] setSOAPPayload(Context context,
+                                         AbstractNativeFunction abstractNativeFunction, boolean isRequest) {
+        BStruct requestStruct = (BStruct) abstractNativeFunction.getRefArgument(context, 0);
+        BXML payload = (BXML) abstractNativeFunction.getRefArgument(context, 1);
+
+        HTTPCarbonMessage httpCarbonMessage = HttpUtil
+                .getCarbonMsg(requestStruct, HttpUtil.createHttpCarbonMessage(isRequest));
+
+        httpCarbonMessage.waitAndReleaseAllEntities();
+
+        httpCarbonMessage.setMessageDataSource(payload);
+        httpCarbonMessage.setHeader(Constants.CONTENT_TYPE, Constants.TEXT_XML);
+        payload.setOutputStream(new HttpMessageDataStreamer(httpCarbonMessage).getOutputStream());
+        httpCarbonMessage.setAlreadyRead(true);
+        return AbstractNativeFunction.VOID_RETURN;
+    }
+
     public static BValue[] getContentLength(Context context,
             AbstractNativeFunction abstractNativeFunction, boolean isRequest) {
         int contentLength = -1;

--- a/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/request/SetSOAPPayload.java
+++ b/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/request/SetSOAPPayload.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ballerinalang.net.http.nativeimpl.request;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.Receiver;
+import org.ballerinalang.net.http.HttpUtil;
+
+/**
+ * Set the payload of the Message as a SOAP.
+ */
+@BallerinaFunction(
+        packageName = "ballerina.net.http",
+        functionName = "setSoapPayload",
+        receiver = @Receiver(type = TypeKind.STRUCT, structType = "Request",
+                structPackage = "ballerina.net.http"),
+        args = {@Argument(name = "payload", type = TypeKind.XML)},
+        isPublic = true
+)
+public class SetSOAPPayload extends AbstractNativeFunction {
+
+    @Override
+    public BValue[] execute(Context context) {
+        return HttpUtil.setSOAPPayload(context, this, true);
+    }
+}

--- a/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/response/SetSOAPPayload.java
+++ b/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/response/SetSOAPPayload.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ballerinalang.net.http.nativeimpl.response;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.Receiver;
+import org.ballerinalang.net.http.HttpUtil;
+
+/**
+ * Set the payload of the Message as a SOAP.
+ */
+@BallerinaFunction(
+        packageName = "ballerina.net.http",
+        functionName = "setSoapPayload",
+        receiver = @Receiver(type = TypeKind.STRUCT, structType = "Response",
+                structPackage = "ballerina.net.http"),
+        args = {@Argument(name = "payload", type = TypeKind.XML)},
+        isPublic = true
+)
+public class SetSOAPPayload extends AbstractNativeFunction {
+
+    @Override
+    public BValue[] execute(Context context) {
+        return HttpUtil.setSOAPPayload(context, this, false);
+    }
+}


### PR DESCRIPTION
This is to introduce setSoapPayload function to HTTP requests/ response structs.
The Content-Type is set to text/xml