### PR TITLE
Close output stream from http-thin layer

### DIFF
--- a/modules/ballerina-core/src/main/java/org/ballerinalang/model/values/BJSON.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/model/values/BJSON.java
@@ -170,7 +170,6 @@ public final class BJSON extends BallerinaMessageDataSource implements BRefType<
              * it should be able to serialize the data out again using the value */
             if (this.value != null) {
                 this.value.serialize(this.outputStream);
-                this.outputStream.close();
             } else {
                 JsonGenerator gen = new JsonGenerator(this.outputStream);
                 this.datasource.serialize(gen);

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/model/values/BMap.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/model/values/BMap.java
@@ -191,7 +191,6 @@ public class BMap<K, V extends BValue> extends BallerinaMessageDataSource implem
     public void serializeData() {
         try {
             outputStream.write(stringValue().getBytes(Charset.defaultCharset()));
-            outputStream.close();
         } catch (IOException e) {
             throw new BallerinaException("Error occurred while serializing data", e);
         }

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/model/values/BXMLItem.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/model/values/BXMLItem.java
@@ -582,7 +582,6 @@ public final class BXMLItem extends BXML<OMNode> {
     public void serializeData() {
         try {
             this.omNode.serialize(this.outputStream);
-            this.outputStream.close();
         } catch (Throwable t) {
             handleXmlException("error occurred during writing the message to the output stream: ", t);
         }

--- a/modules/ballerina-core/src/main/java/org/ballerinalang/runtime/message/StringDataSource.java
+++ b/modules/ballerina-core/src/main/java/org/ballerinalang/runtime/message/StringDataSource.java
@@ -65,7 +65,6 @@ public class StringDataSource extends BallerinaMessageDataSource {
     public void serializeData() {
         try {
             this.outputStream.write(this.value.getBytes(Charset.defaultCharset()));
-            this.outputStream.close();
         } catch (IOException e) {
             throw new BallerinaException("Error occurred during writing the string message to the output stream", e);
         }

--- a/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/Constants.java
+++ b/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/Constants.java
@@ -148,6 +148,7 @@ public class Constants {
     public static final String TYPE_STRING = "string";
     public static final String TRANSPORT_MESSAGE = "transport_message";
     public static final String MESSAGE_DATA_SOURCE = "message_dataSource";
+    public static final String MESSAGE_OUTPUT_STREAM = "message_output_stream";
     public static final String INBOUND_REQUEST_MESSAGE = "inbound_request_msg";
     public static final String INBOUND_REQUEST = "inbound_request";
     public static final String OUTBOUND_RESPONSE = "outbound_response";

--- a/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/HTTPResourceDispatcher.java
+++ b/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/HTTPResourceDispatcher.java
@@ -90,6 +90,6 @@ public class HTTPResourceDispatcher {
         CorsHeaderGenerator.process(cMsg, response, false);
         response.setProperty(Constants.HTTP_STATUS_CODE, 200);
         response.setEndOfMsgAdded(true);
-        HttpUtil.handleResponse(cMsg, response);
+        HttpUtil.sendOutboundResponse(cMsg, response);
     }
 }

--- a/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpUtil.java
+++ b/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpUtil.java
@@ -417,7 +417,9 @@ public class HttpUtil {
     public static void closeMessageOutputStream(BStruct httpMsgStruct) {
         OutputStream messageOutputStream = (OutputStream) httpMsgStruct.getNativeData(MESSAGE_OUTPUT_STREAM);
         try {
-            messageOutputStream.close();
+            if (messageOutputStream != null) {
+                messageOutputStream.close();
+            }
         } catch (IOException e) {
             log.error("Couldn't close message output stream", e);
         }

--- a/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpUtil.java
+++ b/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpUtil.java
@@ -478,8 +478,8 @@ public class HttpUtil {
         HttpResponseStatusFuture outboundResponseStatusFuture = sendOutboundResponse(requestMessage, responseMessage);
         if (outboundMessageSource != null) {
             outboundMessageSource.serializeData();
+            HttpUtil.closeMessageOutputStream(httpMessageStruct);
         }
-        HttpUtil.closeMessageOutputStream(httpMessageStruct);
 
         try {
             outboundResponseStatusFuture = outboundResponseStatusFuture.sync();

--- a/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/AbstractHTTPAction.java
+++ b/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/AbstractHTTPAction.java
@@ -166,6 +166,7 @@ public abstract class AbstractHTTPAction extends AbstractNativeAction {
         if (messageDataSource != null) {
             messageDataSource.serializeData();
         }
+        HttpUtil.closeMessageOutputStream(requestStruct);
     }
 
     private RetryConfig getRetryConfiguration(Context context) {

--- a/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/response/Forward.java
+++ b/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/response/Forward.java
@@ -28,7 +28,6 @@ import org.ballerinalang.natives.annotations.BallerinaFunction;
 import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.net.http.Constants;
 import org.ballerinalang.net.http.HttpUtil;
-import org.ballerinalang.runtime.message.MessageDataSource;
 import org.ballerinalang.util.codegen.AnnAttachmentInfo;
 import org.ballerinalang.util.codegen.AnnAttributeValue;
 import org.ballerinalang.util.exceptions.BallerinaException;

--- a/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/response/Forward.java
+++ b/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/response/Forward.java
@@ -82,11 +82,6 @@ public class Forward extends AbstractNativeFunction {
             HttpUtil.setHeadersToTransportMessage(responseMessage, inboundResponseStruct);
         }
 
-        MessageDataSource messageDataSource = HttpUtil.getMessageDataSource(outboundResponseStruct);
-        if (messageDataSource != null) {
-            messageDataSource.serializeData();
-        }
-
         return HttpUtil.prepareResponseAndSend(context, this, requestMessage,
                 responseMessage, inboundResponseStruct);
     }

--- a/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/response/Send.java
+++ b/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/nativeimpl/response/Send.java
@@ -28,7 +28,6 @@ import org.ballerinalang.natives.annotations.Receiver;
 import org.ballerinalang.natives.annotations.ReturnType;
 import org.ballerinalang.net.http.Constants;
 import org.ballerinalang.net.http.HttpUtil;
-import org.ballerinalang.runtime.message.MessageDataSource;
 import org.ballerinalang.util.codegen.AnnAttachmentInfo;
 import org.ballerinalang.util.codegen.AnnAttributeValue;
 import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
@@ -49,13 +48,13 @@ public class Send extends AbstractNativeFunction {
 
     @Override
     public BValue[] execute(Context context) {
-        BStruct responseStruct = (BStruct) getRefArgument(context, 0);
-        HTTPCarbonMessage requestMessage = (HTTPCarbonMessage) responseStruct
+        BStruct outboundResponseStruct = (BStruct) getRefArgument(context, 0);
+        HTTPCarbonMessage requestMessage = (HTTPCarbonMessage) outboundResponseStruct
                 .getNativeData(Constants.INBOUND_REQUEST_MESSAGE);
-        HttpUtil.checkFunctionValidity(responseStruct, requestMessage);
+        HttpUtil.checkFunctionValidity(outboundResponseStruct, requestMessage);
 
         HTTPCarbonMessage responseMessage = HttpUtil
-                .getCarbonMsg(responseStruct, HttpUtil.createHttpCarbonMessage(false));
+                .getCarbonMsg(outboundResponseStruct, HttpUtil.createHttpCarbonMessage(false));
 
         AnnAttachmentInfo configAnn = context.getServiceInfo().getAnnotationAttachmentInfo(
                 Constants.PROTOCOL_PACKAGE_HTTP, Constants.ANN_NAME_CONFIG);
@@ -73,11 +72,11 @@ public class Send extends AbstractNativeFunction {
             // default behaviour: keepAlive = true
             responseMessage.setHeader(Constants.CONNECTION_HEADER, Constants.HEADER_VAL_CONNECTION_KEEP_ALIVE);
         }
-        if (responseStruct.getRefField(Constants.RESPONSE_HEADERS_INDEX) != null) {
-            HttpUtil.setHeadersToTransportMessage(responseMessage, responseStruct);
+        if (outboundResponseStruct.getRefField(Constants.RESPONSE_HEADERS_INDEX) != null) {
+            HttpUtil.setHeadersToTransportMessage(responseMessage, outboundResponseStruct);
         }
 
-        return HttpUtil.prepareResponseAndSend(context, this, requestMessage,
-                responseMessage, (MessageDataSource) responseStruct.getNativeData(Constants.MESSAGE_DATA_SOURCE));
+        return HttpUtil.prepareResponseAndSend(context, this, requestMessage, responseMessage,
+                outboundResponseStruct);
     }
 }


### PR DESCRIPTION
When we create a DataSource, we create an output stream using the HttpCarbonMessage. This stream is used when we serialize the data. However, along with serializing data it was required to close the stream withing the serialize method. 

With this PR I have moved that part to http-thin layer. So DataSource developers does not need to worry about closing the stream. 