### PR TITLE
Add httpVersion HTTP client Options field

### DIFF
--- a/modules/ballerina-http/src/main/ballerina/ballerina/net/http/natives.bal
+++ b/modules/ballerina-http/src/main/ballerina/ballerina/net/http/natives.bal
@@ -336,6 +336,7 @@ struct Proxy {
 @Field {value:"endpointTimeout: Endpoint timeout value in millisecond"}
 @Field {value:"enableChunking: Enable/disable chunking"}
 @Field {value:"keepAlive: Keep the connection or close it (default value: true)"}
+@Field {value:"httpVersion: The version of HTTP"}
 @Field {value:"followRedirects: Redirect related options"}
 @Field {value:"ssl: SSL/TLS related options"}
 @Field {value:"retryConfig: Retry related options"}
@@ -345,6 +346,7 @@ public struct Options {
     int endpointTimeout = 60000;
     boolean enableChunking = true;
     boolean keepAlive = true;
+	string httpVersion;
     FollowRedirects followRedirects;
     SSL ssl;
     Retry retryConfig;

--- a/modules/ballerina-http/src/main/ballerina/ballerina/net/http/natives.bal
+++ b/modules/ballerina-http/src/main/ballerina/ballerina/net/http/natives.bal
@@ -336,7 +336,7 @@ struct Proxy {
 @Field {value:"endpointTimeout: Endpoint timeout value in millisecond"}
 @Field {value:"enableChunking: Enable/disable chunking"}
 @Field {value:"keepAlive: Keep the connection or close it (default value: true)"}
-@Field {value:"httpVersion: The version of HTTP"}
+@Field {value:"httpVersion: The version of HTTP outbound request"}
 @Field {value:"followRedirects: Redirect related options"}
 @Field {value:"ssl: SSL/TLS related options"}
 @Field {value:"retryConfig: Retry related options"}

--- a/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/Constants.java
+++ b/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/Constants.java
@@ -161,6 +161,7 @@ public class Constants {
     public static final int ENDPOINT_TIMEOUT_STRUCT_INDEX = 1;
     public static final int ENABLE_CHUNKING_INDEX = 0;
     public static final int IS_KEEP_ALIVE_INDEX = 1;
+    public static final int HTTP_VERSION_STRUCT_INDEX = 0;
     public static final int SSL_STRUCT_INDEX = 1;
     public static final int FOLLOW_REDIRECT_STRUCT_INDEX = 0;
     public static final int FOLLOW_REDIRECT_INDEX = 0;

--- a/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpConnectionManager.java
+++ b/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpConnectionManager.java
@@ -359,7 +359,7 @@ public class HttpConnectionManager {
         senderConfiguration.setFollowRedirect(followRedirect == 1);
         senderConfiguration.setMaxRedirectCount(maxRedirectCount);
         int enableChunking = options.getBooleanField(Constants.ENABLE_CHUNKING_INDEX);
-        senderConfiguration.setChunkDisabled(enableChunking == 0);
+        senderConfiguration.setChunkEnabled(enableChunking == 1);
 
         long endpointTimeout = options.getIntField(Constants.ENDPOINT_TIMEOUT_STRUCT_INDEX);
         if (endpointTimeout < 0 || (int) endpointTimeout != endpointTimeout) {
@@ -370,8 +370,7 @@ public class HttpConnectionManager {
         boolean isKeepAlive = options.getBooleanField(Constants.IS_KEEP_ALIVE_INDEX) == 1;
         senderConfiguration.setKeepAlive(isKeepAlive);
         String httpVersion = options.getStringField(Constants.HTTP_VERSION_STRUCT_INDEX);
-        senderConfiguration.setKeepAlive(isKeepAlive);
-
+        senderConfiguration.setHttpVersion(httpVersion);
     }
 
     private String makeFirstLetterLowerCase(String str) {

--- a/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpConnectionManager.java
+++ b/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpConnectionManager.java
@@ -369,6 +369,9 @@ public class HttpConnectionManager {
 
         boolean isKeepAlive = options.getBooleanField(Constants.IS_KEEP_ALIVE_INDEX) == 1;
         senderConfiguration.setKeepAlive(isKeepAlive);
+        String httpVersion = options.getStringField(Constants.HTTP_VERSION_STRUCT_INDEX);
+        senderConfiguration.setKeepAlive(isKeepAlive);
+
     }
 
     private String makeFirstLetterLowerCase(String str) {


### PR DESCRIPTION
PR adds httpVersion field to HTTP client Options where user can config the version. 
```ballerina
endpoint<http:HttpClient> endPoint {
    create http:HttpClient("http://localhost:9090/echo", {httpVersion:"HTTP/1.0"});
}
```
Fixes #3953