### PR TITLE
Fixing annotation order

### DIFF
--- a/modules/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
+++ b/modules/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
@@ -1172,9 +1172,10 @@ public class BLangPackageBuilder {
                 (BLangAnnotAttachmentAttributeValue) TreeBuilder.createAnnotAttributeValueNode();
         annotAttrVal.pos = currentPos;
         annotAttrVal.addWS(ws);
-        while (!annotAttribValStack.isEmpty()) {
-            annotAttrVal.addValue(annotAttribValStack.pop());
+        for (AnnotationAttachmentAttributeValueNode attributeValue : annotAttribValStack) {
+            annotAttrVal.addValue(attributeValue);
         }
+        annotAttribValStack.removeAllElements();
         annotAttribValStack.push(annotAttrVal);
     }
 

--- a/modules/ballerina-test/src/test/java/org/ballerinalang/test/annotations/AnnotationTest.java
+++ b/modules/ballerina-test/src/test/java/org/ballerinalang/test/annotations/AnnotationTest.java
@@ -53,7 +53,7 @@ public class AnnotationTest {
                 .getAttributeValueArray()[0];
         attributeValue = firstElement.getAnnotationAttachmentValue()
                 .getAttributeValue("name").getStringValue();
-        Assert.assertEquals(attributeValue, "paramName3");
+        Assert.assertEquals(attributeValue, "paramName");
 
         AnnAttributeValue secondElement = attachmentInfos[0].getAttributeValue("queryParamValue")
                 .getAttributeValueArray()[1];
@@ -65,7 +65,7 @@ public class AnnotationTest {
                 .getAttributeValueArray()[2];
         attributeValue = thirdElement.getAnnotationAttachmentValue()
                 .getAttributeValue("name").getStringValue();
-        Assert.assertEquals(attributeValue, "paramName");
+        Assert.assertEquals(attributeValue, "paramName3");
 
         Assert.assertEquals(attachmentInfos[1].getAttributeValue("value").getStringValue(),
                 "test @Args annotation");
@@ -190,7 +190,7 @@ public class AnnotationTest {
                 .getAttributeValue("queryParamValue").getAttributeValueArray();
         Assert.assertEquals(annotationArray.length, 3, "Wrong annotation array length");
 
-        String attributeValue = annotationArray[2]
+        String attributeValue = annotationArray[0]
                 .getAnnotationAttachmentValue().getAttributeValue("name").getStringValue();
         Assert.assertEquals(attributeValue, "paramName");
 
@@ -198,7 +198,7 @@ public class AnnotationTest {
                 .getAnnotationAttachmentValue().getAttributeValue("name").getStringValue();
         Assert.assertEquals(attributeValue, "paramName2");
 
-        attributeValue = annotationArray[0]
+        attributeValue = annotationArray[2]
                 .getAnnotationAttachmentValue().getAttributeValue("name").getStringValue();
         Assert.assertEquals(attributeValue, "paramName3");
 

--- a/modules/ballerina-test/src/test/java/org/ballerinalang/test/services/cors/HTTPCorsTest.java
+++ b/modules/ballerina-test/src/test/java/org/ballerinalang/test/services/cors/HTTPCorsTest.java
@@ -93,7 +93,7 @@ public class HTTPCorsTest {
         Assert.assertEquals(bJson.value().get("echo").asText(), "resOnlyCors");
         Assert.assertEquals("http://www.hello.com", response.getHeader(Constants.AC_ALLOW_ORIGIN));
         Assert.assertEquals(null, response.getHeader(Constants.AC_ALLOW_CREDENTIALS));
-        Assert.assertEquals("X-PINGOTHER, X-Content-Type-Options", response.getHeader(Constants.AC_EXPOSE_HEADERS));
+        Assert.assertEquals("X-Content-Type-Options, X-PINGOTHER", response.getHeader(Constants.AC_EXPOSE_HEADERS));
     }
 
     @Test(description = "Test simple request with multiple origins")

--- a/modules/ballerina-test/src/test/java/org/ballerinalang/test/services/dispatching/UriTemplateDispatcherTest.java
+++ b/modules/ballerina-test/src/test/java/org/ballerinalang/test/services/dispatching/UriTemplateDispatcherTest.java
@@ -286,7 +286,7 @@ public class UriTemplateDispatcherTest {
                 , "Response code mismatch");
 
         String allowHeader = response.getHeader(Constants.ALLOW);
-        Assert.assertEquals(allowHeader, "UPDATE, POST, PUT, GET, HEAD, OPTIONS");
+        Assert.assertEquals(allowHeader, "POST, UPDATE, GET, PUT, HEAD, OPTIONS");
     }
 
     @Test(description = "Test dispatching with OPTIONS request to Root")


### PR DESCRIPTION
In following source 
```ballerina
@doc:Description{value: ["description 1", "description 2"] }
function foo (string args) {
    // do nothing
}
```
Tree look like below
```
.
.
├── value=AnnotationAttachmentAttributeValue
│   ├── valueArray[0].Literal=value:"description 2"
│   └── valueArray[1].Literal=value:"description 1"
.
.
```

This PR corrects the order.