### PR TITLE
Revert "Add PKCS as the keystore type supported by ballerina"

### DIFF
--- a/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/Constants.java
+++ b/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/Constants.java
@@ -50,8 +50,6 @@ public class Constants {
     public static final String PORT = "PORT";
     public static final String TO = "TO";
     public static final String HTTP_DEFAULT_HOST = "0.0.0.0";
-    public static final String TLS_STORE_TYPE = "tlsStoreType";
-    public static final String PKCS_STORE_TYPE = "PKCS12";
 
     public static final String HTTP_PACKAGE_PATH = "ballerina.net.http";
 

--- a/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpConnectionManager.java
+++ b/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpConnectionManager.java
@@ -327,7 +327,6 @@ public class HttpConnectionManager {
             if (!clientParams.isEmpty()) {
                 senderConfiguration.setParameters(clientParams);
             }
-            senderConfiguration.setTlsStoreType(Constants.PKCS_STORE_TYPE);
         }
         if (options.getRefField(Constants.PROXY_STRUCT_INDEX) != null) {
             BStruct proxy = (BStruct) options.getRefField(Constants.PROXY_STRUCT_INDEX);

--- a/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpUtil.java
+++ b/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpUtil.java
@@ -643,7 +643,6 @@ public class HttpUtil {
             if (sslProtocolAttrVal != null) {
                 httpsPropMap.put(Constants.ANN_CONFIG_ATTR_SSL_PROTOCOL, sslProtocolAttrVal.getStringValue());
             }
-            httpsPropMap.put(Constants.TLS_STORE_TYPE, Constants.PKCS_STORE_TYPE);
             listenerConfMap.put(buildInterfaceName(httpsPropMap), httpsPropMap);
         }
         return listenerConfMap;

--- a/samples/ballerina-by-example/examples/https-server-client-connectors/https-server-client-connectors.bal
+++ b/samples/ballerina-by-example/examples/https-server-client-connectors/https-server-client-connectors.bal
@@ -3,9 +3,9 @@ import ballerina.net.http;
 @http:configuration {
     basePath:"/hello",
     httpsPort:9095,
-    keyStoreFile:"${ballerina.home}/bre/security/ballerinaKeystore.p12",
-    keyStorePassword:"ballerina",
-    certPassword:"ballerina"
+    keyStoreFile:"${ballerina.home}/bre/security/wso2carbon.jks",
+    keyStorePassword:"wso2carbon",
+    certPassword:"wso2carbon"
 }
 
 service<http> helloWorld {
@@ -36,8 +36,8 @@ function main (string[] args) {
 function getConnectorConfigs() (http:Options) {
     http:Options option = {
           ssl: {
-                 trustStoreFile:"${ballerina.home}/bre/security/ballerinaTruststore.p12",
-                 trustStorePassword:"ballerina"
+                 trustStoreFile:"${ballerina.home}/bre/security/client-truststore.jks",
+                 trustStorePassword:"wso2carbon"
                },
           followRedirects: {}
     };

--- a/samples/ballerina-by-example/examples/https-server-connector/https-server-connector.bal
+++ b/samples/ballerina-by-example/examples/https-server-connector/https-server-connector.bal
@@ -4,9 +4,9 @@ import ballerina.net.http;
 @http:configuration {
     basePath:"/hello",
     httpsPort:9095,
-    keyStoreFile:"${ballerina.home}/bre/security/ballerinaKeystore.p12",
-    keyStorePassword:"ballerina",
-    certPassword:"ballerina"
+    keyStoreFile:"${ballerina.home}/bre/security/wso2carbon.jks",
+    keyStorePassword:"wso2carbon",
+    certPassword:"wso2carbon"
 }
 
 service<http> helloWorld {

--- a/samples/ballerina-by-example/examples/mutual-ssl/mutual-ssl.bal
+++ b/samples/ballerina-by-example/examples/mutual-ssl/mutual-ssl.bal
@@ -3,14 +3,12 @@ import ballerina.net.http;
 @http:configuration {
     basePath:"/hello",
     httpsPort:9095,
-    keyStoreFile:"${ballerina.home}/bre/security/ballerinaKeystore.p12",
-    keyStorePassword:"ballerina",
-    certPassword:"ballerina",
+    keyStoreFile:"${ballerina.home}/bre/security/wso2carbon.jks",
+    keyStorePassword:"wso2carbon",
+    certPassword:"wso2carbon",
     sslVerifyClient:"require",
-    trustStoreFile:"${ballerina.home}/bre/security/ballerinaTruststore.p12",
-    trustStorePassword:"ballerina",
-    ciphers:"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
-    sslEnabledProtocols:"TLSv1.2,TLSv1.1"
+    trustStoreFile:"${ballerina.home}/bre/security/client-truststore.jks",
+    trustStorePassword:"wso2carbon"
 }
 
 service<http> helloWorld {
@@ -43,12 +41,10 @@ function main (string[] args) {
 function getConnectorConfigs() (http:Options) {
     http:Options option = {
           ssl: {
-                 keyStoreFile:"${ballerina.home}/bre/security/ballerinaKeystore.p12",
-                 keyStorePassword:"ballerina",
-                 trustStoreFile:"${ballerina.home}/bre/security/ballerinaTruststore.p12",
-                 trustStorePassword:"ballerina",
-                 ciphers:"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
-                 sslEnabledProtocols:"TLSv1.2,TLSv1.1"
+                 keyStoreFile:"${ballerina.home}/bre/security/wso2carbon.jks",
+                 keyStorePassword:"wso2carbon",
+                 trustStoreFile:"${ballerina.home}/bre/security/client-truststore.jks",
+                 trustStorePassword:"wso2carbon"
                },
           followRedirects: {}
       };


### PR DESCRIPTION
Reverts ballerinalang/ballerina#4040

Unfortunately, we had to revert the PR as it has an issue with older jdk versions such as 8u45.