### PR TITLE
Refactor the getHeader() function

### DIFF
--- a/modules/ballerina-http/src/main/ballerina/ballerina/net/http/natives.bal
+++ b/modules/ballerina-http/src/main/ballerina/ballerina/net/http/natives.bal
@@ -63,9 +63,8 @@ public native function <Request req> setStringPayload (string payload);
 @Description { value:"Gets a transport header from the request"}
 @Param { value:"req: A request message" }
 @Param { value:"headerName: The header name" }
-@Return { value:"The first header value for the provided header name" }
-@Return { value:"Indicates whether the header exists" }
-public native function <Request req> getHeader (string headerName) (string, boolean);
+@Return { value:"The first header value for the provided header name. Returns null if the header does not exist." }
+public native function <Request req> getHeader (string headerName) (string);
 
 @Description { value:"Gets the request payload as a string"}
 @Param { value:"req: A request message" }
@@ -178,9 +177,8 @@ public native function <Response res> setStringPayload (string payload);
 @Description { value:"Gets the named HTTP header from the response"}
 @Param { value:"res: The response message" }
 @Param { value:"headerName: The header name" }
-@Return { value:"The first header value for the provided header name" }
-@Return { value:"Indicates whether the header exists" }
-public native function <Response res> getHeader (string headerName) (string, boolean);
+@Return { value:"The first header value for the provided header name. Returns null if the header does not exist." }
+public native function <Response res> getHeader (string headerName) (string);
 
 @Description { value:"Gets the response payload as a string"}
 @Param { value:"res: The response message" }

--- a/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpUtil.java
+++ b/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpUtil.java
@@ -31,7 +31,6 @@ import org.ballerinalang.connector.api.BallerinaConnectorException;
 import org.ballerinalang.model.util.StringUtils;
 import org.ballerinalang.model.util.XMLUtils;
 import org.ballerinalang.model.values.BBlob;
-import org.ballerinalang.model.values.BBoolean;
 import org.ballerinalang.model.values.BInteger;
 import org.ballerinalang.model.values.BJSON;
 import org.ballerinalang.model.values.BMap;
@@ -142,12 +141,8 @@ public class HttpUtil {
 
         String headerName = abstractNativeFunction.getStringArgument(context, 0);
         String headerValue = httpCarbonMessage.getHeader(headerName);
-        boolean headerExists = headerValue != null;
 
-        // Reset the header value to Ballerina string default value if the header doesn't exist
-        headerValue = !headerExists ? "" : headerValue;
-
-        return abstractNativeFunction.getBValues(new BString(headerValue), new BBoolean(headerExists));
+        return abstractNativeFunction.getBValues(new BString(headerValue));
     }
 
     public static BValue[] getJsonPayload(Context context,

--- a/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/request/GetHeader.java
+++ b/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/request/GetHeader.java
@@ -35,7 +35,7 @@ import org.ballerinalang.net.http.HttpUtil;
         receiver = @Receiver(type = TypeKind.STRUCT, structType = "Request",
                              structPackage = "ballerina.net.http"),
         args = {@Argument(name = "headerName", type = TypeKind.STRING)},
-        returnType = {@ReturnType(type = TypeKind.STRING), @ReturnType(type = TypeKind.BOOLEAN)},
+        returnType = {@ReturnType(type = TypeKind.STRING)},
         isPublic = true
 )
 public class GetHeader extends AbstractNativeFunction {

--- a/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/response/GetHeader.java
+++ b/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/response/GetHeader.java
@@ -35,7 +35,7 @@ import org.ballerinalang.net.http.HttpUtil;
         receiver = @Receiver(type = TypeKind.STRUCT, structType = "Response",
                              structPackage = "ballerina.net.http"),
         args = {@Argument(name = "headerName", type = TypeKind.STRING)},
-        returnType = {@ReturnType(type = TypeKind.STRING), @ReturnType(type = TypeKind.BOOLEAN)},
+        returnType = {@ReturnType(type = TypeKind.STRING)},
         isPublic = true
 )
 public class GetHeader extends AbstractNativeFunction {

--- a/modules/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/request/RequestNativeFunctionNegativeTest.java
+++ b/modules/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/request/RequestNativeFunctionNegativeTest.java
@@ -76,9 +76,8 @@ public class RequestNativeFunctionNegativeTest {
         BString key = new BString(Constants.CONTENT_TYPE);
         BValue[] inputArg = {request, key};
         BValue[] returnVals = BRunUtil.invoke(result, "testGetHeader", inputArg);
-        Assert.assertNotNull(((BString) returnVals[0]).value());
-        Assert.assertEquals(((BString) returnVals[0]).value(), "");
-        Assert.assertFalse(((BBoolean) returnVals[1]).booleanValue());
+        Assert.assertNotNull(returnVals[0]);
+        Assert.assertNull(((BString) returnVals[0]).value());
     }
 
     @Test(description = "Test method without json payload")

--- a/modules/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/request/RequestNativeFunctionNegativeTest.java
+++ b/modules/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/request/RequestNativeFunctionNegativeTest.java
@@ -21,7 +21,6 @@ import org.ballerinalang.launcher.util.BAssertUtil;
 import org.ballerinalang.launcher.util.BCompileUtil;
 import org.ballerinalang.launcher.util.BRunUtil;
 import org.ballerinalang.launcher.util.CompileResult;
-import org.ballerinalang.model.values.BBoolean;
 import org.ballerinalang.model.values.BJSON;
 import org.ballerinalang.model.values.BString;
 import org.ballerinalang.model.values.BStruct;

--- a/modules/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/request/RequestNativeFunctionSuccessTest.java
+++ b/modules/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/request/RequestNativeFunctionSuccessTest.java
@@ -197,7 +197,6 @@ public class RequestNativeFunctionSuccessTest {
         Assert.assertFalse(returnVals == null || returnVals.length == 0 || returnVals[0] == null,
                 "Invalid Return Values.");
         Assert.assertEquals(returnVals[0].stringValue(), Constants.APPLICATION_FORM);
-        Assert.assertTrue(((BBoolean) returnVals[1]).booleanValue());
     }
 
     @Test(description = "Test GetHeader function within a service")
@@ -356,7 +355,7 @@ public class RequestNativeFunctionSuccessTest {
 
         Assert.assertNotNull(response, "Response message not found");
         BJSON bJson = ((BJSON) response.getMessageDataSource());
-        Assert.assertTrue(bJson.value().get("value").textValue().equals(""));
+        Assert.assertNull(bJson.value().get("value").textValue());
     }
 
     @Test
@@ -390,7 +389,7 @@ public class RequestNativeFunctionSuccessTest {
 
         Assert.assertNotNull(response, "Response message not found");
         BJSON bJson = ((BJSON) response.getMessageDataSource());
-        Assert.assertTrue(bJson.value().get("value").textValue().equals(""));
+        Assert.assertNull(bJson.value().get("value").textValue());
     }
 
     @Test

--- a/modules/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/request/RequestNativeFunctionSuccessTest.java
+++ b/modules/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/request/RequestNativeFunctionSuccessTest.java
@@ -21,7 +21,6 @@ import org.ballerinalang.launcher.util.BCompileUtil;
 import org.ballerinalang.launcher.util.BRunUtil;
 import org.ballerinalang.launcher.util.BServiceUtil;
 import org.ballerinalang.launcher.util.CompileResult;
-import org.ballerinalang.model.values.BBoolean;
 import org.ballerinalang.model.values.BInteger;
 import org.ballerinalang.model.values.BJSON;
 import org.ballerinalang.model.values.BString;

--- a/modules/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/response/ResponseNativeFunctionNegativeTest.java
+++ b/modules/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/response/ResponseNativeFunctionNegativeTest.java
@@ -22,7 +22,6 @@ import org.ballerinalang.launcher.util.BCompileUtil;
 import org.ballerinalang.launcher.util.BRunUtil;
 import org.ballerinalang.launcher.util.BServiceUtil;
 import org.ballerinalang.launcher.util.CompileResult;
-import org.ballerinalang.model.values.BBoolean;
 import org.ballerinalang.model.values.BJSON;
 import org.ballerinalang.model.values.BString;
 import org.ballerinalang.model.values.BStruct;

--- a/modules/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/response/ResponseNativeFunctionNegativeTest.java
+++ b/modules/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/response/ResponseNativeFunctionNegativeTest.java
@@ -84,8 +84,7 @@ public class ResponseNativeFunctionNegativeTest {
         BString key = new BString(Constants.CONTENT_TYPE);
         BValue[] inputArg = {request, key};
         BValue[] returnVals = BRunUtil.invoke(result, "testGetHeader", inputArg);
-        Assert.assertEquals(((BString) returnVals[0]).value(), "");
-        Assert.assertFalse(((BBoolean) returnVals[1]).booleanValue());
+        Assert.assertNull(((BString) returnVals[0]).value());
     }
 
     @Test(description = "Test method without json payload")

--- a/modules/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/response/ResponseNativeFunctionSuccessTest.java
+++ b/modules/ballerina-test/src/test/java/org/ballerinalang/test/services/nativeimpl/response/ResponseNativeFunctionSuccessTest.java
@@ -345,7 +345,7 @@ public class ResponseNativeFunctionSuccessTest {
 
         Assert.assertNotNull(response, "Response message not found");
         BJSON bJson = ((BJSON) response.getMessageDataSource());
-        Assert.assertTrue(bJson.value().get("value").textValue().equals(""));
+        Assert.assertNull(bJson.value().get("value").textValue());
     }
 
     @Test
@@ -375,7 +375,7 @@ public class ResponseNativeFunctionSuccessTest {
 
         Assert.assertNotNull(response, "Response message not found");
         BJSON bJson = ((BJSON) response.getMessageDataSource());
-        Assert.assertTrue(bJson.value().get("value").textValue().equals(""));
+        Assert.assertNull(bJson.value().get("value").textValue());
     }
 
     @Test

--- a/modules/ballerina-test/src/test/resources/test-src/services/dispatching/uri-template.bal
+++ b/modules/ballerina-test/src/test/resources/test-src/services/dispatching/uri-template.bal
@@ -8,7 +8,7 @@ service<http> Ecommerce {
     }
     resource productsInfo1 (http:Request req, http:Response res, string productId, string regId) {
         string orderId;
-        orderId, _ = req.getHeader("X-ORDER-ID");
+        orderId = req.getHeader("X-ORDER-ID");
         println("Order ID " + orderId);
         println("Product ID " + productId);
         println("Reg ID " + regId);

--- a/modules/ballerina-test/src/test/resources/test-src/services/session/http-session-test.bal
+++ b/modules/ballerina-test/src/test/resources/test-src/services/session/http-session-test.bal
@@ -304,10 +304,9 @@ service<http> sample2 {
     resource getmap (http:Request req, http:Response res) {
 
         http:Session session = req.createSessionIfAbsent();
-        string value;
-        boolean available;
-        value,available = req.getHeader("counter");
-        if (!available) {
+        string value = req.getHeader("counter");
+        if (value == null) {
+            println("null header");
             session.setAttribute("Name", "chamil");
             session.setAttribute("Lang", "ballerina");
             map attributes = session.getAttributes();
@@ -317,6 +316,7 @@ service<http> sample2 {
             res.setStringPayload(arr[0] + ":" + v0);
         } else {
             map attributes = session.getAttributes();
+            println(attributes);
             string[] arr = attributes.keys();
             string v1;
             v1,_ = (string)attributes[arr[1]];

--- a/modules/ballerina-test/src/test/resources/test-src/statements/services/nativeimpl/request/request-native-function-negative.bal
+++ b/modules/ballerina-test/src/test/resources/test-src/statements/services/nativeimpl/request/request-native-function-negative.bal
@@ -5,11 +5,9 @@ function testGetContentLength (http:Request req) (int) {
     return length;
 }
 
-function testGetHeader (http:Request req, string key) (string, boolean) {
-    string contentType;
-    boolean headerExists;
-    contentType, headerExists = req.getHeader(key);
-    return contentType, headerExists;
+function testGetHeader (http:Request req, string key) (string) {
+    string contentType = req.getHeader(key);
+    return contentType;
 }
 
 function testGetJsonPayload (http:Request req) (json) {

--- a/modules/ballerina-test/src/test/resources/test-src/statements/services/nativeimpl/request/request-native-function.bal
+++ b/modules/ballerina-test/src/test/resources/test-src/statements/services/nativeimpl/request/request-native-function.bal
@@ -15,11 +15,9 @@ function testGetContentLength (http:Request req) (int) {
     return length;
 }
 
-function testGetHeader (http:Request req, string key) (string, boolean) {
-    string contentType;
-    boolean headerExists;
-    contentType, headerExists = req.getHeader(key);
-    return contentType, headerExists;
+function testGetHeader (http:Request req, string key) (string) {
+    string contentType = req.getHeader(key);
+    return contentType;
 }
 
 function testGetJsonPayload (http:Request req) (json) {
@@ -127,8 +125,7 @@ service<http> helloServer {
     }
     resource addheader (http:Request req, http:Response res, string key, string value) {
         req.addHeader(key, value);
-        string result;
-        result, _ = req.getHeader(key);
+        string result = req.getHeader(key);
         res.setJsonPayload({lang:result});
         _ = res.send();
     }
@@ -156,8 +153,7 @@ service<http> helloServer {
         path:"/getHeader"
     }
     resource getHeader (http:Request req, http:Response res) {
-        string header;
-        header, _ = req.getHeader("Content-Type");
+        string header = req.getHeader("Content-Type");
         res.setJsonPayload({value:header});
         _ = res.send();
     }
@@ -205,8 +201,7 @@ service<http> helloServer {
     }
     resource RemoveHeader (http:Request req, http:Response res) {
         req.removeHeader("Content-Type");
-        string header;
-        header, _ = req.getHeader("Content-Type");
+        string header = req.getHeader("Content-Type");
         res.setJsonPayload({value:header});
         _ = res.send();
     }
@@ -216,8 +211,7 @@ service<http> helloServer {
     }
     resource RemoveAllHeaders (http:Request req, http:Response res) {
         req.removeAllHeaders();
-        string header;
-        header, _ = req.getHeader("Range");
+        string header = req.getHeader("Range");
         res.setJsonPayload({value:header});
         _ = res.send();
     }
@@ -237,8 +231,7 @@ service<http> helloServer {
     }
     resource setHeader (http:Request req, http:Response res, string key, string value) {
         req.setHeader(key, value);
-        string result;
-        result, _ = req.getHeader(key);
+        string result = req.getHeader(key);
         res.setJsonPayload({value:result});
         _ = res.send();
     }

--- a/modules/ballerina-test/src/test/resources/test-src/statements/services/nativeimpl/response/response-native-function-negative.bal
+++ b/modules/ballerina-test/src/test/resources/test-src/statements/services/nativeimpl/response/response-native-function-negative.bal
@@ -15,11 +15,9 @@ function testGetContentLength (http:Response res) (int) {
     return length;
 }
 
-function testGetHeader (http:Response res, string key) (string, boolean) {
-    string contentType;
-    boolean headerExists;
-    contentType, headerExists = res.getHeader(key);
-    return contentType, headerExists;
+function testGetHeader (http:Response res, string key) (string) {
+    string contentType = res.getHeader(key);
+    return contentType;
 }
 
 function testGetJsonPayload (http:Response res) (json) {

--- a/modules/ballerina-test/src/test/resources/test-src/statements/services/nativeimpl/response/response-native-function.bal
+++ b/modules/ballerina-test/src/test/resources/test-src/statements/services/nativeimpl/response/response-native-function.bal
@@ -15,11 +15,9 @@ function testGetContentLength (http:Response res) (int) {
     return length;
 }
 
-function testGetHeader (http:Response res, string key) (string, boolean) {
-    string contentType;
-    boolean headerExists;
-    contentType, headerExists = res.getHeader(key);
-    return contentType, headerExists;
+function testGetHeader (http:Response res, string key) (string) {
+    string contentType = res.getHeader(key);
+    return contentType;
 }
 
 function testGetJsonPayload (http:Response res) (json) {
@@ -128,8 +126,7 @@ service<http> helloServer {
     }
     resource addheader (http:Request req, http:Response res, string key, string value) {
         res.addHeader(key, value);
-        string result;
-        result, _ = res.getHeader(key);
+        string result = res.getHeader(key);
         res.setJsonPayload({lang:result});
         _ = res.send();
     }
@@ -160,8 +157,7 @@ service<http> helloServer {
     }
     resource getHeader (http:Request req, http:Response res, string header, string value) {
         res.setHeader(header, value);
-        string result;
-        result, _ = res.getHeader(header);
+        string result = res.getHeader(header);
         res.setJsonPayload({value:result});
         _ = res.send();
     }
@@ -216,8 +212,7 @@ service<http> helloServer {
     resource RemoveHeader (http:Request req, http:Response res, string key, string value) {
         res.setHeader(key, value);
         res.removeHeader(key);
-        string header;
-        header, _ = res.getHeader(key);
+        string header = res.getHeader(key);
         res.setJsonPayload({value:header});
         _ = res.send();
     }
@@ -229,8 +224,7 @@ service<http> helloServer {
         res.setHeader("Expect", "100-continue");
         res.setHeader("Range", "bytes=500-999");
         res.removeAllHeaders();
-        string header;
-        header, _ = res.getHeader("Range");
+        string header = res.getHeader("Range");
         res.setJsonPayload({value:header});
         _ = res.send();
     }

--- a/samples/ballerina-by-example/examples/header-based-routing/header-based-routing.bal
+++ b/samples/ballerina-by-example/examples/header-based-routing/header-based-routing.bal
@@ -20,15 +20,12 @@ service<http> headerBasedRouting {
         http:Response clientResponse = {};
         http:HttpConnectorError err;
         //Native function getHeader() returns header value of a specified header name.
-        string nameString;
-        boolean headerExists;
-        nameString, headerExists = req.getHeader("type");
-        if (headerExists && nameString == "location") {
+        string nameString = req.getHeader("type");
+        if (nameString == "location") {
             //"post" represent the POST action of HTTP connector. Route payload to relevant service.
             clientResponse, err = locationEP.post("/v2/594e12271100001f13d6d3a6", newRequest);
         } else {
             //"get" action can be used to make http GET call.
-
             clientResponse, err = weatherEP.get("/data/2.5/weather?lat=35&lon=139&appid=b1b1", newRequest);
         }
 

--- a/samples/ballerina-by-example/examples/http-client-connector/http-client-connector.bal
+++ b/samples/ballerina-by-example/examples/http-client-connector/http-client-connector.bal
@@ -50,7 +50,7 @@ function main (string[] args) {
     resp, _ = httpConnector.get("/get", req);
 
     string contentType;
-    contentType, _ = resp.getHeader("Content-Type");
+    contentType = resp.getHeader("Content-Type");
     println("\nContent-Type: " + contentType);
 
     int statusCode = resp.getStatusCode();

--- a/samples/getting_started/routingServices/routingServices/samples/headerBasedRoutingService.bal
+++ b/samples/getting_started/routingServices/routingServices/samples/headerBasedRoutingService.bal
@@ -17,12 +17,10 @@ service<http> headerBasedRouting {
             create http:HttpClient("http://localhost:9090/nyseStocks", {});
         }
         string nyseString = "nyse";
-        string nameString;
-        boolean headerExists;
-        nameString, headerExists = req.getHeader("name");
+        string nameString = req.getHeader("name");
         http:Response clientResponse = {};
         http:HttpConnectorError err;
-        if (headerExists && nameString == nyseString) {
+        if (nameString == nyseString) {
             clientResponse, err = nyseEP.post("/stocks", req);
         } else {
             clientResponse, err = nasdaqEP.post("/stocks", req);


### PR DESCRIPTION
This PR refactors the getHeader() function to make use of null in strings to indicate non-existent headers, instead of returning a boolean with the header value to indicate the presence of a header.