### PR TITLE
Fix 3957: Add support for configuring max active connections per client connector 

### DIFF
--- a/modules/ballerina-http/src/main/ballerina/ballerina/net/http/natives.bal
+++ b/modules/ballerina-http/src/main/ballerina/ballerina/net/http/natives.bal
@@ -349,9 +349,9 @@ public struct Options {
     int endpointTimeout = 60000;
     int maxActiveConnections = -1;
     boolean keepAlive = true;
-	string transferEncoding = "chunking";
-	string chunking = "auto";
-	string httpVersion;
+    string transferEncoding = "chunking";
+    string chunking = "auto";
+    string httpVersion;
     FollowRedirects followRedirects;
     SSL ssl;
     Retry retryConfig;

--- a/modules/ballerina-http/src/main/ballerina/ballerina/net/http/natives.bal
+++ b/modules/ballerina-http/src/main/ballerina/ballerina/net/http/natives.bal
@@ -334,9 +334,11 @@ struct Proxy {
 
 @Description { value:"Options struct represents options to be used for HTTP client invocation" }
 @Field {value:"port: Port number of the remote service"}
-@Field {value:"endpointTimeout: Endpoint timeout value in millisecond"}
-@Field {value:"enableChunking: Enable/disable chunking"}
+@Field {value:"endpointTimeout: Endpoint timeout value in millisecond (default value: 60000 milliseconds)"}
+@Field {value:"maxActiveConnections: The maximum number of active connections the connector can create (default value: -1, indicates that the number of connections is not restricted)"}
 @Field {value:"keepAlive: Keep the connection or close it (default value: true)"}
+@Field {value:"transferEncoding: The types of encoding applied to the request (default value: chunking)"}
+@Field {value:"chunking: The chunking behaviour of the request"}
 @Field {value:"httpVersion: The version of HTTP outbound request"}
 @Field {value:"followRedirects: Redirect related options"}
 @Field {value:"ssl: SSL/TLS related options"}
@@ -345,6 +347,7 @@ struct Proxy {
 public struct Options {
     int port;
     int endpointTimeout = 60000;
+    int maxActiveConnections = -1;
     boolean keepAlive = true;
 	string transferEncoding = "chunking";
 	string chunking = "auto";

--- a/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/Constants.java
+++ b/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/Constants.java
@@ -61,6 +61,7 @@ public class Constants {
     public static final String CHUNKING_AUTO = "auto";
     public static final String CHUNKING_ALWAYS = "always";
     public static final String CHUNKING_NEVER = "never";
+    public static final String MAX_ACTIVE_CONNECTIONS_PER_POOL = "client.max.active.connections.per.pool";
 
     public static final String HTTP_PACKAGE_PATH = "ballerina.net.http";
 
@@ -166,6 +167,7 @@ public class Constants {
     public static final String SSL_ENABLED_PROTOCOLS = "sslEnabledProtocols";
     public static final int OPTIONS_STRUCT_INDEX = 0;
     public static final int ENDPOINT_TIMEOUT_STRUCT_INDEX = 1;
+    public static final int MAX_ACTIVE_CONNECTIONS_INDEX = 2;
     public static final int TRANSFER_ENCODING = 0;
     public static final int ENABLE_CHUNKING_INDEX = 1;
     public static final int IS_KEEP_ALIVE_INDEX = 0;

--- a/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Init.java
+++ b/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Init.java
@@ -102,6 +102,11 @@ public class Init extends AbstractHTTPAction {
         BStruct options = (BStruct) connector.getRefField(Constants.OPTIONS_STRUCT_INDEX);
         if (options != null) {
             populateSenderConfigurationOptions(senderConfiguration, options);
+            long maxActiveConnections = options.getIntField(Constants.MAX_ACTIVE_CONNECTIONS_INDEX);
+            if (!isInteger(maxActiveConnections)) {
+                throw new BallerinaConnectorException("invalid maxActiveConnections value: " + maxActiveConnections);
+            }
+            properties.put(Constants.MAX_ACTIVE_CONNECTIONS_PER_POOL, (int) maxActiveConnections);
         }
 
         HttpClientConnector httpClientConnector =


### PR DESCRIPTION
Fix #3957

Created a new PR in place of PR #4364 due to a few issues with the its branch.

This PR adds support for configuring the maximum number of active connections per HTTP client connector. Sample usage of the configuration is as given below. 

```ballerina
endpoint<http:HttpClient> helloEP {
        create http:HttpClient("http://localhost:8080/hello", {maxActiveConnections:5});
}
```
