### PR TITLE
Add missing findbugs-exclude file

### DIFF
--- a/modules/ballerina-samples/findbugs-exclude.xml
+++ b/modules/ballerina-samples/findbugs-exclude.xml
@@ -1,0 +1,17 @@
+<!--
+  ~  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~  Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~  http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  -->
+<FindBugsFilter>
+</FindBugsFilter>


### PR DESCRIPTION
Without this file, `mvn test` command fails. Travis CI uses this command to run tests.