### PR TITLE
WS related fixes

### DIFF
--- a/modules/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
+++ b/modules/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
@@ -1315,12 +1315,16 @@ public class BLangPackageBuilder {
         startBlock();
     }
 
-    public void addTransactionBlock(DiagnosticPos pos, Set<Whitespace> ws) {
+    public void addTransactionBlock(DiagnosticPos pos) {
         TransactionNode transactionNode = transactionNodeStack.peek();
         BLangBlockStmt transactionBlock = (BLangBlockStmt) this.blockNodeStack.pop();
         transactionBlock.pos = pos;
-        transactionBlock.addWS(ws);
         transactionNode.setTransactionBody(transactionBlock);
+    }
+
+    public void endTransactionBlock(Set<Whitespace> ws) {
+        TransactionNode transactionNode = transactionNodeStack.peek();
+        transactionNode.getTransactionBody().addWS(ws);
     }
 
     public void startFailedBlock() {

--- a/modules/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
+++ b/modules/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
@@ -1645,9 +1645,6 @@ public class BLangPackageBuilder {
         addStmtToCurrentBlock(xmlnsStmt);
     }
 
-    public void attachStringTemplateLiteralWS(Set<Whitespace> ws) {
-    }
-
     public void createStringTemplateLiteral(DiagnosticPos pos, Set<Whitespace> ws, Stack<String> precedingTextFragments,
                                             String endingText) {
         BLangStringTemplateLiteral stringTemplateLiteral =

--- a/modules/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangParserListener.java
+++ b/modules/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangParserListener.java
@@ -1655,7 +1655,7 @@ public class BLangParserListener extends BallerinaParserBaseListener {
             return;
         }
 
-        this.pkgBuilder.addTransactionBlock(getCurrentPos(ctx), getWS(ctx));
+        this.pkgBuilder.addTransactionBlock(getCurrentPos(ctx));
     }
 
     /**
@@ -1663,6 +1663,7 @@ public class BLangParserListener extends BallerinaParserBaseListener {
      */
     @Override
     public void exitTransactionHandlers(BallerinaParser.TransactionHandlersContext ctx) {
+        this.pkgBuilder.endTransactionBlock(getWS(ctx));
     }
 
     /**

--- a/modules/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangWSPreservingParserListener.java
+++ b/modules/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangWSPreservingParserListener.java
@@ -95,6 +95,7 @@ public class BLangWSPreservingParserListener extends BLangParserListener {
                 // This is needed to handle A + B + C case of BinaryAddSubExpression
                 rangeEndTokenIndex = ((TerminalNode) child).getSymbol().getTokenIndex();
             } else {
+                rangesOfRuleContext.pop();
                 return;
             }
         } else {


### PR DESCRIPTION
1. Fixing white space issues of chained expressions like `a[1].b`.
See ballerinalang/composer#4670
and ballerinalang/composer@52d9b4a

2. Fixing bug in transaction ws capture.
WS can only be captured at exit rule. Please see the test file https://github.com/ballerinalang/composer/blob/master/modules/js-tests/src/test/resources/passing/jms-reliable-message-delivery.bal

3. Removing unused method.
