### PR TITLE
Fix Ballerina txManager reuse issue in worker contexts

### DIFF
--- a/modules/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/WorkerContext.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/WorkerContext.java
@@ -40,7 +40,6 @@ public class WorkerContext extends Context {
     
     private void populateContextPropsFromParent() {
         this.setConnectorFuture(this.parent.getConnectorFuture());
-        this.setBallerinaTransactionManager(this.parent.getBallerinaTransactionManager());
         this.setServiceInfo(this.parent.getServiceInfo());
     }
 


### PR DESCRIPTION
BallerinaTransactionManager is designed to run within a single context. It should not be passed from parent context to the child contexts.