### PR TITLE
Move the client connector creation logic to init action

### DIFF
--- a/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpConnectionManager.java
+++ b/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpConnectionManager.java
@@ -17,23 +17,16 @@
  */
 package org.ballerinalang.net.http;
 
-import org.apache.commons.lang3.StringUtils;
 import org.ballerinalang.connector.api.BallerinaConnectorException;
 import org.ballerinalang.logging.BLogManager;
 import org.ballerinalang.logging.util.BLogLevel;
-import org.ballerinalang.model.values.BConnector;
-import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.net.http.util.ConnectorStartupSynchronizer;
 import org.ballerinalang.net.ws.BallerinaWsServerConnectorListener;
 import org.ballerinalang.net.ws.WebSocketServicesRegistry;
 import org.wso2.carbon.messaging.exceptions.ServerConnectorException;
-import org.wso2.transport.http.netty.common.ProxyServerConfiguration;
 import org.wso2.transport.http.netty.config.ConfigurationBuilder;
 import org.wso2.transport.http.netty.config.ListenerConfiguration;
-import org.wso2.transport.http.netty.config.Parameter;
-import org.wso2.transport.http.netty.config.SenderConfiguration;
 import org.wso2.transport.http.netty.config.TransportsConfiguration;
-import org.wso2.transport.http.netty.contract.HttpClientConnector;
 import org.wso2.transport.http.netty.contract.HttpWsConnectorFactory;
 import org.wso2.transport.http.netty.contract.ServerConnector;
 import org.wso2.transport.http.netty.contract.ServerConnectorFuture;
@@ -46,11 +39,8 @@ import org.wso2.transport.http.netty.message.HTTPConnectorUtil;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.net.UnknownHostException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -64,13 +54,8 @@ import java.util.logging.LogManager;
 public class HttpConnectionManager {
 
     private static HttpConnectionManager instance = new HttpConnectionManager();
-    private Map<String, org.wso2.transport.http.netty.contract.ServerConnector>
-            startupDelayedHTTPServerConnectors = new HashMap<>();
-
-    private Map<String, org.wso2.transport.http.netty.contract.ServerConnector>
-            startedHTTPServerConnectors = new HashMap<>();
-    private Map<String, HttpServerConnectorContext>
-            serverConnectorPool = new HashMap<>();
+    private Map<String, ServerConnector> startupDelayedHTTPServerConnectors = new HashMap<>();
+    private Map<String, HttpServerConnectorContext> serverConnectorPool = new HashMap<>();
     private ServerBootstrapConfiguration serverBootstrapConfiguration;
     private TransportsConfiguration trpConfig;
     private HttpWsConnectorFactory httpConnectorFactory = new HttpWsConnectorFactoryImpl();
@@ -96,7 +81,7 @@ public class HttpConnectionManager {
         return instance;
     }
 
-    public Set<ListenerConfiguration> getDefaultListenerConfiugrationSet() {
+    Set<ListenerConfiguration> getDefaultListenerConfiugrationSet() {
         Set<ListenerConfiguration> listenerConfigurationSet = new HashSet<>();
         for (ListenerConfiguration listenerConfiguration : trpConfig.getListenerConfigurations()) {
             listenerConfiguration.setId(listenerConfiguration.getHost() == null ?
@@ -106,8 +91,7 @@ public class HttpConnectionManager {
         return listenerConfigurationSet;
     }
 
-    public org.wso2.transport.http.netty.contract.ServerConnector createHttpServerConnector(
-            ListenerConfiguration listenerConfig) {
+    public ServerConnector createHttpServerConnector(ListenerConfiguration listenerConfig) {
         String listenerInterface = listenerConfig.getHost() + ":" + listenerConfig.getPort();
         HttpServerConnectorContext httpServerConnectorContext =
                 serverConnectorPool.get(listenerInterface);
@@ -126,7 +110,7 @@ public class HttpConnectionManager {
 
         serverBootstrapConfiguration = HTTPConnectorUtil
                 .getServerBootstrapConfiguration(trpConfig.getTransportProperties());
-        org.wso2.transport.http.netty.contract.ServerConnector serverConnector =
+        ServerConnector serverConnector =
                 httpConnectorFactory.createServerConnector(serverBootstrapConfiguration, listenerConfig);
 
         httpServerConnectorContext = new HttpServerConnectorContext(serverConnector, listenerConfig);
@@ -141,8 +125,7 @@ public class HttpConnectionManager {
      *
      * @param serverConnector ServerConnector
      */
-    public void addStartupDelayedHTTPServerConnector(String id,
-            org.wso2.transport.http.netty.contract.ServerConnector serverConnector) {
+    public void addStartupDelayedHTTPServerConnector(String id, ServerConnector serverConnector) {
         startupDelayedHTTPServerConnectors.put(id, serverConnector);
     }
 
@@ -152,8 +135,7 @@ public class HttpConnectionManager {
      * @param httpServerConnector {@link BallerinaHttpServerConnector} of the pending transport server connectors.
      * @throws ServerConnectorException if exception occurs while starting at least one connector.
      */
-    public void startPendingHTTPConnectors(BallerinaHttpServerConnector httpServerConnector)
-            throws ServerConnectorException {
+    void startPendingHTTPConnectors(BallerinaHttpServerConnector httpServerConnector) throws ServerConnectorException {
         ConnectorStartupSynchronizer startupSyncer =
                 new ConnectorStartupSynchronizer(new CountDownLatch(startupDelayedHTTPServerConnectors.size()));
 
@@ -162,7 +144,6 @@ public class HttpConnectionManager {
             ServerConnectorFuture connectorFuture = serverConnector.start();
             setConnectorListeners(connectorFuture, serverConnector.getConnectorID(), startupSyncer,
                                   httpServerConnector);
-            startedHTTPServerConnectors.put(serverConnector.getConnectorID(), serverConnector);
         }
         try {
             // Wait for all the connectors to start
@@ -174,51 +155,33 @@ public class HttpConnectionManager {
         startupDelayedHTTPServerConnectors.clear();
     }
 
-    public HttpClientConnector getHTTPHttpClientConnector(String scheme, BConnector bConnector) {
-        Map<String, Object> properties = HTTPConnectorUtil.getTransportProperties(trpConfig);
-        SenderConfiguration senderConfiguration =
-                HTTPConnectorUtil.getSenderConfiguration(trpConfig, scheme);
-
-        if (isHTTPTraceLoggerEnabled()) {
-            senderConfiguration.setHttpTraceLogEnabled(true);
-        }
-        senderConfiguration.setTlsStoreType(Constants.PKCS_STORE_TYPE);
-
-        BStruct options = (BStruct) bConnector.getRefField(Constants.OPTIONS_STRUCT_INDEX);
-        if (options != null) {
-            populateSenderConfigurationOptions(senderConfiguration, options);
-        }
-        return httpConnectorFactory.createHttpClientConnector(properties, senderConfiguration);
-    }
-
     private static class HttpServerConnectorContext {
-        private org.wso2.transport.http.netty.contract.ServerConnector serverConnector;
+        private ServerConnector serverConnector;
         private ListenerConfiguration listenerConfiguration;
         private int referenceCount = 0;
 
-        public HttpServerConnectorContext(org.wso2.transport.http.netty.contract.ServerConnector
-                serverConnector, ListenerConfiguration listenerConfiguration) {
+        HttpServerConnectorContext(ServerConnector serverConnector, ListenerConfiguration listenerConfiguration) {
             this.serverConnector = serverConnector;
             this.listenerConfiguration = listenerConfiguration;
         }
 
-        public void incrementReferenceCount() {
+        void incrementReferenceCount() {
             this.referenceCount++;
         }
 
-        public void decrementReferenceCount() {
+        void decrementReferenceCount() {
             this.referenceCount--;
         }
 
-        public org.wso2.transport.http.netty.contract.ServerConnector getServerConnector() {
+        ServerConnector getServerConnector() {
             return this.serverConnector;
         }
 
-        public ListenerConfiguration getListenerConfiguration() {
+        ListenerConfiguration getListenerConfiguration() {
             return this.listenerConfiguration;
         }
 
-        public int getReferenceCount() {
+        int getReferenceCount() {
             return this.referenceCount;
         }
     }
@@ -239,17 +202,12 @@ public class HttpConnectionManager {
         return false;
     }
 
-    public boolean closeIfLast(String connectorId) {
-        HttpServerConnectorContext context = serverConnectorPool.get(connectorId);
-        if (context.getReferenceCount() == 1) {
-            return context.getServerConnector().stop();
-        }
-        context.decrementReferenceCount();
-        return false;
-    }
-
     public WebSocketClientConnector getWebSocketClientConnector(WsClientConnectorConfig configuration) {
         return  httpConnectorFactory.createWsClientConnector(configuration);
+    }
+
+    public TransportsConfiguration getTransportConfig() {
+        return trpConfig;
     }
 
     private void setConnectorListeners(ServerConnectorFuture connectorFuture, String serverConnectorId,
@@ -270,9 +228,8 @@ public class HttpConnectionManager {
         }
         PrintStream console = System.err;
 
-        startupSyncer.getExceptions().forEach((connectorId, e) -> {
-            console.println("ballerina: " + makeFirstLetterLowerCase(e.getMessage()) + ": [" + connectorId + "]");
-        });
+        startupSyncer.getExceptions().forEach((connectorId, e) ->
+            console.println("ballerina: " + makeFirstLetterLowerCase(e.getMessage()) + ": [" + connectorId + "]"));
 
         if (noOfExceptions == startupDelayedHTTPServerConnectors.size()) {
             // If the no. of exceptions is equal to the no. of connectors to be started, then none of the
@@ -281,106 +238,10 @@ public class HttpConnectionManager {
         }
     }
 
-    private boolean isHTTPTraceLoggerEnabled() {
+    public boolean isHTTPTraceLoggerEnabled() {
         // TODO: Take a closer look at this since looking up from the Config Registry here caused test failures
         return ((BLogManager) LogManager.getLogManager()).getPackageLogLevel(
                 org.ballerinalang.logging.util.Constants.HTTP_TRACE_LOG) == BLogLevel.TRACE;
-    }
-
-    private void populateSenderConfigurationOptions(SenderConfiguration senderConfiguration, BStruct options) {
-        //TODO Define default values until we get Anonymous struct (issues #3635)
-        ProxyServerConfiguration proxyServerConfiguration = null;
-        int followRedirect = 0;
-        int maxRedirectCount = 5;
-        if (options.getRefField(Constants.FOLLOW_REDIRECT_STRUCT_INDEX) != null) {
-            BStruct followRedirects = (BStruct) options.getRefField(Constants.FOLLOW_REDIRECT_STRUCT_INDEX);
-            followRedirect = followRedirects.getBooleanField(Constants.FOLLOW_REDIRECT_INDEX);
-            maxRedirectCount = (int) followRedirects.getIntField(Constants.MAX_REDIRECT_COUNT);
-        }
-        if (options.getRefField(Constants.SSL_STRUCT_INDEX) != null) {
-            BStruct ssl = (BStruct) options.getRefField(Constants.SSL_STRUCT_INDEX);
-            String trustStoreFile = ssl.getStringField(Constants.TRUST_STORE_FILE_INDEX);
-            String trustStorePassword = ssl.getStringField(Constants.TRUST_STORE_PASSWORD_INDEX);
-            String keyStoreFile = ssl.getStringField(Constants.KEY_STORE_FILE_INDEX);
-            String keyStorePassword = ssl.getStringField(Constants.KEY_STORE_PASSWORD_INDEX);
-            String sslEnabledProtocols = ssl.getStringField(Constants.SSL_ENABLED_PROTOCOLS_INDEX);
-            String ciphers = ssl.getStringField(Constants.CIPHERS_INDEX);
-            String sslProtocol = ssl.getStringField(Constants.SSL_PROTOCOL_INDEX);
-
-            if (StringUtils.isNotBlank(trustStoreFile)) {
-                senderConfiguration.setTrustStoreFile(trustStoreFile);
-            }
-            if (StringUtils.isNotBlank(trustStorePassword)) {
-                senderConfiguration.setTrustStorePass(trustStorePassword);
-            }
-            if (StringUtils.isNotBlank(keyStoreFile)) {
-                senderConfiguration.setKeyStoreFile(keyStoreFile);
-            }
-            if (StringUtils.isNotBlank(keyStorePassword)) {
-                senderConfiguration.setKeyStorePassword(keyStorePassword);
-            }
-
-            List<Parameter> clientParams = new ArrayList<>();
-            if (StringUtils.isNotBlank(sslEnabledProtocols)) {
-                Parameter clientProtocols = new Parameter(Constants.SSL_ENABLED_PROTOCOLS, sslEnabledProtocols);
-                clientParams.add(clientProtocols);
-            }
-            if (StringUtils.isNotBlank(ciphers)) {
-                Parameter clientCiphers = new Parameter(Constants.CIPHERS, ciphers);
-                clientParams.add(clientCiphers);
-            }
-            if (StringUtils.isNotBlank(sslProtocol)) {
-                senderConfiguration.setSslProtocol(sslProtocol);
-            }
-            if (!clientParams.isEmpty()) {
-                senderConfiguration.setParameters(clientParams);
-            }
-        }
-        if (options.getRefField(Constants.PROXY_STRUCT_INDEX) != null) {
-            BStruct proxy = (BStruct) options.getRefField(Constants.PROXY_STRUCT_INDEX);
-            String proxyHost = proxy.getStringField(Constants.PROXY_HOST_INDEX);
-            int proxyPort = (int) proxy.getIntField(Constants.PROXY_PORT_INDEX);
-            String proxyUserName = proxy.getStringField(Constants.PROXY_USER_NAME_INDEX);
-            String proxyPassword = proxy.getStringField(Constants.PROXY_PASSWORD_INDEX);
-            try {
-                proxyServerConfiguration = new ProxyServerConfiguration(proxyHost, proxyPort);
-            } catch (UnknownHostException e) {
-                throw new BallerinaConnectorException("Failed to resolve host" + proxyHost, e);
-            }
-            if (!proxyUserName.isEmpty()) {
-                proxyServerConfiguration.setProxyUsername(proxyUserName);
-            }
-            if (!proxyPassword.isEmpty()) {
-                proxyServerConfiguration.setProxyPassword(proxyPassword);
-            }
-            senderConfiguration.setProxyServerConfiguration(proxyServerConfiguration);
-        }
-
-        senderConfiguration.setFollowRedirect(followRedirect == 1);
-        senderConfiguration.setMaxRedirectCount(maxRedirectCount);
-
-        // For the moment we don't have to pass it down to transport as we only support
-        // chunking. Once we start supporting gzip, deflate, etc, we need to parse down the config.
-        String transferEncoding = options.getStringField(Constants.TRANSFER_ENCODING);
-        if (transferEncoding != null && !Constants.ANN_CONFIG_ATTR_CHUNKING.equalsIgnoreCase(transferEncoding)) {
-            throw new BallerinaConnectorException("Unsupported configuration found for Transfer-Encoding : "
-                    + transferEncoding);
-        }
-
-        String chunking = options.getStringField(Constants.ENABLE_CHUNKING_INDEX);
-        senderConfiguration.setChunkingConfig(HttpUtil.getChunkConfig(chunking));
-
-        long endpointTimeout = options.getIntField(Constants.ENDPOINT_TIMEOUT_STRUCT_INDEX);
-        if (endpointTimeout < 0 || (int) endpointTimeout != endpointTimeout) {
-            throw new BallerinaConnectorException("Invalid idle timeout: " + endpointTimeout);
-        }
-        senderConfiguration.setSocketIdleTimeout((int) endpointTimeout);
-
-        boolean isKeepAlive = options.getBooleanField(Constants.IS_KEEP_ALIVE_INDEX) == 1;
-        senderConfiguration.setKeepAlive(isKeepAlive);
-
-        String httpVersion = options.getStringField(Constants.HTTP_VERSION_STRUCT_INDEX);
-        senderConfiguration.setHttpVersion(httpVersion);
     }
 
     private String makeFirstLetterLowerCase(String str) {

--- a/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpUtil.java
+++ b/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/HttpUtil.java
@@ -983,7 +983,7 @@ public class HttpUtil {
                 throw new BallerinaException("Truststore password value must be provided to enable Mutual SSL");
             }
 
-            listenerConfiguration.setTlsStoreType(Constants.PKCS_STORE_TYPE);
+            listenerConfiguration.setTLSStoreType(Constants.PKCS_STORE_TYPE);
             listenerConfiguration.setKeyStoreFile(keyStoreFileAttrVal.getStringValue());
             listenerConfiguration.setKeyStorePass(keyStorePasswordAttrVal.getStringValue());
             listenerConfiguration.setCertPass(certPasswordAttrVal.getStringValue());
@@ -1016,7 +1016,7 @@ public class HttpUtil {
             }
 
             if (sslProtocolAttrVal != null) {
-                listenerConfiguration.setSslProtocol(sslProtocolAttrVal.getStringValue());
+                listenerConfiguration.setSSLProtocol(sslProtocolAttrVal.getStringValue());
             }
 
             listenerConfiguration

--- a/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/AbstractHTTPAction.java
+++ b/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/AbstractHTTPAction.java
@@ -27,7 +27,6 @@ import org.ballerinalang.model.values.BConnector;
 import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.nativeimpl.actions.ClientConnectorFuture;
 import org.ballerinalang.net.http.Constants;
-import org.ballerinalang.net.http.HttpConnectionManager;
 import org.ballerinalang.net.http.HttpUtil;
 import org.ballerinalang.net.http.RetryConfig;
 import org.ballerinalang.runtime.message.MessageDataSource;
@@ -191,9 +190,8 @@ public abstract class AbstractHTTPAction extends AbstractNativeAction {
                                     HTTPClientConnectorListener httpClientConnectorLister) {
         try {
             BConnector bConnector = (BConnector) getRefArgument(context, 0);
-            String scheme = (String) httpRequestMsg.getProperty(Constants.PROTOCOL);
             HttpClientConnector clientConnector =
-                    HttpConnectionManager.getInstance().getHTTPHttpClientConnector(scheme, bConnector);
+                    (HttpClientConnector) bConnector.getnativeData(Constants.CONNECTOR_NAME);
             HttpResponseFuture future = clientConnector.send(httpRequestMsg);
             future.setHttpConnectorListener(httpClientConnectorLister);
             serializeDataSource(context);

--- a/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Init.java
+++ b/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Init.java
@@ -18,19 +18,37 @@
 package org.ballerinalang.net.http.actions;
 
 
+import org.apache.commons.lang3.StringUtils;
 import org.ballerinalang.bre.Context;
+import org.ballerinalang.connector.api.BallerinaConnectorException;
 import org.ballerinalang.connector.api.ConnectorFuture;
 import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.model.values.BConnector;
+import org.ballerinalang.model.values.BStruct;
 import org.ballerinalang.nativeimpl.actions.ClientConnectorFuture;
 import org.ballerinalang.natives.annotations.Argument;
 import org.ballerinalang.natives.annotations.BallerinaAction;
 import org.ballerinalang.net.http.Constants;
+import org.ballerinalang.net.http.HttpConnectionManager;
+import org.ballerinalang.net.http.HttpUtil;
+import org.ballerinalang.util.exceptions.BallerinaException;
+import org.wso2.transport.http.netty.common.ProxyServerConfiguration;
+import org.wso2.transport.http.netty.config.Parameter;
+import org.wso2.transport.http.netty.config.SenderConfiguration;
+import org.wso2.transport.http.netty.contract.HttpClientConnector;
+import org.wso2.transport.http.netty.contract.HttpWsConnectorFactory;
+import org.wso2.transport.http.netty.contractimpl.HttpWsConnectorFactoryImpl;
+import org.wso2.transport.http.netty.message.HTTPConnectorUtil;
+
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 /**
- * {@code Init} is the Init action implementation of the SQL Connector.
+ * {@code Init} is the Init action implementation of the HTTP Client Connector.
  *
- * @since 0.8.5
+ * @since 0.94.0-M1
  */
 @BallerinaAction(
         packageName = "ballerina.net.http",
@@ -45,6 +63,12 @@ import org.ballerinalang.net.http.Constants;
         })
 public class Init extends AbstractHTTPAction {
 
+    private static final int TRUE = 1;
+    private static final int FALSE = 0;
+    private static final int DEFAULT_MAX_REDIRECT_COUNT = 5;
+
+    private HttpWsConnectorFactory httpConnectorFactory = new HttpWsConnectorFactoryImpl();
+
     @Override
     public ConnectorFuture execute(Context context) {
         BConnector connector = (BConnector) getRefArgument(context, 0);
@@ -53,8 +77,140 @@ public class Init extends AbstractHTTPAction {
             url = url.substring(0, url.length() - 1);
             connector.setStringField(0, url);
         }
+
+        HttpConnectionManager connectionManager = HttpConnectionManager.getInstance();
+
+        String scheme;
+        if (url.startsWith("http://")) {
+            scheme = Constants.PROTOCOL_HTTP;
+        } else if (url.startsWith("https://")) {
+            scheme = Constants.PROTOCOL_HTTPS;
+        } else {
+            throw new BallerinaException("malformed URL: " + url);
+        }
+
+        Map<String, Object> properties =
+                HTTPConnectorUtil.getTransportProperties(connectionManager.getTransportConfig());
+        SenderConfiguration senderConfiguration =
+                HTTPConnectorUtil.getSenderConfiguration(connectionManager.getTransportConfig(), scheme);
+
+        if (connectionManager.isHTTPTraceLoggerEnabled()) {
+            senderConfiguration.setHttpTraceLogEnabled(true);
+        }
+        senderConfiguration.setTLSStoreType(Constants.PKCS_STORE_TYPE);
+
+        BStruct options = (BStruct) connector.getRefField(Constants.OPTIONS_STRUCT_INDEX);
+        if (options != null) {
+            populateSenderConfigurationOptions(senderConfiguration, options);
+        }
+
+        HttpClientConnector httpClientConnector =
+                httpConnectorFactory.createHttpClientConnector(properties, senderConfiguration);
+        connector.setNativeData(Constants.CONNECTOR_NAME, httpClientConnector);
+
         ClientConnectorFuture ballerinaFuture = new ClientConnectorFuture();
         ballerinaFuture.notifySuccess();
+
         return ballerinaFuture;
+    }
+
+    private void populateSenderConfigurationOptions(SenderConfiguration senderConfiguration, BStruct options) {
+        //TODO Define default values until we get Anonymous struct (issues #3635)
+        ProxyServerConfiguration proxyServerConfiguration = null;
+        int followRedirect = FALSE;
+        int maxRedirectCount = DEFAULT_MAX_REDIRECT_COUNT;
+        if (options.getRefField(Constants.FOLLOW_REDIRECT_STRUCT_INDEX) != null) {
+            BStruct followRedirects = (BStruct) options.getRefField(Constants.FOLLOW_REDIRECT_STRUCT_INDEX);
+            followRedirect = followRedirects.getBooleanField(Constants.FOLLOW_REDIRECT_INDEX);
+            maxRedirectCount = (int) followRedirects.getIntField(Constants.MAX_REDIRECT_COUNT);
+        }
+        if (options.getRefField(Constants.SSL_STRUCT_INDEX) != null) {
+            BStruct ssl = (BStruct) options.getRefField(Constants.SSL_STRUCT_INDEX);
+            String trustStoreFile = ssl.getStringField(Constants.TRUST_STORE_FILE_INDEX);
+            String trustStorePassword = ssl.getStringField(Constants.TRUST_STORE_PASSWORD_INDEX);
+            String keyStoreFile = ssl.getStringField(Constants.KEY_STORE_FILE_INDEX);
+            String keyStorePassword = ssl.getStringField(Constants.KEY_STORE_PASSWORD_INDEX);
+            String sslEnabledProtocols = ssl.getStringField(Constants.SSL_ENABLED_PROTOCOLS_INDEX);
+            String ciphers = ssl.getStringField(Constants.CIPHERS_INDEX);
+            String sslProtocol = ssl.getStringField(Constants.SSL_PROTOCOL_INDEX);
+
+            if (StringUtils.isNotBlank(trustStoreFile)) {
+                senderConfiguration.setTrustStoreFile(trustStoreFile);
+            }
+            if (StringUtils.isNotBlank(trustStorePassword)) {
+                senderConfiguration.setTrustStorePass(trustStorePassword);
+            }
+            if (StringUtils.isNotBlank(keyStoreFile)) {
+                senderConfiguration.setKeyStoreFile(keyStoreFile);
+            }
+            if (StringUtils.isNotBlank(keyStorePassword)) {
+                senderConfiguration.setKeyStorePassword(keyStorePassword);
+            }
+
+            List<Parameter> clientParams = new ArrayList<>();
+            if (StringUtils.isNotBlank(sslEnabledProtocols)) {
+                Parameter clientProtocols = new Parameter(Constants.SSL_ENABLED_PROTOCOLS, sslEnabledProtocols);
+                clientParams.add(clientProtocols);
+            }
+            if (StringUtils.isNotBlank(ciphers)) {
+                Parameter clientCiphers = new Parameter(Constants.CIPHERS, ciphers);
+                clientParams.add(clientCiphers);
+            }
+            if (StringUtils.isNotBlank(sslProtocol)) {
+                senderConfiguration.setSSLProtocol(sslProtocol);
+            }
+            if (!clientParams.isEmpty()) {
+                senderConfiguration.setParameters(clientParams);
+            }
+        }
+        if (options.getRefField(Constants.PROXY_STRUCT_INDEX) != null) {
+            BStruct proxy = (BStruct) options.getRefField(Constants.PROXY_STRUCT_INDEX);
+            String proxyHost = proxy.getStringField(Constants.PROXY_HOST_INDEX);
+            int proxyPort = (int) proxy.getIntField(Constants.PROXY_PORT_INDEX);
+            String proxyUserName = proxy.getStringField(Constants.PROXY_USER_NAME_INDEX);
+            String proxyPassword = proxy.getStringField(Constants.PROXY_PASSWORD_INDEX);
+            try {
+                proxyServerConfiguration = new ProxyServerConfiguration(proxyHost, proxyPort);
+            } catch (UnknownHostException e) {
+                throw new BallerinaConnectorException("Failed to resolve host" + proxyHost, e);
+            }
+            if (!proxyUserName.isEmpty()) {
+                proxyServerConfiguration.setProxyUsername(proxyUserName);
+            }
+            if (!proxyPassword.isEmpty()) {
+                proxyServerConfiguration.setProxyPassword(proxyPassword);
+            }
+            senderConfiguration.setProxyServerConfiguration(proxyServerConfiguration);
+        }
+
+        senderConfiguration.setFollowRedirect(followRedirect == TRUE);
+        senderConfiguration.setMaxRedirectCount(maxRedirectCount);
+
+        // For the moment we don't have to pass it down to transport as we only support
+        // chunking. Once we start supporting gzip, deflate, etc, we need to parse down the config.
+        String transferEncoding = options.getStringField(Constants.TRANSFER_ENCODING);
+        if (transferEncoding != null && !Constants.ANN_CONFIG_ATTR_CHUNKING.equalsIgnoreCase(transferEncoding)) {
+            throw new BallerinaConnectorException("Unsupported configuration found for Transfer-Encoding : "
+                                                          + transferEncoding);
+        }
+
+        String chunking = options.getStringField(Constants.ENABLE_CHUNKING_INDEX);
+        senderConfiguration.setChunkingConfig(HttpUtil.getChunkConfig(chunking));
+
+        long endpointTimeout = options.getIntField(Constants.ENDPOINT_TIMEOUT_STRUCT_INDEX);
+        if (endpointTimeout < 0 || !isInteger(endpointTimeout)) {
+            throw new BallerinaConnectorException("invalid idle timeout: " + endpointTimeout);
+        }
+        senderConfiguration.setSocketIdleTimeout((int) endpointTimeout);
+
+        boolean isKeepAlive = options.getBooleanField(Constants.IS_KEEP_ALIVE_INDEX) == TRUE;
+        senderConfiguration.setKeepAlive(isKeepAlive);
+
+        String httpVersion = options.getStringField(Constants.HTTP_VERSION_STRUCT_INDEX);
+        senderConfiguration.setHttpVersion(httpVersion);
+    }
+
+    private boolean isInteger(long val) {
+        return (int) val == val;
     }
 }


### PR DESCRIPTION
This PR moves the client connector creation logic from `HttpConnectionManager` to `Init`. This is to prevent the whole client connector creation process from being repeated per each request. 
 
Fix #4365 