### PR TITLE
Add HTTP-Disable-Chunking ballerina by example

### DIFF
--- a/samples/ballerina-by-example/examples.txt
+++ b/samples/ballerina-by-example/examples.txt
@@ -59,6 +59,7 @@ HTTP Sessions
 HTTP Client Connector
 HTTPS Server Connector
 HTTPS Server/Client Connectors
+HTTP Disable Chunking
 HTTP to WebSocket Upgrade
 Log API
 Function Pointers

--- a/samples/ballerina-by-example/examples/http-disable-chunking/http-disable-chunking.bal
+++ b/samples/ballerina-by-example/examples/http-disable-chunking/http-disable-chunking.bal
@@ -27,7 +27,7 @@ service<http> echo {
     }
     resource echoResource (http:Request req, http:Response res) {
         string value;
-        //Sets respond according to the request headers.
+        //Set response according to the request headers.
         if (req.getHeader("Content-Length") != null) {
             value = "Lenght-" + req.getHeader("Content-Length").value;
         } else {

--- a/samples/ballerina-by-example/examples/http-disable-chunking/http-disable-chunking.bal
+++ b/samples/ballerina-by-example/examples/http-disable-chunking/http-disable-chunking.bal
@@ -1,0 +1,39 @@
+import ballerina.net.http;
+
+service<http> chunkingSample {
+
+    @Description {value:"Server does a backend call using chunking disabled HttpClient"}
+    @http:resourceConfig {
+        path:"/"
+    }
+    resource sample (http:Request req, http:Response res) {
+        //Config client connector chunking behaviour by adding boolean value to enableChunking option.
+        endpoint<http:HttpClient> endPoint {
+            create http:HttpClient("http://localhost:9090", {enableChunking:false});
+        }
+        //Create new request and set payload.
+        http:Request newReq = {};
+        newReq.setJsonPayload({"hello":"world!"});
+        var clientResponse, _ = endPoint.post("/echo/", newReq);
+        //Respond the inbound response.
+        _ = res.forward(clientResponse);
+    }
+}
+
+@Description {value:"Sample backend which respond according chunking behaviour."}
+service<http> echo {
+    @http:resourceConfig {
+        path:"/"
+    }
+    resource echoResource (http:Request req, http:Response res) {
+        string value;
+        //Sets respond according to the request headers.
+        if (req.getHeader("Content-Length") != null) {
+            value = "Lenght-" + req.getHeader("Content-Length").value;
+        } else {
+            value = req.getHeader("Transfer-Encoding").value;
+        }
+        res.setJsonPayload({"Outbound request content":value});
+        _ = res.send();
+    }
+}

--- a/samples/ballerina-by-example/examples/http-disable-chunking/http-disable-chunking.client.sh
+++ b/samples/ballerina-by-example/examples/http-disable-chunking/http-disable-chunking.client.sh
@@ -1,0 +1,5 @@
+$ curl http://localhost:9090/chunkingSample/
+{"Outbound request content":"Lenght-18"}
+
+Try setting true to enableChunking in Options
+{"Outbound request content":"chunked"}

--- a/samples/ballerina-by-example/examples/http-disable-chunking/http-disable-chunking.description
+++ b/samples/ballerina-by-example/examples/http-disable-chunking/http-disable-chunking.description
@@ -1,0 +1,3 @@
+//Example depicts the method of changing ballerina http client connector chunking option. By default http client sends Transfer encoding chunked requests. But user can disable chunking using connector Options.
+
+

--- a/samples/ballerina-by-example/examples/http-disable-chunking/http-disable-chunking.server.sh
+++ b/samples/ballerina-by-example/examples/http-disable-chunking/http-disable-chunking.server.sh
@@ -1,0 +1,3 @@
+$ ballerina run http-enable-disable-chunking.bal
+ballerina: deploying service(s) in 'http-enable-disable-chunking.bal'
+ballerina: started HTTP/WS server connector 0.0.0.0:9090


### PR DESCRIPTION
PR adds ballerina by example to depict how to disable/enable chunking behavior in Http Client.
Fixes #4325 