### PR TITLE
Improve config API example and discard trailing whitespace in config entries

### DIFF
--- a/modules/ballerina-config/src/main/java/org/ballerinalang/config/ConfigProcessor.java
+++ b/modules/ballerina-config/src/main/java/org/ballerinalang/config/ConfigProcessor.java
@@ -83,7 +83,12 @@ public class ConfigProcessor {
             resolvedGlobalConfigs.putAll(fileGlobalConfigs);
 
             // Add the remaining configs of each instance config to the resolved pool
-            resolvedInstanceConfigs.forEach((key, val) -> val.putAll(fileInstanceConfigs.get(key)));
+            resolvedInstanceConfigs.forEach((key, val) -> {
+                Map<String, String> map = fileInstanceConfigs.get(key);
+                if (map != null) {
+                    val.putAll(map);
+                }
+            });
 
             // Add the remaining instance configs to the resolved pool
             fileInstanceConfigs.forEach((key, val) -> resolvedInstanceConfigs.putIfAbsent(key, val));

--- a/modules/ballerina-config/src/main/java/org/ballerinalang/config/utils/parser/AbstractConfigParser.java
+++ b/modules/ballerina-config/src/main/java/org/ballerinalang/config/utils/parser/AbstractConfigParser.java
@@ -31,7 +31,7 @@ import java.util.regex.Pattern;
  */
 public abstract class AbstractConfigParser {
 
-    protected static final String CONFIG_KEY_FORMAT = "([a-zA-Z0-9._]+)";
+    protected static final String CONFIG_KEY_FORMAT = "([a-zA-Z0-9._]+\\s*)";
     protected static final String INSTANCE_ID_FORMAT = "\\[[a-zA-Z0-9._]+\\]";
     protected static final String COMMENT_OR_WS_FORMAT = "[\\s]*#[\\ -~]*|[\\s]*"; // to skip comments or whitespace
     // TODO: rethink this regex

--- a/modules/ballerina-config/src/main/java/org/ballerinalang/config/utils/parser/ConfigFileParser.java
+++ b/modules/ballerina-config/src/main/java/org/ballerinalang/config/utils/parser/ConfigFileParser.java
@@ -85,6 +85,7 @@ public class ConfigFileParser extends AbstractConfigParser {
             instanceConfigs.put(currentInstance, new HashMap<>());
 
             for (; (line = reader.readLine()) != null; currentLine++) {
+                line = line.trim();
                 if (line.matches(CONFIG_ENTRY_FORMAT)) {
                     parseInstanceConfigEntry(currentInstance, line);
                 } else if (line.matches(INSTANCE_ID_FORMAT)) {
@@ -126,12 +127,16 @@ public class ConfigFileParser extends AbstractConfigParser {
 
     private String[] getConfigKeyAndValue(String configEntry) {
         String[] entryParts = configEntry.split("=");
-        entryParts[0] = entryParts[0].trim();
-        entryParts[1] = entryParts[1].trim();
+        trimConfigEntry(entryParts);
         return entryParts;
     }
 
     private void collectConfigError(int invalidLine) {
         invalidConfigs.add(invalidLine);
+    }
+
+    private void trimConfigEntry(String[] entryParts) {
+        entryParts[0] = entryParts[0].trim();
+        entryParts[1] = entryParts[1].trim();
     }
 }

--- a/modules/ballerina-config/src/main/java/org/ballerinalang/config/utils/parser/ConfigFileParser.java
+++ b/modules/ballerina-config/src/main/java/org/ballerinalang/config/utils/parser/ConfigFileParser.java
@@ -66,6 +66,7 @@ public class ConfigFileParser extends AbstractConfigParser {
 
             String line;
             for (currentLine = 1; (line = reader.readLine()) != null; currentLine++) {
+                line = line.trim();
                 if (line.matches(CONFIG_ENTRY_FORMAT)) {
                     parseGlobalConfigEntry(line);
                 } else if (line.matches(INSTANCE_ID_FORMAT)) {
@@ -124,7 +125,10 @@ public class ConfigFileParser extends AbstractConfigParser {
     }
 
     private String[] getConfigKeyAndValue(String configEntry) {
-        return configEntry.split("=");
+        String[] entryParts = configEntry.split("=");
+        entryParts[0] = entryParts[0].trim();
+        entryParts[1] = entryParts[1].trim();
+        return entryParts;
     }
 
     private void collectConfigError(int invalidLine) {

--- a/modules/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/config/ConfigTest.java
+++ b/modules/ballerina-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/config/ConfigTest.java
@@ -18,6 +18,7 @@
 package org.ballerinalang.test.nativeimpl.functions.config;
 
 import org.ballerinalang.config.ConfigRegistry;
+import org.ballerinalang.config.utils.ConfigFileParserException;
 import org.ballerinalang.launcher.util.BCompileUtil;
 import org.ballerinalang.launcher.util.BRunUtil;
 import org.ballerinalang.launcher.util.CompileResult;
@@ -171,6 +172,21 @@ public class ConfigTest {
                 "Invalid Return Values.");
         Assert.assertTrue(returnVals[0] instanceof BString);
         Assert.assertEquals(returnVals[0].stringValue(), "");
+    }
+
+    @Test(description = "Test config entries with trailing whitespaces")
+    public void testEntriesWithTrailingWhitespace() throws ConfigFileParserException {
+        BString id = new BString("http3");
+        BString key = new BString("ballerina.http.port");
+        BValue[] inputArg = {id, key};
+        ConfigRegistry registry = ConfigRegistry.getInstance();
+        registry.initRegistry(new HashMap<>());
+        registry.loadConfigurations();
+        BValue[] returnVals = BRunUtil.invoke(compileResult, "testConfigsWithWhitespace", inputArg);
+        Assert.assertFalse(returnVals == null || returnVals.length == 0 || returnVals[0] == null,
+                           "Invalid Return Values.");
+        Assert.assertTrue(returnVals[0] instanceof BString);
+        Assert.assertEquals(returnVals[0].stringValue(), "7070");
     }
 
     private Map<String, String> getRuntimeProperties() {

--- a/modules/ballerina-test/src/test/resources/datafiles/config/default/ballerina.conf
+++ b/modules/ballerina-test/src/test/resources/datafiles/config/default/ballerina.conf
@@ -18,7 +18,7 @@
 
 ballerina.http.host=10.100.1.205
 
-ballerina.http.instances=http1,http2
+ballerina.http.instances=http1,http2,http3
 ballerina.env.Path=${env:PATH}
 ballerina.log.format={{timestamp}}[yyyy-MM-dd HH:mm:ss,SSS] {{level}} [{{package}}:{{unit}}] [{{file}}:{{line}}] [{{worker}}] - \"{{msg}}\" {{err}}
 
@@ -28,3 +28,6 @@ ballerina.http.port=8085
 [http2]
 ballerina.http.port=8081
 #ballerina.http.host= http://$sysv.host
+
+[http3]
+ballerina.http.port  =   7070

--- a/modules/ballerina-test/src/test/resources/test-src/nativeimpl/functions/config.bal
+++ b/modules/ballerina-test/src/test/resources/test-src/nativeimpl/functions/config.bal
@@ -7,3 +7,7 @@ function testGetGlobalValues(string key) (string) {
 function testGetInstanceValues(string id, string key) (string) {
     return config:getInstanceValue(id, key);
 }
+
+function testConfigsWithWhitespace(string id, string key) (string) {
+    return config:getInstanceValue(id, key);
+}

--- a/samples/ballerina-by-example/examples/config-api/config-api.sh
+++ b/samples/ballerina-by-example/examples/config-api/config-api.sh
@@ -1,4 +1,13 @@
-# As it can be seen, configs given in a file can also be provided through CLI params
+# To explicitly specify the config file, one can use the -Bballerina.conf flag as shown.
+# If this is not set, Ballerina will look for a "ballerina.conf" file in the directory from which
+# the user executes the program. The path to the config file can either be an absolute path or a relative path.
+$ ballerina run config-api.bal -Bballerina.conf=path/to/conf/file/custom-config-file-name.conf
+john has RW access
+peter has R access
+
+# The same configs given through a config file can also be given through CLI params as shown.
+# Notice how the instance config keys are prefixed with the instance tag. <br>
+# i.e: [john].access.rights
 $ ballerina run config-api.bal -Busername.instances=john,peter -B[john].access.rights=RW -B[peter].access.rights=R
 john has RW access
 peter has R access


### PR DESCRIPTION
Fixes #4094 and #4105 