### PR TITLE
Fix identifier literal

### DIFF
--- a/modules/ballerina-lang/src/main/java/org/ballerinalang/model/tree/expressions/AnnotationAttachmentAttributeNode.java
+++ b/modules/ballerina-lang/src/main/java/org/ballerinalang/model/tree/expressions/AnnotationAttachmentAttributeNode.java
@@ -17,14 +17,16 @@
 */
 package org.ballerinalang.model.tree.expressions;
 
+import org.ballerinalang.model.tree.IdentifierNode;
+
 /**
  * @since 0.94
  */
 public interface AnnotationAttachmentAttributeNode extends ExpressionNode {
 
-    String getName();
+    IdentifierNode getName();
 
-    void setName(String name);
+    void setName(IdentifierNode name);
 
     AnnotationAttachmentAttributeValueNode getValue();
 

--- a/modules/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/codegen/CodeGenerator.java
+++ b/modules/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/codegen/CodeGenerator.java
@@ -1384,8 +1384,8 @@ public class CodeGenerator extends BLangNodeVisitor {
         AnnAttachmentInfo annAttachmentInfo = new AnnAttachmentInfo(pkgRefCPIndex, attachmentNameCPIndex);
         attachment.attributes.forEach(attr -> {
             AnnAttributeValue attribValue = getAnnotationAttributeValue(attr.value);
-            int attributeNameCPIndex = addUTF8CPEntry(currentPkgInfo, attr.getName());
-            annAttachmentInfo.addAttributeValue(attributeNameCPIndex, attr.getName(), attribValue);
+            int attributeNameCPIndex = addUTF8CPEntry(currentPkgInfo, attr.getName().getValue());
+            annAttachmentInfo.addAttributeValue(attributeNameCPIndex, attr.getName().getValue(), attribValue);
         });
         return annAttachmentInfo;
     }

--- a/modules/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
+++ b/modules/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
@@ -226,6 +226,8 @@ public class BLangPackageBuilder {
     
     private DiagnosticLog dlog;
 
+    private static final String PIPE = "|";
+
     public BLangPackageBuilder(CompilerContext context, CompilationUnitNode compUnit) {
         this.dlog = DiagnosticLog.getInstance(context);
         this.compUnit = compUnit;
@@ -390,8 +392,16 @@ public class BLangPackageBuilder {
 
     private IdentifierNode createIdentifier(String value) {
         IdentifierNode node = TreeBuilder.createIdentifierNode();
-        if (value != null) {
+        if (value == null) {
+            return node;
+        }
+
+        if (value.startsWith(PIPE) && value.endsWith(PIPE)) {
+            node.setValue(value.substring(1, value.length() - 1));
+            node.setLiteral(true);
+        } else {
             node.setValue(value);
+            node.setLiteral(false);
         }
         return node;
     }
@@ -1172,7 +1182,7 @@ public class BLangPackageBuilder {
         AnnotationAttachmentAttributeValueNode attributeValueNode = annotAttribValStack.pop();
         BLangAnnotAttachmentAttribute attrib =
                 (BLangAnnotAttachmentAttribute) TreeBuilder.createAnnotAttachmentAttributeNode();
-        attrib.name = attrName;
+        attrib.name = (BLangIdentifier) createIdentifier(attrName);
         attrib.value = (BLangAnnotAttachmentAttributeValue) attributeValueNode;
         attrib.addWS(ws);
         annotAttachmentStack.peek().addAttribute(attrib);

--- a/modules/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/modules/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -18,6 +18,7 @@
 package org.wso2.ballerinalang.compiler.semantics.analyzer;
 
 import org.ballerinalang.compiler.CompilerPhase;
+import org.ballerinalang.model.TreeBuilder;
 import org.ballerinalang.model.tree.NodeKind;
 import org.ballerinalang.model.tree.statements.StatementNode;
 import org.ballerinalang.model.tree.types.BuiltInReferenceTypeNode;
@@ -43,6 +44,7 @@ import org.wso2.ballerinalang.compiler.tree.BLangAnnotationAttachmentPoint;
 import org.wso2.ballerinalang.compiler.tree.BLangConnector;
 import org.wso2.ballerinalang.compiler.tree.BLangEnum;
 import org.wso2.ballerinalang.compiler.tree.BLangFunction;
+import org.wso2.ballerinalang.compiler.tree.BLangIdentifier;
 import org.wso2.ballerinalang.compiler.tree.BLangImportPackage;
 import org.wso2.ballerinalang.compiler.tree.BLangInvokableNode;
 import org.wso2.ballerinalang.compiler.tree.BLangNode;
@@ -320,8 +322,10 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
 
     private void validateAttributes(BLangAnnotationAttachment annAttachmentNode, BAnnotationSymbol annotationSymbol) {
         annAttachmentNode.attributes.forEach(annotAttachmentAttribute -> {
-            BAnnotationAttributeSymbol attributeSymbol = (BAnnotationAttributeSymbol)
-                    annotationSymbol.scope.lookup(new Name(annotAttachmentAttribute.getName())).symbol;
+            Name attributeName = names.fromIdNode((BLangIdentifier) annotAttachmentAttribute.getName());
+            BAnnotationAttributeSymbol attributeSymbol =
+                    (BAnnotationAttributeSymbol) annotationSymbol.scope.lookup(attributeName).symbol;
+            
             // Resolve Attribute against the Annotation Definition
             if (attributeSymbol == null) {
                 this.dlog.error(annAttachmentNode.pos, DiagnosticCode.NO_SUCH_ATTRIBUTE,
@@ -429,15 +433,16 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
             // Annotation Definition attribute is present
             Optional<BLangAnnotAttachmentAttribute> matchingAttribute = Arrays
                     .stream(annAttachmentNode.getAttributes().toArray(attributeArrray))
-                    .filter(attribute -> attribute.name.equals(defAttribute.name.getValue()))
+                    .filter(attribute -> attribute.name.value.equals(defAttribute.name.getValue()))
                     .findAny();
             // If no matching attribute is present populate with default value
             if (!matchingAttribute.isPresent()) {
                 if (defAttribute.expr != null) {
                     BLangAnnotAttachmentAttributeValue value = new BLangAnnotAttachmentAttributeValue();
                     value.value = defAttribute.expr;
-                    BLangAnnotAttachmentAttribute attribute =
-                            new BLangAnnotAttachmentAttribute(defAttribute.name.getValue(), value);
+                    BLangIdentifier name = (BLangIdentifier) TreeBuilder.createIdentifierNode();
+                    name.value = defAttribute.name.getValue();
+                    BLangAnnotAttachmentAttribute attribute = new BLangAnnotAttachmentAttribute(name, value);
                     annAttachmentNode.addAttribute(attribute);
                 }
                 continue;

--- a/modules/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangAnnotAttachmentAttribute.java
+++ b/modules/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangAnnotAttachmentAttribute.java
@@ -17,9 +17,11 @@
 */
 package org.wso2.ballerinalang.compiler.tree.expressions;
 
+import org.ballerinalang.model.tree.IdentifierNode;
 import org.ballerinalang.model.tree.NodeKind;
 import org.ballerinalang.model.tree.expressions.AnnotationAttachmentAttributeNode;
 import org.ballerinalang.model.tree.expressions.AnnotationAttachmentAttributeValueNode;
+import org.wso2.ballerinalang.compiler.tree.BLangIdentifier;
 import org.wso2.ballerinalang.compiler.tree.BLangNodeVisitor;
 
 /**
@@ -27,10 +29,10 @@ import org.wso2.ballerinalang.compiler.tree.BLangNodeVisitor;
  */
 public class BLangAnnotAttachmentAttribute extends BLangExpression implements AnnotationAttachmentAttributeNode {
 
-    public String name;
+    public BLangIdentifier name;
     public BLangAnnotAttachmentAttributeValue value;
 
-    public BLangAnnotAttachmentAttribute(String name, BLangAnnotAttachmentAttributeValue value) {
+    public BLangAnnotAttachmentAttribute(BLangIdentifier name, BLangAnnotAttachmentAttributeValue value) {
         this.name = name;
         this.value = value;
     }
@@ -39,13 +41,13 @@ public class BLangAnnotAttachmentAttribute extends BLangExpression implements An
     }
 
     @Override
-    public String getName() {
+    public BLangIdentifier getName() {
         return name;
     }
 
     @Override
-    public void setName(String name) {
-        this.name = name;
+    public void setName(IdentifierNode name) {
+        this.name = (BLangIdentifier) name;
     }
 
     @Override

--- a/modules/ballerina-test/src/test/java/org/ballerinalang/test/expressions/identifierliteral/IdentifierLiteralTest.java
+++ b/modules/ballerina-test/src/test/java/org/ballerinalang/test/expressions/identifierliteral/IdentifierLiteralTest.java
@@ -174,16 +174,22 @@ public class IdentifierLiteralTest {
     @Test(description = "Test defining local variables with Identifier Literal")
     public void testIdentifierLiteralInStructName() {
         BValue[] returns = BRunUtil.invoke(result, "useILInStructName");
-        Assert.assertEquals(returns.length, 3);
+        Assert.assertEquals(returns.length, 4);
         Assert.assertSame(returns[0].getClass(), BString.class);
         Assert.assertSame(returns[1].getClass(), BString.class);
         Assert.assertSame(returns[2].getClass(), BInteger.class);
+        Assert.assertSame(returns[3].getClass(), BString.class);
+
         String actualFirstName = ((BString) returns[0]).stringValue();
         Assert.assertEquals(actualFirstName, "Tom");
+
         String actualLastName = ((BString) returns[1]).stringValue();
         Assert.assertEquals(actualLastName, "hank");
+
         long actualInt = ((BInteger) returns[2]).intValue();
         Assert.assertEquals(actualInt, 50);
+
+        Assert.assertEquals(returns[3].stringValue(), "Tom");
     }
 
     @Test(description = "Test unicode with identifier literal")
@@ -201,8 +207,7 @@ public class IdentifierLiteralTest {
         CompileResult resultNeg = BCompileUtil.compile("test-src/expressions/identifierliteral" +
                 "/identifier-literal-undefined-variable-negative.bal");
         Assert.assertEquals(resultNeg.getErrorCount(), 1);
-        BAssertUtil.validateError(resultNeg, 0, "undefined symbol '|global v \" ar|'", 5, 12);
-
+        BAssertUtil.validateError(resultNeg, 0, "undefined symbol 'global v \" ar'", 5, 12);
     }
 
     @Test(description = "Test wrong character in identifier literal")
@@ -216,5 +221,25 @@ public class IdentifierLiteralTest {
         BAssertUtil.validateError(resultNeg, 2, "extraneous input 'return'", 4, 5);
         BAssertUtil.validateError(resultNeg, 3, "mismatched input ';'. expecting {'.', ',', '[', '=', '@'}",
                 4, 25);
+    }
+
+    @Test
+    public void testAcessILWithoutPipe() {
+        BValue[] returns = BRunUtil.invoke(result, "testAcessILWithoutPipe");
+        Assert.assertEquals(returns.length, 2);
+
+        Assert.assertSame(returns[0].getClass(), BString.class);
+        Assert.assertEquals(returns[0].stringValue(), "hello");
+
+        Assert.assertSame(returns[1].getClass(), BString.class);
+        Assert.assertEquals(returns[1].stringValue(), "hello");
+    }
+
+    @Test
+    public void testAcessJSONFielAsIL() {
+        BValue[] returns = BRunUtil.invoke(result, "testAcessJSONFielAsIL");
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertSame(returns[0].getClass(), BJSON.class);
+        Assert.assertEquals(returns[0].stringValue(), "I am an integer");
     }
 }

--- a/modules/ballerina-test/src/test/resources/test-src/expressions/identifierliteral/identifier-literal-success.bal
+++ b/modules/ballerina-test/src/test/resources/test-src/expressions/identifierliteral/identifier-literal-success.bal
@@ -107,9 +107,9 @@ function testConnectorActionWithIL() (string) {
     return value;
 }
 
-function useILInStructName() (string, string, int) {
+function useILInStructName() (string, string, int, string) {
     |family person| |person one| = {|first name|: "Tom", |last name|:"hank", |current age|: 50};
-    return |person one|.|first name|, |person one|.|last name|, |person one|.|current age|;
+    return |person one|.|first name|, |person one|.|last name|, |person one|.|current age|, |person one|["first name"];
 }
 
 struct |family person| {
@@ -123,3 +123,13 @@ function testUnicodeInIL() (string) {
     return |සිංහල වචනය|;
 }
 
+function testAcessILWithoutPipe() (string, string) {
+     string |x| = "hello";
+     return |x|, x;
+ }
+ 
+ function testAcessJSONFielAsIL() (json) {
+     json j = {"foo" : {"int" : "I am an integer"}};
+     return j.foo.|int|;
+ }
+ 


### PR DESCRIPTION
Currently, variable names `|x|` and `x` are considered as two distinguish names. This PR fixes that, and now both of them are considered equal.

PR with the changes for composer: https://github.com/ballerinalang/composer/pull/4709

Fix #4045