### PR TITLE
Allow duplicate column names in json xml conversion

### DIFF
--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/client/AbstractSQLAction.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/client/AbstractSQLAction.java
@@ -365,14 +365,21 @@ public abstract class AbstractSQLAction extends AbstractNativeAction {
     private ArrayList<ColumnDefinition> getColumnDefinitions(ResultSet rs)
             throws SQLException {
         ArrayList<ColumnDefinition> columnDefs = new ArrayList<>();
+        ArrayList<String> columnNames = new ArrayList<>();
         ResultSetMetaData rsMetaData = rs.getMetaData();
         int cols = rsMetaData.getColumnCount();
         for (int i = 1; i <= cols; i++) {
             String colName = rsMetaData.getColumnLabel(i);
+            if (columnNames.contains(colName)) {
+                String tableName = rsMetaData.getTableName(i).toUpperCase();
+                colName = tableName + "." + colName;
+            }
             int colType = rsMetaData.getColumnType(i);
             TypeKind mappedType = SQLDatasourceUtils.getColumnType(colType);
             columnDefs.add(new SQLDataIterator.SQLColumnDefinition(colName, mappedType, colType));
+            columnNames.add(colName);
         }
+        columnNames.clear();
         return columnDefs;
     }
 

--- a/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/client/AbstractSQLAction.java
+++ b/modules/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/actions/data/sql/client/AbstractSQLAction.java
@@ -69,7 +69,10 @@ import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import java.util.TimeZone;
 import javax.sql.XAConnection;
 import javax.transaction.TransactionManager;
@@ -362,10 +365,10 @@ public abstract class AbstractSQLAction extends AbstractNativeAction {
         return stmt;
     }
 
-    private ArrayList<ColumnDefinition> getColumnDefinitions(ResultSet rs)
+    private List<ColumnDefinition> getColumnDefinitions(ResultSet rs)
             throws SQLException {
-        ArrayList<ColumnDefinition> columnDefs = new ArrayList<>();
-        ArrayList<String> columnNames = new ArrayList<>();
+        List<ColumnDefinition> columnDefs = new ArrayList<>();
+        Set<String> columnNames = new HashSet<>();
         ResultSetMetaData rsMetaData = rs.getMetaData();
         int cols = rsMetaData.getColumnCount();
         for (int i = 1; i <= cols; i++) {
@@ -379,7 +382,6 @@ public abstract class AbstractSQLAction extends AbstractNativeAction {
             columnDefs.add(new SQLDataIterator.SQLColumnDefinition(colName, mappedType, colType));
             columnNames.add(colName);
         }
-        columnNames.clear();
         return columnDefs;
     }
 
@@ -779,7 +781,7 @@ public abstract class AbstractSQLAction extends AbstractNativeAction {
     }
 
     private BDataTable constructDataTable(ResultSet rs, Statement stmt, Connection conn) throws SQLException {
-        ArrayList<ColumnDefinition> columnDefinitions = getColumnDefinitions(rs);
+        List<ColumnDefinition> columnDefinitions = getColumnDefinitions(rs);
         return new BDataTable(new SQLDataIterator(conn, stmt, rs, utcCalendar, columnDefinitions));
     }
 

--- a/modules/ballerina-test/src/test/java/org/ballerinalang/test/types/datatable/DatatableTest.java
+++ b/modules/ballerina-test/src/test/java/org/ballerinalang/test/types/datatable/DatatableTest.java
@@ -396,6 +396,17 @@ public class DatatableTest {
         Assert.assertEquals((returns[4]).stringValue(), "100|Sample Text|Sample Text|200||null|");
     }
 
+    @Test(groups = "DatatableTest", description = "Check result sets with same column name or complex name.")
+    public void testJsonXMLConversionwithDuplicateColumnNames() {
+        BValue[] returns = BRunUtil.invoke(result, "testJsonXMLConversionwithDuplicateColumnNames");
+        Assert.assertEquals(returns.length, 2);
+        Assert.assertEquals((returns[0]).stringValue(), "[{\"ROW_ID\":1,\"INT_TYPE\":1,\"DATATABLEREP.ROW_ID\":1,"
+                + "\"DATATABLEREP.INT_TYPE\":100}]");
+        Assert.assertEquals((returns[1]).stringValue(), "<results><result><ROW_ID>1</ROW_ID><INT_TYPE>1</INT_TYPE>"
+                + "<DATATABLEREP.ROW_ID>1</DATATABLEREP.ROW_ID><DATATABLEREP.INT_TYPE>100</DATATABLEREP.INT_TYPE>"
+                + "</result></results>");
+    }
+
     @AfterSuite
     public void cleanup() {
         SQLDBUtils.deleteDirectory(new File(SQLDBUtils.DB_DIRECTORY));

--- a/modules/ballerina-test/src/test/resources/test-src/types/datatable/datatable-type.bal
+++ b/modules/ballerina-test/src/test/resources/test-src/types/datatable/datatable-type.bal
@@ -682,3 +682,24 @@ function testComplexTypeInsertAndRetrieval () (int retDataInsert, int retNullIns
     testDB.close();
     return;
 }
+
+function testJsonXMLConversionwithDuplicateColumnNames () (string jsonStr, string xmlStr) {
+    endpoint<sql:ClientConnector> testDB {
+        create sql:ClientConnector(sql:DB.HSQLDB_FILE, "./target/tempdb/",
+                                   0, "TEST_DATA_TABLE_DB", "SA", "", {maximumPoolSize:1});
+    }
+    datatable dt = testDB.select("SELECT dt1.row_id, dt1.int_type, dt2.row_id, dt2.int_type from DataTable dt1 left
+            join DataTableRep dt2 on dt1.row_id = dt2.row_id WHERE dt1.row_id = 1", null);
+    var j,_ = <json> dt;
+    jsonStr = j.toString();
+    println(jsonStr);
+
+    datatable dt2 = testDB.select("SELECT dt1.row_id, dt1.int_type, dt2.row_id, dt2.int_type from DataTable dt1 left
+            join DataTableRep dt2 on dt1.row_id = dt2.row_id WHERE dt1.row_id = 1", null);
+    var x,_ = <xml> dt2;
+    xmlStr = <string> x;
+    println(xmlStr);
+
+    testDB.close();
+    return;
+}


### PR DESCRIPTION
Fixes https://github.com/ballerinalang/ballerina/issues/2610

When duplicate column name is found the latter occurrences are appended with table name.