### PR TITLE
Fixing bug: composer fails when '~/.ballerina' does not exist.

### DIFF
--- a/modules/ballerina-lang/src/main/java/org/ballerinalang/repository/fs/GeneralFSPackageRepository.java
+++ b/modules/ballerina-lang/src/main/java/org/ballerinalang/repository/fs/GeneralFSPackageRepository.java
@@ -34,6 +34,7 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -108,6 +109,9 @@ public class GeneralFSPackageRepository implements PackageRepository {
     public Set<PackageID> listPackages(int maxDepth) {
         if (maxDepth <= 0) {
             throw new IllegalArgumentException("maxDepth must be greater than zero");
+        }
+        if (!Files.isDirectory(this.basePath)) {
+            return Collections.emptySet();
         }
         Set<PackageID> result = new LinkedHashSet<>();
         int baseNameCount = this.basePath.getNameCount();


### PR DESCRIPTION
Listing all built-in packages in composer throws an error when user repo dir dosn't exist. 