### PR TITLE
Circuit Breaker for HTTP Client Connector

### DIFF
--- a/modules/ballerina-http/src/main/ballerina/ballerina/net/http/natives.bal
+++ b/modules/ballerina-http/src/main/ballerina/ballerina/net/http/natives.bal
@@ -358,8 +358,8 @@ public struct Options {
     Proxy proxy;
 }
 
-@Description { value:"Http client connector for outbound HTTP requests"}
-@Param { value:"serviceUri: Url of the service" }
+@Description { value:"HTTP client connector for outbound HTTP requests"}
+@Param { value:"serviceUri: URI of the service" }
 @Param { value:"connectorOptions: connector options" }
 public connector HttpClient (string serviceUri, Options connectorOptions) {
 
@@ -420,7 +420,7 @@ public connector HttpClient (string serviceUri, Options connectorOptions) {
 	@Return { value:"Error occured during HTTP client invocation" }
 	native action options (string path, Request req) (Response, HttpConnectorError);
 
-	@Description { value:"forward action can be used to invoke an HTTP call with incoming request HTTPVerb"}
+	@Description { value:"Forward action can be used to invoke an HTTP call with incoming request's HTTP verb"}
 	@Param { value:"path: Request path" }
 	@Param { value:"req: An HTTP Request struct" }
 	@Return { value:"The response message" }

--- a/modules/ballerina-http/src/main/ballerina/ballerina/net/http/natives.bal
+++ b/modules/ballerina-http/src/main/ballerina/ballerina/net/http/natives.bal
@@ -385,12 +385,12 @@ public connector HttpClient (string serviceUri, Options connectorOptions) {
 	native action put (string path, Request req) (Response, HttpConnectorError);
 
 	@Description { value:"Invokes an HTTP call with the specified HTTP verb."}
-	@Param { value:"HTTPVerb: HTTP verb value" }
+	@Param { value:"httpVerb: HTTP verb value" }
 	@Param { value:"path: Resource path " }
 	@Param { value:"req: An HTTP Request struct" }
 	@Return { value:"The response message" }
 	@Return { value:"Error occured during HTTP client invocation" }
-	native action execute (string HTTPVerb, string path, Request req) (Response, HttpConnectorError);
+	native action execute (string httpVerb, string path, Request req) (Response, HttpConnectorError);
 
 	@Description { value:"The PATCH action implementation of the HTTP Connector."}
 	@Param { value:"path: Resource path " }

--- a/modules/ballerina-http/src/main/ballerina/ballerina/net/http/resiliency/circuit-breaker.bal
+++ b/modules/ballerina-http/src/main/ballerina/ballerina/net/http/resiliency/circuit-breaker.bal
@@ -22,148 +22,148 @@ public connector CircuitBreaker (http:HttpClient httpClient, float failurePercen
     // TODO: once enum init inside a struct is do-able, move this inside circuitHealth (issue #4340)
     CircuitState currentState = CircuitState.CLOSE;
 
-    action post (string path, http:Request req) (http:Response, http:HttpConnectorError) {
+    action post (string path, http:Request request) (http:Response, http:HttpConnectorError) {
         currentState = updateCircuitState(circuitHealth, currentState, failurePercentageThreshold, resetTimeout);
-        http:Response res;
-        http:HttpConnectorError e;
+        http:Response response;
+        http:HttpConnectorError err;
 
         if (currentState == CircuitState.OPEN) {
             // TODO: Allow the user to handle this scenario. Maybe through a user provided function
-            res = handleOpenCircuit(circuitHealth, resetTimeout);
+            response = handleOpenCircuit(circuitHealth, resetTimeout);
         } else {
-            res, e = httpEP.post(path, req);
-            updateCircuitHealth(circuitHealth, e);
+            response, err = httpEP.post(path, request);
+            updateCircuitHealth(circuitHealth, err);
         }
 
-        return res, e;
+        return response, err;
     }
 
-    action head (string path, http:Request req) (http:Response, http:HttpConnectorError) {
+    action head (string path, http:Request request) (http:Response, http:HttpConnectorError) {
         currentState = updateCircuitState(circuitHealth, currentState, failurePercentageThreshold, resetTimeout);
-        http:Response res;
-        http:HttpConnectorError e;
+        http:Response response;
+        http:HttpConnectorError err;
 
         if (currentState == CircuitState.OPEN) {
             // TODO: Allow the user to handle this scenario. Maybe through a user provided function
-            res = handleOpenCircuit(circuitHealth, resetTimeout);
+            response = handleOpenCircuit(circuitHealth, resetTimeout);
         } else {
-            res, e = httpEP.head(path, req);
-            updateCircuitHealth(circuitHealth, e);
+            response, err = httpEP.head(path, request);
+            updateCircuitHealth(circuitHealth, err);
         }
 
-        return res, e;
+        return response, err;
     }
 
-    action put (string path, http:Request req) (http:Response, http:HttpConnectorError) {
+    action put (string path, http:Request request) (http:Response, http:HttpConnectorError) {
         currentState = updateCircuitState(circuitHealth, currentState, failurePercentageThreshold, resetTimeout);
-        http:Response res;
-        http:HttpConnectorError e;
+        http:Response response;
+        http:HttpConnectorError err;
 
         if (currentState == CircuitState.OPEN) {
             // TODO: Allow the user to handle this scenario. Maybe through a user provided function
-            res = handleOpenCircuit(circuitHealth, resetTimeout);
+            response = handleOpenCircuit(circuitHealth, resetTimeout);
         } else {
-            res, e = httpEP.put(path, req);
-            updateCircuitHealth(circuitHealth, e);
+            response, err = httpEP.put(path, request);
+            updateCircuitHealth(circuitHealth, err);
         }
 
-        return res, e;
+        return response, err;
     }
 
-    action execute (string httpVerb, string path, http:Request req) (http:Response, http:HttpConnectorError) {
+    action execute (string httpVerb, string path, http:Request request) (http:Response, http:HttpConnectorError) {
         currentState = updateCircuitState(circuitHealth, currentState, failurePercentageThreshold, resetTimeout);
-        http:Response res;
-        http:HttpConnectorError e;
+        http:Response response;
+        http:HttpConnectorError err;
 
         if (currentState == CircuitState.OPEN) {
             // TODO: Allow the user to handle this scenario. Maybe through a user provided function
-            res = handleOpenCircuit(circuitHealth, resetTimeout);
+            response = handleOpenCircuit(circuitHealth, resetTimeout);
         } else {
-            res, e = httpEP.execute(httpVerb, path, req);
-            updateCircuitHealth(circuitHealth, e);
+            response, err = httpEP.execute(httpVerb, path, request);
+            updateCircuitHealth(circuitHealth, err);
         }
 
-        return res, e;
+        return response, err;
     }
 
-    action patch (string path, http:Request req) (http:Response, http:HttpConnectorError) {
+    action patch (string path, http:Request request) (http:Response, http:HttpConnectorError) {
         currentState = updateCircuitState(circuitHealth, currentState, failurePercentageThreshold, resetTimeout);
-        http:Response res;
-        http:HttpConnectorError e;
+        http:Response response;
+        http:HttpConnectorError err;
 
         if (currentState == CircuitState.OPEN) {
             // TODO: Allow the user to handle this scenario. Maybe through a user provided function
-            res = handleOpenCircuit(circuitHealth, resetTimeout);
+            response = handleOpenCircuit(circuitHealth, resetTimeout);
         } else {
-            res, e = httpEP.patch(path, req);
-            updateCircuitHealth(circuitHealth, e);
+            response, err = httpEP.patch(path, request);
+            updateCircuitHealth(circuitHealth, err);
         }
 
-        return res, e;
+        return response, err;
     }
 
-    action delete (string path, http:Request req) (http:Response, http:HttpConnectorError) {
+    action delete (string path, http:Request request) (http:Response, http:HttpConnectorError) {
         currentState = updateCircuitState(circuitHealth, currentState, failurePercentageThreshold, resetTimeout);
-        http:Response res;
-        http:HttpConnectorError e;
+        http:Response response;
+        http:HttpConnectorError err;
 
         if (currentState == CircuitState.OPEN) {
             // TODO: Allow the user to handle this scenario. Maybe through a user provided function
-            res = handleOpenCircuit(circuitHealth, resetTimeout);
+            response = handleOpenCircuit(circuitHealth, resetTimeout);
         } else {
-            res, e = httpEP.delete(path, req);
-            updateCircuitHealth(circuitHealth, e);
+            response, err = httpEP.delete(path, request);
+            updateCircuitHealth(circuitHealth, err);
         }
 
-        return res, e;
+        return response, err;
     }
 
-    action options (string path, http:Request req) (http:Response, http:HttpConnectorError) {
+    action options (string path, http:Request request) (http:Response, http:HttpConnectorError) {
         currentState = updateCircuitState(circuitHealth, currentState, failurePercentageThreshold, resetTimeout);
-        http:Response res;
-        http:HttpConnectorError e;
+        http:Response response;
+        http:HttpConnectorError err;
 
         if (currentState == CircuitState.OPEN) {
             // TODO: Allow the user to handle this scenario. Maybe through a user provided function
-            res = handleOpenCircuit(circuitHealth, resetTimeout);
+            response = handleOpenCircuit(circuitHealth, resetTimeout);
         } else {
-            res, e = httpEP.options(path, req);
-            updateCircuitHealth(circuitHealth, e);
+            response, err = httpEP.options(path, request);
+            updateCircuitHealth(circuitHealth, err);
         }
 
-        return res, e;
+        return response, err;
     }
 
-    action forward (string path, http:Request req) (http:Response, http:HttpConnectorError) {
+    action forward (string path, http:Request request) (http:Response, http:HttpConnectorError) {
         currentState = updateCircuitState(circuitHealth, currentState, failurePercentageThreshold, resetTimeout);
-        http:Response res;
-        http:HttpConnectorError e;
+        http:Response response;
+        http:HttpConnectorError err;
 
         if (currentState == CircuitState.OPEN) {
             // TODO: Allow the user to handle this scenario. Maybe through a user provided function
-            res = handleOpenCircuit(circuitHealth, resetTimeout);
+            response = handleOpenCircuit(circuitHealth, resetTimeout);
         } else {
-            res, e = httpEP.forward(path, req);
-            updateCircuitHealth(circuitHealth, e);
+            response, err = httpEP.forward(path, request);
+            updateCircuitHealth(circuitHealth, err);
         }
 
-        return res, e;
+        return response, err;
     }
 
-    action get (string path, http:Request req) (http:Response, http:HttpConnectorError) {
+    action get (string path, http:Request request) (http:Response, http:HttpConnectorError) {
         currentState = updateCircuitState(circuitHealth, currentState, failurePercentageThreshold, resetTimeout);
-        http:Response res;
-        http:HttpConnectorError e;
+        http:Response response;
+        http:HttpConnectorError err;
 
         if (currentState == CircuitState.OPEN) {
             // TODO: Allow the user to handle this scenario. Maybe through a user provided function
-            res = handleOpenCircuit(circuitHealth, resetTimeout);
+            response = handleOpenCircuit(circuitHealth, resetTimeout);
         } else {
-            res, e = httpEP.get(path, req);
-            updateCircuitHealth(circuitHealth, e);
+            response, err = httpEP.get(path, request);
+            updateCircuitHealth(circuitHealth, err);
         }
 
-        return res, e;
+        return response, err;
     }
 }
 

--- a/modules/ballerina-http/src/main/ballerina/ballerina/net/http/resiliency/circuit-breaker.bal
+++ b/modules/ballerina-http/src/main/ballerina/ballerina/net/http/resiliency/circuit-breaker.bal
@@ -33,7 +33,7 @@ public connector CircuitBreaker (http:HttpClient httpClient, float failurePercen
 
             if (e != null) {
                 circuitHealth.updateHealth();
-                http:Response errorResponse = createErrorResponse(e.msg);
+                http:Response errorResponse = createErrorResponse(e.msg, e.statusCode);
                 return errorResponse, e;
             }
         } else if (currentState == CircuitState.HALF_OPEN) {
@@ -42,7 +42,7 @@ public connector CircuitBreaker (http:HttpClient httpClient, float failurePercen
 
             if (e != null) {
                 circuitHealth.updateHealth();
-                http:Response errorResponse = createErrorResponse(e.msg);
+                http:Response errorResponse = createErrorResponse(e.msg, e.statusCode);
                 return errorResponse, e;
             }
         } else {
@@ -65,7 +65,7 @@ public connector CircuitBreaker (http:HttpClient httpClient, float failurePercen
 
             if (e != null) {
                 circuitHealth.updateHealth();
-                http:Response errorResponse = createErrorResponse(e.msg);
+                http:Response errorResponse = createErrorResponse(e.msg, e.statusCode);
                 return errorResponse, e;
             }
         } else if (currentState == CircuitState.HALF_OPEN) {
@@ -74,7 +74,7 @@ public connector CircuitBreaker (http:HttpClient httpClient, float failurePercen
 
             if (e != null) {
                 circuitHealth.updateHealth();
-                http:Response errorResponse = createErrorResponse(e.msg);
+                http:Response errorResponse = createErrorResponse(e.msg, e.statusCode);
                 return errorResponse, e;
             }
         } else {
@@ -97,7 +97,7 @@ public connector CircuitBreaker (http:HttpClient httpClient, float failurePercen
 
             if (e != null) {
                 circuitHealth.updateHealth();
-                http:Response errorResponse = createErrorResponse(e.msg);
+                http:Response errorResponse = createErrorResponse(e.msg, e.statusCode);
                 return errorResponse, e;
             }
         } else if (currentState == CircuitState.HALF_OPEN) {
@@ -106,7 +106,7 @@ public connector CircuitBreaker (http:HttpClient httpClient, float failurePercen
 
             if (e != null) {
                 circuitHealth.updateHealth();
-                http:Response errorResponse = createErrorResponse(e.msg);
+                http:Response errorResponse = createErrorResponse(e.msg, e.statusCode);
                 return errorResponse, e;
             }
         } else {
@@ -129,7 +129,7 @@ public connector CircuitBreaker (http:HttpClient httpClient, float failurePercen
 
             if (e != null) {
                 circuitHealth.updateHealth();
-                http:Response errorResponse = createErrorResponse(e.msg);
+                http:Response errorResponse = createErrorResponse(e.msg, e.statusCode);
                 return errorResponse, e;
             }
         } else if (currentState == CircuitState.HALF_OPEN) {
@@ -138,7 +138,7 @@ public connector CircuitBreaker (http:HttpClient httpClient, float failurePercen
 
             if (e != null) {
                 circuitHealth.updateHealth();
-                http:Response errorResponse = createErrorResponse(e.msg);
+                http:Response errorResponse = createErrorResponse(e.msg, e.statusCode);
                 return errorResponse, e;
             }
         } else {
@@ -161,7 +161,7 @@ public connector CircuitBreaker (http:HttpClient httpClient, float failurePercen
 
             if (e != null) {
                 circuitHealth.updateHealth();
-                http:Response errorResponse = createErrorResponse(e.msg);
+                http:Response errorResponse = createErrorResponse(e.msg, e.statusCode);
                 return errorResponse, e;
             }
         } else if (currentState == CircuitState.HALF_OPEN) {
@@ -170,7 +170,7 @@ public connector CircuitBreaker (http:HttpClient httpClient, float failurePercen
 
             if (e != null) {
                 circuitHealth.updateHealth();
-                http:Response errorResponse = createErrorResponse(e.msg);
+                http:Response errorResponse = createErrorResponse(e.msg, e.statusCode);
                 return errorResponse, e;
             }
         } else {
@@ -193,7 +193,7 @@ public connector CircuitBreaker (http:HttpClient httpClient, float failurePercen
 
             if (e != null) {
                 circuitHealth.updateHealth();
-                http:Response errorResponse = createErrorResponse(e.msg);
+                http:Response errorResponse = createErrorResponse(e.msg, e.statusCode);
                 return errorResponse, e;
             }
         } else if (currentState == CircuitState.HALF_OPEN) {
@@ -202,7 +202,7 @@ public connector CircuitBreaker (http:HttpClient httpClient, float failurePercen
 
             if (e != null) {
                 circuitHealth.updateHealth();
-                http:Response errorResponse = createErrorResponse(e.msg);
+                http:Response errorResponse = createErrorResponse(e.msg, e.statusCode);
                 return errorResponse, e;
             }
         } else {
@@ -225,7 +225,7 @@ public connector CircuitBreaker (http:HttpClient httpClient, float failurePercen
 
             if (e != null) {
                 circuitHealth.updateHealth();
-                http:Response errorResponse = createErrorResponse(e.msg);
+                http:Response errorResponse = createErrorResponse(e.msg, e.statusCode);
                 return errorResponse, e;
             }
         } else if (currentState == CircuitState.HALF_OPEN) {
@@ -234,7 +234,7 @@ public connector CircuitBreaker (http:HttpClient httpClient, float failurePercen
 
             if (e != null) {
                 circuitHealth.updateHealth();
-                http:Response errorResponse = createErrorResponse(e.msg);
+                http:Response errorResponse = createErrorResponse(e.msg, e.statusCode);
                 return errorResponse, e;
             }
         } else {
@@ -257,7 +257,7 @@ public connector CircuitBreaker (http:HttpClient httpClient, float failurePercen
 
             if (e != null) {
                 circuitHealth.updateHealth();
-                http:Response errorResponse = createErrorResponse(e.msg);
+                http:Response errorResponse = createErrorResponse(e.msg, e.statusCode);
                 return errorResponse, e;
             }
         } else if (currentState == CircuitState.HALF_OPEN) {
@@ -266,7 +266,7 @@ public connector CircuitBreaker (http:HttpClient httpClient, float failurePercen
 
             if (e != null) {
                 circuitHealth.updateHealth();
-                http:Response errorResponse = createErrorResponse(e.msg);
+                http:Response errorResponse = createErrorResponse(e.msg, e.statusCode);
                 return errorResponse, e;
             }
         } else {
@@ -289,7 +289,7 @@ public connector CircuitBreaker (http:HttpClient httpClient, float failurePercen
 
             if (e != null) {
                 circuitHealth.updateHealth();
-                http:Response errorResponse = createErrorResponse(e.msg);
+                http:Response errorResponse = createErrorResponse(e.msg, e.statusCode);
                 return errorResponse, e;
             }
         } else if (currentState == CircuitState.HALF_OPEN) {
@@ -298,7 +298,7 @@ public connector CircuitBreaker (http:HttpClient httpClient, float failurePercen
 
             if (e != null) {
                 circuitHealth.updateHealth();
-                http:Response errorResponse = createErrorResponse(e.msg);
+                http:Response errorResponse = createErrorResponse(e.msg, e.statusCode);
                 return errorResponse, e;
             }
         } else {
@@ -352,10 +352,10 @@ function <CircuitHealth circuitHealth> updateHealth () {
     circuitHealth.lastErrorTime = currentTime();
 }
 
-function createErrorResponse (string msg) (http:Response) {
+function createErrorResponse (string msg, int statusCode) (http:Response) {
     http:Response errorResponse = {};
     errorResponse.setStringPayload(msg);
-    errorResponse.setStatusCode(500);
+    errorResponse.setStatusCode(statusCode);
     return errorResponse;
 }
 
@@ -364,5 +364,5 @@ function handleOpenCircuit (CircuitHealth circuitHealth, int resetTimeout) (http
     int timeDif = currentT.time - circuitHealth.lastErrorTime.time;
     int timeRemaining = resetTimeout - timeDif;
     return createErrorResponse("Upstream service unavailable. Requests to upstream service will be suspended for "
-                               + timeRemaining + " milliseconds");
+                               + timeRemaining + " milliseconds", 503);
 }

--- a/modules/ballerina-http/src/main/ballerina/ballerina/net/http/resiliency/circuit-breaker.bal
+++ b/modules/ballerina-http/src/main/ballerina/ballerina/net/http/resiliency/circuit-breaker.bal
@@ -1,0 +1,368 @@
+package ballerina.net.http.resiliency;
+
+import ballerina.net.http;
+
+enum CircuitState {
+    OPEN, CLOSE, HALF_OPEN
+}
+
+struct CircuitHealth {
+    float requestCount;
+    float errorCount;
+    Time lastErrorTime;
+}
+
+public connector CircuitBreaker (http:HttpClient httpClient, float failurePercentageThreshold, int resetTimeout) {
+
+    endpoint<http:HttpClient> httpEP {
+        httpClient;
+    }
+
+    CircuitHealth circuitHealth = {};
+    // TODO: once enum init inside a struct is do-able, move this inside circuitHealth (issue #4340)
+    CircuitState currentState = CircuitState.CLOSE;
+
+    action post (string path, http:Request req) (http:Response, http:HttpConnectorError) {
+        currentState = updateCircuitState(circuitHealth, currentState, failurePercentageThreshold, resetTimeout);
+        http:Response res;
+        http:HttpConnectorError e;
+
+        if (currentState == CircuitState.CLOSE) {
+            res, e = httpEP.post(path, req);
+            circuitHealth.requestCount = circuitHealth.requestCount + 1;
+
+            if (e != null) {
+                circuitHealth.updateHealth();
+                http:Response errorResponse = createErrorResponse(e.msg);
+                return errorResponse, e;
+            }
+        } else if (currentState == CircuitState.HALF_OPEN) {
+            res, e = httpEP.post(path, req);
+            circuitHealth.requestCount = circuitHealth.requestCount + 1;
+
+            if (e != null) {
+                circuitHealth.updateHealth();
+                http:Response errorResponse = createErrorResponse(e.msg);
+                return errorResponse, e;
+            }
+        } else {
+            // TODO: Allow the user to handle this scenario. Maybe through a user provided function
+            http:Response errorResponse = handleOpenCircuit(circuitHealth, resetTimeout);
+            return errorResponse, e;
+        }
+
+        return res, null;
+    }
+
+    action head (string path, http:Request req) (http:Response, http:HttpConnectorError) {
+        currentState = updateCircuitState(circuitHealth, currentState, failurePercentageThreshold, resetTimeout);
+        http:Response res;
+        http:HttpConnectorError e;
+
+        if (currentState == CircuitState.CLOSE) {
+            res, e = httpEP.head(path, req);
+            circuitHealth.requestCount = circuitHealth.requestCount + 1;
+
+            if (e != null) {
+                circuitHealth.updateHealth();
+                http:Response errorResponse = createErrorResponse(e.msg);
+                return errorResponse, e;
+            }
+        } else if (currentState == CircuitState.HALF_OPEN) {
+            res, e = httpEP.head(path, req);
+            circuitHealth.requestCount = circuitHealth.requestCount + 1;
+
+            if (e != null) {
+                circuitHealth.updateHealth();
+                http:Response errorResponse = createErrorResponse(e.msg);
+                return errorResponse, e;
+            }
+        } else {
+            // TODO: Allow the user to handle this scenario. Maybe through a user provided function
+            http:Response errorResponse = handleOpenCircuit(circuitHealth, resetTimeout);
+            return errorResponse, e;
+        }
+
+        return res, null;
+    }
+
+    action put (string path, http:Request req) (http:Response, http:HttpConnectorError) {
+        currentState = updateCircuitState(circuitHealth, currentState, failurePercentageThreshold, resetTimeout);
+        http:Response res;
+        http:HttpConnectorError e;
+
+        if (currentState == CircuitState.CLOSE) {
+            res, e = httpEP.put(path, req);
+            circuitHealth.requestCount = circuitHealth.requestCount + 1;
+
+            if (e != null) {
+                circuitHealth.updateHealth();
+                http:Response errorResponse = createErrorResponse(e.msg);
+                return errorResponse, e;
+            }
+        } else if (currentState == CircuitState.HALF_OPEN) {
+            res, e = httpEP.put(path, req);
+            circuitHealth.requestCount = circuitHealth.requestCount + 1;
+
+            if (e != null) {
+                circuitHealth.updateHealth();
+                http:Response errorResponse = createErrorResponse(e.msg);
+                return errorResponse, e;
+            }
+        } else {
+            // TODO: Allow the user to handle this scenario. Maybe through a user provided function
+            http:Response errorResponse = handleOpenCircuit(circuitHealth, resetTimeout);
+            return errorResponse, e;
+        }
+
+        return res, null;
+    }
+
+    action execute (string httpVerb, string path, http:Request req) (http:Response, http:HttpConnectorError) {
+        currentState = updateCircuitState(circuitHealth, currentState, failurePercentageThreshold, resetTimeout);
+        http:Response res;
+        http:HttpConnectorError e;
+
+        if (currentState == CircuitState.CLOSE) {
+            res, e = httpEP.execute(httpVerb, path, req);
+            circuitHealth.requestCount = circuitHealth.requestCount + 1;
+
+            if (e != null) {
+                circuitHealth.updateHealth();
+                http:Response errorResponse = createErrorResponse(e.msg);
+                return errorResponse, e;
+            }
+        } else if (currentState == CircuitState.HALF_OPEN) {
+            res, e = httpEP.execute(httpVerb, path, req);
+            circuitHealth.requestCount = circuitHealth.requestCount + 1;
+
+            if (e != null) {
+                circuitHealth.updateHealth();
+                http:Response errorResponse = createErrorResponse(e.msg);
+                return errorResponse, e;
+            }
+        } else {
+            // TODO: Allow the user to handle this scenario. Maybe through a user provided function
+            http:Response errorResponse = handleOpenCircuit(circuitHealth, resetTimeout);
+            return errorResponse, e;
+        }
+
+        return res, null;
+    }
+
+    action patch (string path, http:Request req) (http:Response, http:HttpConnectorError) {
+        currentState = updateCircuitState(circuitHealth, currentState, failurePercentageThreshold, resetTimeout);
+        http:Response res;
+        http:HttpConnectorError e;
+
+        if (currentState == CircuitState.CLOSE) {
+            res, e = httpEP.patch(path, req);
+            circuitHealth.requestCount = circuitHealth.requestCount + 1;
+
+            if (e != null) {
+                circuitHealth.updateHealth();
+                http:Response errorResponse = createErrorResponse(e.msg);
+                return errorResponse, e;
+            }
+        } else if (currentState == CircuitState.HALF_OPEN) {
+            res, e = httpEP.patch(path, req);
+            circuitHealth.requestCount = circuitHealth.requestCount + 1;
+
+            if (e != null) {
+                circuitHealth.updateHealth();
+                http:Response errorResponse = createErrorResponse(e.msg);
+                return errorResponse, e;
+            }
+        } else {
+            // TODO: Allow the user to handle this scenario. Maybe through a user provided function
+            http:Response errorResponse = handleOpenCircuit(circuitHealth, resetTimeout);
+            return errorResponse, e;
+        }
+
+        return res, null;
+    }
+
+    action delete (string path, http:Request req) (http:Response, http:HttpConnectorError) {
+        currentState = updateCircuitState(circuitHealth, currentState, failurePercentageThreshold, resetTimeout);
+        http:Response res;
+        http:HttpConnectorError e;
+
+        if (currentState == CircuitState.CLOSE) {
+            res, e = httpEP.delete(path, req);
+            circuitHealth.requestCount = circuitHealth.requestCount + 1;
+
+            if (e != null) {
+                circuitHealth.updateHealth();
+                http:Response errorResponse = createErrorResponse(e.msg);
+                return errorResponse, e;
+            }
+        } else if (currentState == CircuitState.HALF_OPEN) {
+            res, e = httpEP.delete(path, req);
+            circuitHealth.requestCount = circuitHealth.requestCount + 1;
+
+            if (e != null) {
+                circuitHealth.updateHealth();
+                http:Response errorResponse = createErrorResponse(e.msg);
+                return errorResponse, e;
+            }
+        } else {
+            // TODO: Allow the user to handle this scenario. Maybe through a user provided function
+            http:Response errorResponse = handleOpenCircuit(circuitHealth, resetTimeout);
+            return errorResponse, e;
+        }
+
+        return res, null;
+    }
+
+    action options (string path, http:Request req) (http:Response, http:HttpConnectorError) {
+        currentState = updateCircuitState(circuitHealth, currentState, failurePercentageThreshold, resetTimeout);
+        http:Response res;
+        http:HttpConnectorError e;
+
+        if (currentState == CircuitState.CLOSE) {
+            res, e = httpEP.options(path, req);
+            circuitHealth.requestCount = circuitHealth.requestCount + 1;
+
+            if (e != null) {
+                circuitHealth.updateHealth();
+                http:Response errorResponse = createErrorResponse(e.msg);
+                return errorResponse, e;
+            }
+        } else if (currentState == CircuitState.HALF_OPEN) {
+            res, e = httpEP.options(path, req);
+            circuitHealth.requestCount = circuitHealth.requestCount + 1;
+
+            if (e != null) {
+                circuitHealth.updateHealth();
+                http:Response errorResponse = createErrorResponse(e.msg);
+                return errorResponse, e;
+            }
+        } else {
+            // TODO: Allow the user to handle this scenario. Maybe through a user provided function
+            http:Response errorResponse = handleOpenCircuit(circuitHealth, resetTimeout);
+            return errorResponse, e;
+        }
+
+        return res, null;
+    }
+
+    action forward (string path, http:Request req) (http:Response, http:HttpConnectorError) {
+        currentState = updateCircuitState(circuitHealth, currentState, failurePercentageThreshold, resetTimeout);
+        http:Response res;
+        http:HttpConnectorError e;
+
+        if (currentState == CircuitState.CLOSE) {
+            res, e = httpEP.forward(path, req);
+            circuitHealth.requestCount = circuitHealth.requestCount + 1;
+
+            if (e != null) {
+                circuitHealth.updateHealth();
+                http:Response errorResponse = createErrorResponse(e.msg);
+                return errorResponse, e;
+            }
+        } else if (currentState == CircuitState.HALF_OPEN) {
+            res, e = httpEP.forward(path, req);
+            circuitHealth.requestCount = circuitHealth.requestCount + 1;
+
+            if (e != null) {
+                circuitHealth.updateHealth();
+                http:Response errorResponse = createErrorResponse(e.msg);
+                return errorResponse, e;
+            }
+        } else {
+            // TODO: Allow the user to handle this scenario. Maybe through a user provided function
+            http:Response errorResponse = handleOpenCircuit(circuitHealth, resetTimeout);
+            return errorResponse, e;
+        }
+
+        return res, null;
+    }
+
+    action get (string path, http:Request req) (http:Response, http:HttpConnectorError) {
+        currentState = updateCircuitState(circuitHealth, currentState, failurePercentageThreshold, resetTimeout);
+        http:Response res;
+        http:HttpConnectorError e;
+
+        if (currentState == CircuitState.CLOSE) {
+            res, e = httpEP.get(path, req);
+            circuitHealth.requestCount = circuitHealth.requestCount + 1;
+
+            if (e != null) {
+                circuitHealth.updateHealth();
+                http:Response errorResponse = createErrorResponse(e.msg);
+                return errorResponse, e;
+            }
+        } else if (currentState == CircuitState.HALF_OPEN) {
+            res, e = httpEP.get(path, req);
+            circuitHealth.requestCount = circuitHealth.requestCount + 1;
+
+            if (e != null) {
+                circuitHealth.updateHealth();
+                http:Response errorResponse = createErrorResponse(e.msg);
+                return errorResponse, e;
+            }
+        } else {
+            // TODO: Allow the user to handle this scenario. Maybe through a user provided function
+            http:Response errorResponse = handleOpenCircuit(circuitHealth, resetTimeout);
+            return errorResponse, e;
+        }
+
+        return res, null;
+    }
+}
+
+function updateCircuitState (CircuitHealth circuitHealth, CircuitState currentState, float failureThreshold,
+                             int resetTimeout) (CircuitState) {
+    if (currentState == CircuitState.OPEN) {
+        Time currentT = currentTime();
+        int elapsedTime = currentT.time - circuitHealth.lastErrorTime.time;
+
+        if (elapsedTime > resetTimeout) {
+            circuitHealth.errorCount = 0;
+            circuitHealth.requestCount = 0;
+            currentState = CircuitState.HALF_OPEN;
+        }
+    } else if (currentState == CircuitState.HALF_OPEN) {
+        if (circuitHealth.errorCount > 0) {
+            // If the trial run has failed, trip the circuit again
+            currentState = CircuitState.OPEN;
+        } else {
+            // If the trial run was successful reset the circuit
+            currentState = CircuitState.CLOSE;
+        }
+    } else {
+        float currentFailureRate;
+
+        if (circuitHealth.requestCount > 0) {
+            currentFailureRate = (circuitHealth.errorCount / circuitHealth.requestCount) * 100;
+        } else {
+            currentFailureRate = 0;
+        }
+
+        if (currentFailureRate > failureThreshold) {
+            currentState = CircuitState.OPEN;
+        }
+    }
+
+    return currentState;
+}
+
+function <CircuitHealth circuitHealth> updateHealth () {
+    circuitHealth.errorCount = circuitHealth.errorCount + 1;
+    circuitHealth.lastErrorTime = currentTime();
+}
+
+function createErrorResponse (string msg) (http:Response) {
+    http:Response errorResponse = {};
+    errorResponse.setStringPayload(msg);
+    errorResponse.setStatusCode(500);
+    return errorResponse;
+}
+
+function handleOpenCircuit (CircuitHealth circuitHealth, int resetTimeout) (http:Response) {
+    Time currentT = currentTime();
+    int timeDif = currentT.time - circuitHealth.lastErrorTime.time;
+    int timeRemaining = resetTimeout - timeDif;
+    return createErrorResponse("Upstream service unavailable. Requests to upstream service will be suspended for "
+                               + timeRemaining + " milliseconds");
+}

--- a/modules/ballerina-http/src/main/ballerina/ballerina/net/http/resiliency/circuit-breaker.bal
+++ b/modules/ballerina-http/src/main/ballerina/ballerina/net/http/resiliency/circuit-breaker.bal
@@ -27,31 +27,15 @@ public connector CircuitBreaker (http:HttpClient httpClient, float failurePercen
         http:Response res;
         http:HttpConnectorError e;
 
-        if (currentState == CircuitState.CLOSE) {
-            res, e = httpEP.post(path, req);
-            circuitHealth.requestCount = circuitHealth.requestCount + 1;
-
-            if (e != null) {
-                circuitHealth.updateHealth();
-                http:Response errorResponse = createErrorResponse(e.msg, e.statusCode);
-                return errorResponse, e;
-            }
-        } else if (currentState == CircuitState.HALF_OPEN) {
-            res, e = httpEP.post(path, req);
-            circuitHealth.requestCount = circuitHealth.requestCount + 1;
-
-            if (e != null) {
-                circuitHealth.updateHealth();
-                http:Response errorResponse = createErrorResponse(e.msg, e.statusCode);
-                return errorResponse, e;
-            }
-        } else {
+        if (currentState == CircuitState.OPEN) {
             // TODO: Allow the user to handle this scenario. Maybe through a user provided function
-            http:Response errorResponse = handleOpenCircuit(circuitHealth, resetTimeout);
-            return errorResponse, e;
+            res = handleOpenCircuit(circuitHealth, resetTimeout);
+        } else {
+            res, e = httpEP.post(path, req);
+            updateCircuitHealth(circuitHealth, e);
         }
 
-        return res, null;
+        return res, e;
     }
 
     action head (string path, http:Request req) (http:Response, http:HttpConnectorError) {
@@ -59,31 +43,15 @@ public connector CircuitBreaker (http:HttpClient httpClient, float failurePercen
         http:Response res;
         http:HttpConnectorError e;
 
-        if (currentState == CircuitState.CLOSE) {
-            res, e = httpEP.head(path, req);
-            circuitHealth.requestCount = circuitHealth.requestCount + 1;
-
-            if (e != null) {
-                circuitHealth.updateHealth();
-                http:Response errorResponse = createErrorResponse(e.msg, e.statusCode);
-                return errorResponse, e;
-            }
-        } else if (currentState == CircuitState.HALF_OPEN) {
-            res, e = httpEP.head(path, req);
-            circuitHealth.requestCount = circuitHealth.requestCount + 1;
-
-            if (e != null) {
-                circuitHealth.updateHealth();
-                http:Response errorResponse = createErrorResponse(e.msg, e.statusCode);
-                return errorResponse, e;
-            }
-        } else {
+        if (currentState == CircuitState.OPEN) {
             // TODO: Allow the user to handle this scenario. Maybe through a user provided function
-            http:Response errorResponse = handleOpenCircuit(circuitHealth, resetTimeout);
-            return errorResponse, e;
+            res = handleOpenCircuit(circuitHealth, resetTimeout);
+        } else {
+            res, e = httpEP.head(path, req);
+            updateCircuitHealth(circuitHealth, e);
         }
 
-        return res, null;
+        return res, e;
     }
 
     action put (string path, http:Request req) (http:Response, http:HttpConnectorError) {
@@ -91,31 +59,15 @@ public connector CircuitBreaker (http:HttpClient httpClient, float failurePercen
         http:Response res;
         http:HttpConnectorError e;
 
-        if (currentState == CircuitState.CLOSE) {
-            res, e = httpEP.put(path, req);
-            circuitHealth.requestCount = circuitHealth.requestCount + 1;
-
-            if (e != null) {
-                circuitHealth.updateHealth();
-                http:Response errorResponse = createErrorResponse(e.msg, e.statusCode);
-                return errorResponse, e;
-            }
-        } else if (currentState == CircuitState.HALF_OPEN) {
-            res, e = httpEP.put(path, req);
-            circuitHealth.requestCount = circuitHealth.requestCount + 1;
-
-            if (e != null) {
-                circuitHealth.updateHealth();
-                http:Response errorResponse = createErrorResponse(e.msg, e.statusCode);
-                return errorResponse, e;
-            }
-        } else {
+        if (currentState == CircuitState.OPEN) {
             // TODO: Allow the user to handle this scenario. Maybe through a user provided function
-            http:Response errorResponse = handleOpenCircuit(circuitHealth, resetTimeout);
-            return errorResponse, e;
+            res = handleOpenCircuit(circuitHealth, resetTimeout);
+        } else {
+            res, e = httpEP.put(path, req);
+            updateCircuitHealth(circuitHealth, e);
         }
 
-        return res, null;
+        return res, e;
     }
 
     action execute (string httpVerb, string path, http:Request req) (http:Response, http:HttpConnectorError) {
@@ -123,31 +75,15 @@ public connector CircuitBreaker (http:HttpClient httpClient, float failurePercen
         http:Response res;
         http:HttpConnectorError e;
 
-        if (currentState == CircuitState.CLOSE) {
-            res, e = httpEP.execute(httpVerb, path, req);
-            circuitHealth.requestCount = circuitHealth.requestCount + 1;
-
-            if (e != null) {
-                circuitHealth.updateHealth();
-                http:Response errorResponse = createErrorResponse(e.msg, e.statusCode);
-                return errorResponse, e;
-            }
-        } else if (currentState == CircuitState.HALF_OPEN) {
-            res, e = httpEP.execute(httpVerb, path, req);
-            circuitHealth.requestCount = circuitHealth.requestCount + 1;
-
-            if (e != null) {
-                circuitHealth.updateHealth();
-                http:Response errorResponse = createErrorResponse(e.msg, e.statusCode);
-                return errorResponse, e;
-            }
-        } else {
+        if (currentState == CircuitState.OPEN) {
             // TODO: Allow the user to handle this scenario. Maybe through a user provided function
-            http:Response errorResponse = handleOpenCircuit(circuitHealth, resetTimeout);
-            return errorResponse, e;
+            res = handleOpenCircuit(circuitHealth, resetTimeout);
+        } else {
+            res, e = httpEP.execute(httpVerb, path, req);
+            updateCircuitHealth(circuitHealth, e);
         }
 
-        return res, null;
+        return res, e;
     }
 
     action patch (string path, http:Request req) (http:Response, http:HttpConnectorError) {
@@ -155,31 +91,15 @@ public connector CircuitBreaker (http:HttpClient httpClient, float failurePercen
         http:Response res;
         http:HttpConnectorError e;
 
-        if (currentState == CircuitState.CLOSE) {
-            res, e = httpEP.patch(path, req);
-            circuitHealth.requestCount = circuitHealth.requestCount + 1;
-
-            if (e != null) {
-                circuitHealth.updateHealth();
-                http:Response errorResponse = createErrorResponse(e.msg, e.statusCode);
-                return errorResponse, e;
-            }
-        } else if (currentState == CircuitState.HALF_OPEN) {
-            res, e = httpEP.patch(path, req);
-            circuitHealth.requestCount = circuitHealth.requestCount + 1;
-
-            if (e != null) {
-                circuitHealth.updateHealth();
-                http:Response errorResponse = createErrorResponse(e.msg, e.statusCode);
-                return errorResponse, e;
-            }
-        } else {
+        if (currentState == CircuitState.OPEN) {
             // TODO: Allow the user to handle this scenario. Maybe through a user provided function
-            http:Response errorResponse = handleOpenCircuit(circuitHealth, resetTimeout);
-            return errorResponse, e;
+            res = handleOpenCircuit(circuitHealth, resetTimeout);
+        } else {
+            res, e = httpEP.patch(path, req);
+            updateCircuitHealth(circuitHealth, e);
         }
 
-        return res, null;
+        return res, e;
     }
 
     action delete (string path, http:Request req) (http:Response, http:HttpConnectorError) {
@@ -187,31 +107,15 @@ public connector CircuitBreaker (http:HttpClient httpClient, float failurePercen
         http:Response res;
         http:HttpConnectorError e;
 
-        if (currentState == CircuitState.CLOSE) {
-            res, e = httpEP.delete(path, req);
-            circuitHealth.requestCount = circuitHealth.requestCount + 1;
-
-            if (e != null) {
-                circuitHealth.updateHealth();
-                http:Response errorResponse = createErrorResponse(e.msg, e.statusCode);
-                return errorResponse, e;
-            }
-        } else if (currentState == CircuitState.HALF_OPEN) {
-            res, e = httpEP.delete(path, req);
-            circuitHealth.requestCount = circuitHealth.requestCount + 1;
-
-            if (e != null) {
-                circuitHealth.updateHealth();
-                http:Response errorResponse = createErrorResponse(e.msg, e.statusCode);
-                return errorResponse, e;
-            }
-        } else {
+        if (currentState == CircuitState.OPEN) {
             // TODO: Allow the user to handle this scenario. Maybe through a user provided function
-            http:Response errorResponse = handleOpenCircuit(circuitHealth, resetTimeout);
-            return errorResponse, e;
+            res = handleOpenCircuit(circuitHealth, resetTimeout);
+        } else {
+            res, e = httpEP.delete(path, req);
+            updateCircuitHealth(circuitHealth, e);
         }
 
-        return res, null;
+        return res, e;
     }
 
     action options (string path, http:Request req) (http:Response, http:HttpConnectorError) {
@@ -219,31 +123,15 @@ public connector CircuitBreaker (http:HttpClient httpClient, float failurePercen
         http:Response res;
         http:HttpConnectorError e;
 
-        if (currentState == CircuitState.CLOSE) {
-            res, e = httpEP.options(path, req);
-            circuitHealth.requestCount = circuitHealth.requestCount + 1;
-
-            if (e != null) {
-                circuitHealth.updateHealth();
-                http:Response errorResponse = createErrorResponse(e.msg, e.statusCode);
-                return errorResponse, e;
-            }
-        } else if (currentState == CircuitState.HALF_OPEN) {
-            res, e = httpEP.options(path, req);
-            circuitHealth.requestCount = circuitHealth.requestCount + 1;
-
-            if (e != null) {
-                circuitHealth.updateHealth();
-                http:Response errorResponse = createErrorResponse(e.msg, e.statusCode);
-                return errorResponse, e;
-            }
-        } else {
+        if (currentState == CircuitState.OPEN) {
             // TODO: Allow the user to handle this scenario. Maybe through a user provided function
-            http:Response errorResponse = handleOpenCircuit(circuitHealth, resetTimeout);
-            return errorResponse, e;
+            res = handleOpenCircuit(circuitHealth, resetTimeout);
+        } else {
+            res, e = httpEP.options(path, req);
+            updateCircuitHealth(circuitHealth, e);
         }
 
-        return res, null;
+        return res, e;
     }
 
     action forward (string path, http:Request req) (http:Response, http:HttpConnectorError) {
@@ -251,31 +139,15 @@ public connector CircuitBreaker (http:HttpClient httpClient, float failurePercen
         http:Response res;
         http:HttpConnectorError e;
 
-        if (currentState == CircuitState.CLOSE) {
-            res, e = httpEP.forward(path, req);
-            circuitHealth.requestCount = circuitHealth.requestCount + 1;
-
-            if (e != null) {
-                circuitHealth.updateHealth();
-                http:Response errorResponse = createErrorResponse(e.msg, e.statusCode);
-                return errorResponse, e;
-            }
-        } else if (currentState == CircuitState.HALF_OPEN) {
-            res, e = httpEP.forward(path, req);
-            circuitHealth.requestCount = circuitHealth.requestCount + 1;
-
-            if (e != null) {
-                circuitHealth.updateHealth();
-                http:Response errorResponse = createErrorResponse(e.msg, e.statusCode);
-                return errorResponse, e;
-            }
-        } else {
+        if (currentState == CircuitState.OPEN) {
             // TODO: Allow the user to handle this scenario. Maybe through a user provided function
-            http:Response errorResponse = handleOpenCircuit(circuitHealth, resetTimeout);
-            return errorResponse, e;
+            res = handleOpenCircuit(circuitHealth, resetTimeout);
+        } else {
+            res, e = httpEP.forward(path, req);
+            updateCircuitHealth(circuitHealth, e);
         }
 
-        return res, null;
+        return res, e;
     }
 
     action get (string path, http:Request req) (http:Response, http:HttpConnectorError) {
@@ -283,31 +155,15 @@ public connector CircuitBreaker (http:HttpClient httpClient, float failurePercen
         http:Response res;
         http:HttpConnectorError e;
 
-        if (currentState == CircuitState.CLOSE) {
-            res, e = httpEP.get(path, req);
-            circuitHealth.requestCount = circuitHealth.requestCount + 1;
-
-            if (e != null) {
-                circuitHealth.updateHealth();
-                http:Response errorResponse = createErrorResponse(e.msg, e.statusCode);
-                return errorResponse, e;
-            }
-        } else if (currentState == CircuitState.HALF_OPEN) {
-            res, e = httpEP.get(path, req);
-            circuitHealth.requestCount = circuitHealth.requestCount + 1;
-
-            if (e != null) {
-                circuitHealth.updateHealth();
-                http:Response errorResponse = createErrorResponse(e.msg, e.statusCode);
-                return errorResponse, e;
-            }
-        } else {
+        if (currentState == CircuitState.OPEN) {
             // TODO: Allow the user to handle this scenario. Maybe through a user provided function
-            http:Response errorResponse = handleOpenCircuit(circuitHealth, resetTimeout);
-            return errorResponse, e;
+            res = handleOpenCircuit(circuitHealth, resetTimeout);
+        } else {
+            res, e = httpEP.get(path, req);
+            updateCircuitHealth(circuitHealth, e);
         }
 
-        return res, null;
+        return res, e;
     }
 }
 
@@ -331,12 +187,10 @@ function updateCircuitState (CircuitHealth circuitHealth, CircuitState currentSt
             currentState = CircuitState.CLOSE;
         }
     } else {
-        float currentFailureRate;
+        float currentFailureRate = 0;
 
         if (circuitHealth.requestCount > 0) {
             currentFailureRate = (circuitHealth.errorCount / circuitHealth.requestCount) * 100;
-        } else {
-            currentFailureRate = 0;
         }
 
         if (currentFailureRate > failureThreshold) {
@@ -347,9 +201,13 @@ function updateCircuitState (CircuitHealth circuitHealth, CircuitState currentSt
     return currentState;
 }
 
-function <CircuitHealth circuitHealth> updateHealth () {
-    circuitHealth.errorCount = circuitHealth.errorCount + 1;
-    circuitHealth.lastErrorTime = currentTime();
+function updateCircuitHealth(CircuitHealth circuitHealth, http:HttpConnectorError err) {
+    circuitHealth.requestCount = circuitHealth.requestCount + 1;
+
+    if (err != null) {
+        circuitHealth.errorCount = circuitHealth.errorCount + 1;
+        circuitHealth.lastErrorTime = currentTime();
+    }
 }
 
 function createErrorResponse (string msg, int statusCode) (http:Response) {

--- a/modules/ballerina-test/src/test/java/org/ballerinalang/test/net/http/resiliency/CircuitBreakerTest.java
+++ b/modules/ballerina-test/src/test/java/org/ballerinalang/test/net/http/resiliency/CircuitBreakerTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.test.net.http.resiliency;
+
+import org.ballerinalang.launcher.util.BCompileUtil;
+import org.ballerinalang.launcher.util.BRunUtil;
+import org.ballerinalang.launcher.util.CompileResult;
+import org.ballerinalang.model.values.BRefValueArray;
+import org.ballerinalang.model.values.BStruct;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.net.http.Constants;
+import org.testng.Assert;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+import org.wso2.transport.http.netty.message.HTTPCarbonMessage;
+
+/**
+ * Test cases for the Circuit Breaker
+ */
+public class CircuitBreakerTest {
+
+    private CompileResult compileResult;
+
+    @BeforeTest
+    public void setup() {
+        compileResult = BCompileUtil.compile("test-src/net/http/resiliency/circuit-breaker-test.bal");
+    }
+
+    /**
+     * Test case for a typical scenario where an upstream service may become unavailable temporarily.
+     */
+    @Test
+    public void testCircuitBreaker() {
+        int[] expectedStatusCodes = new int[]{200, 200, 502, 503, 503, 200, 200, 200};
+        BValue[] returnVals = BRunUtil.invoke(compileResult, "testTypicalScenario");
+
+        Assert.assertEquals(returnVals.length, 2);
+
+        BRefValueArray responses = (BRefValueArray) returnVals[0];
+        BRefValueArray errs = (BRefValueArray) returnVals[1];
+
+        for (int i = 0; i < responses.size(); i++) {
+            // TODO: remove this Carbon message usage once status code bug is fixed (issue #4448)
+            HTTPCarbonMessage res = getCarbonMessage((BStruct) responses.get(i));
+
+            if (res != null) {
+                Assert.assertEquals(
+                        Integer.parseInt(res.getProperty(Constants.HTTP_STATUS_CODE).toString()),
+                        expectedStatusCodes[i]);
+            } else {
+                Assert.assertNotNull(errs.get(i)); // the request which resulted in an error
+                BStruct err = (BStruct) errs.get(i);
+                long statusCode = err.getIntField(0);
+
+                Assert.assertEquals(statusCode, 502);
+            }
+        }
+    }
+
+    /**
+     * Test case scenario:
+     * * Initially the circuit is healthy and functioning normally.
+     * * Backend service becomes unavailable and eventually, the failure threshold is exceeded.
+     * * Requests afterwards are immediately failed, with a 503 response.
+     * * After the reset timeout expires, the circuit goes to HALF_OPEN state and a trial request is sent.
+     * * The backend service is not available and therefore, the request fails again and the circuit goes back to OPEN.
+     */
+    @Test
+    public void testTrialRunFailure() {
+        int[] expectedStatusCodes = new int[]{200, 502, 503, 502, 503, 503};
+        BValue[] returnVals = BRunUtil.invoke(compileResult, "testTrialRunFailure");
+
+        Assert.assertEquals(returnVals.length, 2);
+
+        BRefValueArray responses = (BRefValueArray) returnVals[0];
+        BRefValueArray errs = (BRefValueArray) returnVals[1];
+
+        for (int i = 0; i < responses.size(); i++) {
+            // TODO: remove this Carbon message usage once status code bug is fixed (issue #4448)
+            HTTPCarbonMessage res = getCarbonMessage((BStruct) responses.get(i));
+            long statusCode;
+
+            if (res != null) {
+                statusCode = Integer.parseInt(res.getProperty(Constants.HTTP_STATUS_CODE).toString());
+
+                Assert.assertEquals(statusCode, expectedStatusCodes[i]);
+            } else {
+                Assert.assertNotNull(errs.get(i)); // the request which resulted in an error
+                BStruct err = (BStruct) errs.get(i);
+                statusCode = err.getIntField(0);
+
+                Assert.assertEquals(statusCode, 502);
+            }
+        }
+    }
+
+
+    private HTTPCarbonMessage getCarbonMessage(BStruct response) {
+        if (response != null) {
+            return (HTTPCarbonMessage) response.getNativeData(Constants.TRANSPORT_MESSAGE);
+        }
+
+        return null;
+    }
+}

--- a/modules/ballerina-test/src/test/resources/test-src/net/http/resiliency/circuit-breaker-test.bal
+++ b/modules/ballerina-test/src/test/resources/test-src/net/http/resiliency/circuit-breaker-test.bal
@@ -9,7 +9,7 @@ const string SCENARIO_TRIAL_RUN_FAILURE = "trial-run-failure";
 function testTypicalScenario () (http:Response[], http:HttpConnectorError[]) {
 
     endpoint<resiliency:CircuitBreaker> circuitBreakerEP {
-        create resiliency:CircuitBreaker((http:HttpClient)create MockHttpClient("http://localhost:8080", {}), 10, 2000);
+        create resiliency:CircuitBreaker((http:HttpClient)create MockHttpClient("http://localhost:8080", {}), 0.1, 2000);
     }
 
     http:Request request;
@@ -35,7 +35,7 @@ function testTypicalScenario () (http:Response[], http:HttpConnectorError[]) {
 function testTrialRunFailure () (http:Response[], http:HttpConnectorError[]) {
 
     endpoint<resiliency:CircuitBreaker> circuitBreakerEP {
-        create resiliency:CircuitBreaker((http:HttpClient)create MockHttpClient("http://localhost:8080", {}), 10, 2000);
+        create resiliency:CircuitBreaker((http:HttpClient)create MockHttpClient("http://localhost:8080", {}), 0.1, 2000);
     }
 
     http:Request request;

--- a/modules/ballerina-test/src/test/resources/test-src/net/http/resiliency/circuit-breaker-test.bal
+++ b/modules/ballerina-test/src/test/resources/test-src/net/http/resiliency/circuit-breaker-test.bal
@@ -1,0 +1,146 @@
+import ballerina.net.http;
+import ballerina.net.http.resiliency;
+
+const string TEST_SCENARIO_HEADER = "test-scenario";
+
+const string SCENARIO_TYPICAL = "typical-scenario";
+const string SCENARIO_TRIAL_RUN_FAILURE = "trial-run-failure";
+
+function testTypicalScenario () (http:Response[], http:HttpConnectorError[]) {
+
+    endpoint<resiliency:CircuitBreaker> circuitBreakerEP {
+        create resiliency:CircuitBreaker((http:HttpClient)create MockHttpClient("http://localhost:8080", {}), 10, 2000);
+    }
+
+    http:Request request;
+    http:Response[] responses = [];
+    http:HttpConnectorError[] errs = [];
+    int counter = 0;
+
+    while (counter < 8) {
+        request = {};
+        request.setHeader(TEST_SCENARIO_HEADER, SCENARIO_TYPICAL);
+        responses[counter], errs[counter] = circuitBreakerEP.get("/hello", request);
+        counter = counter + 1;
+
+        // To ensure the reset timeout period expires
+        if (counter == 5) {
+            sleep(5000);
+        }
+    }
+
+    return responses, errs;
+}
+
+function testTrialRunFailure () (http:Response[], http:HttpConnectorError[]) {
+
+    endpoint<resiliency:CircuitBreaker> circuitBreakerEP {
+        create resiliency:CircuitBreaker((http:HttpClient)create MockHttpClient("http://localhost:8080", {}), 10, 2000);
+    }
+
+    http:Request request;
+    http:Response[] responses = [];
+    http:HttpConnectorError[] errs = [];
+    int counter = 0;
+
+    while (counter < 6) {
+        request = {};
+        request.setHeader(TEST_SCENARIO_HEADER, SCENARIO_TRIAL_RUN_FAILURE);
+        responses[counter], errs[counter] = circuitBreakerEP.get("/hello", request);
+        counter = counter + 1;
+
+        if (counter == 3) {
+            sleep(5000);
+        }
+    }
+
+    return responses, errs;
+}
+
+connector MockHttpClient (string serviceUri, http:Options connectorOptions) {
+
+    int actualRequestNumber = 0;
+
+    action post (string path, http:Request req) (http:Response, http:HttpConnectorError) {
+        return null, null;
+    }
+
+    action head (string path, http:Request req) (http:Response, http:HttpConnectorError) {
+        return null, null;
+    }
+
+    action put (string path, http:Request req) (http:Response, http:HttpConnectorError) {
+        return null, null;
+    }
+
+    action execute (string httpVerb, string path, http:Request req) (http:Response, http:HttpConnectorError) {
+        return null, null;
+    }
+
+    action patch (string path, http:Request req) (http:Response, http:HttpConnectorError) {
+        return null, null;
+    }
+
+    action delete (string path, http:Request req) (http:Response, http:HttpConnectorError) {
+        return null, null;
+    }
+
+    action get (string path, http:Request req) (http:Response, http:HttpConnectorError) {
+        http:Response response;
+        http:HttpConnectorError err;
+        actualRequestNumber = actualRequestNumber + 1;
+
+        string scenario = req.getHeader(TEST_SCENARIO_HEADER).value;
+
+        if (scenario == SCENARIO_TYPICAL) {
+            response, err = handleScenario1(actualRequestNumber);
+        } else if (scenario == SCENARIO_TRIAL_RUN_FAILURE) {
+            response, err = handleScenario2(actualRequestNumber);
+        }
+
+        return response, err;
+    }
+
+    action options (string path, http:Request req) (http:Response, http:HttpConnectorError) {
+        return null, null;
+    }
+
+    action forward (string path, http:Request req) (http:Response, http:HttpConnectorError) {
+        return null, null;
+    }
+}
+
+function handleScenario1 (int requesetNo) (http:Response, http:HttpConnectorError) {
+    // Deliberately fail a request
+    if (requesetNo == 3) {
+        http:HttpConnectorError err = getErrorStruct();
+        return null, err;
+    }
+
+    http:Response response = getResponse();
+    return response, null;
+}
+
+function handleScenario2 (int counter) (http:Response, http:HttpConnectorError) {
+    // Fail a request. Then, fail the trial request sent while in the HALF_OPEN state as well.
+    if (counter == 2 || counter == 3) {
+        http:HttpConnectorError err = getErrorStruct();
+        return null, err;
+    }
+
+    http:Response response = getResponse();
+    return response, null;
+}
+
+function getErrorStruct () (http:HttpConnectorError) {
+    http:HttpConnectorError err = {};
+    err.msg = "Connection refused";
+    err.statusCode = 502;
+    return err;
+}
+
+function getResponse () (http:Response) {
+    http:Response response = {};
+    response.setStatusCode(200);
+    return response;
+}

--- a/samples/ballerina-by-example/examples.txt
+++ b/samples/ballerina-by-example/examples.txt
@@ -66,6 +66,7 @@ HTTPS Server/Client Connectors
 HTTP Disable Chunking
 HTTP to WebSocket Upgrade
 HTTP CORS
+HTTP Circuit Breaker
 Log API
 Function Pointers
 Lambda

--- a/samples/ballerina-by-example/examples/http-circuit-breaker/http-circuit-breaker.bal
+++ b/samples/ballerina-by-example/examples/http-circuit-breaker/http-circuit-breaker.bal
@@ -1,0 +1,55 @@
+import ballerina.net.http;
+import ballerina.net.http.resiliency;
+
+@http:configuration {basePath:"/cb"}
+service<http> circuitBreakerDemo {
+
+    // The Circuit Breaker accepts an HTTP client connector as its first argument.
+    // The second and third arguments to the Circuit Breaker are the failure threshold as a percentage and the reset timeout respectively.<br>
+    // * When the percentage of failed requests passes the specified threshold, the circuit trips and subsequent requests to the backend fails immediately.<br>
+    // * When the time specified in the reset timeout elapses, the circuit goes to 'half-open' state.<br>
+    // * If a request comes when it is in half-open state, it is sent to the backend and if it does not result in an error, the circuit state goes to 'close'.<br>
+    // * If it fails though, the circuit goes back to 'open' state, and the above process repeats.<br>
+    endpoint<resiliency:CircuitBreaker> circuitBreakerEP {
+        create resiliency:CircuitBreaker(create http:HttpClient("http://localhost:8080", {endpointTimeout:2000}), 30, 20000);
+    }
+
+    @http:resourceConfig {
+        methods:["GET"],
+        path:"/"
+    }
+    resource sayHello (http:Request request, http:Response response) {
+        http:Response clientRes;
+        http:HttpConnectorError err;
+        clientRes, err = circuitBreakerEP.forward("/hello", request);
+
+        if (err != null) {
+            println(err);
+        } else {
+            println(clientRes.getStringPayload());
+        }
+        _ = response.forward(clientRes);
+    }
+}
+
+// This sample service can be used to mock connection timeouts and service outages. Service outage can be mocked by stopping/starting this service.
+// This should be run separately from the circuitBreakerDemo service.
+@http:configuration {basePath:"/hello", port:8080}
+service<http> helloWorld {
+
+    int counter = 1;
+
+    @http:resourceConfig {
+        methods:["GET"],
+        path:"/"
+    }
+    resource sayHello (http:Request request, http:Response response) {
+        if (counter % 3 == 0) {
+            sleep(5000);
+        }
+        counter = counter + 1;
+
+        response.setStringPayload("Hello World!!!");
+        _ = response.send();
+    }
+}

--- a/samples/ballerina-by-example/examples/http-circuit-breaker/http-circuit-breaker.bal
+++ b/samples/ballerina-by-example/examples/http-circuit-breaker/http-circuit-breaker.bal
@@ -25,6 +25,10 @@ service<http> circuitBreakerDemo {
 
         if (err != null) {
             println(err);
+            if (clientRes == null) {
+                clientRes = {};
+                clientRes.setStatusCode(err.statusCode);
+            }
         } else {
             println(clientRes.getStringPayload());
         }

--- a/samples/ballerina-by-example/examples/http-circuit-breaker/http-circuit-breaker.client.sh
+++ b/samples/ballerina-by-example/examples/http-circuit-breaker/http-circuit-breaker.client.sh
@@ -38,7 +38,7 @@ $ curl -v http://localhost:9090/cb
 > User-Agent: curl/7.47.0
 > Accept: */*
 >
-< HTTP/1.1 500 Internal Server Error
+< HTTP/1.1 504 Gateway Timeout
 < Content-Type: text/plain
 < Content-Length: 15
 <
@@ -54,12 +54,12 @@ $ curl -v http://localhost:9090/cb
 > User-Agent: curl/7.47.0
 > Accept: */*
 >
-< HTTP/1.1 500 Internal Server Error
+< HTTP/1.1 503 Service Unavailable
 < Content-Type: text/plain
 < Content-Length: 99
 <
 * Connection #0 to host localhost left intact
-Upstream service unavailable. Requests to upstream service will be suspended for 18919 milliseconds
+Upstream service unavailable. Requests to upstream service will be suspended for 14061 milliseconds
 
 $ curl -v http://localhost:9090/cb
 *   Trying 127.0.0.1...
@@ -69,27 +69,12 @@ $ curl -v http://localhost:9090/cb
 > User-Agent: curl/7.47.0
 > Accept: */*
 >
-< HTTP/1.1 500 Internal Server Error
-< Content-Type: text/plain
-< Content-Length: 99
-<
-* Connection #0 to host localhost left intact
-Upstream service unavailable. Requests to upstream service will be suspended for 13526 milliseconds
-
-$ curl -v http://localhost:9090/cb
-*   Trying 127.0.0.1...
-* Connected to localhost (127.0.0.1) port 9090 (#0)
-> GET /cb HTTP/1.1
-> Host: localhost:9090
-> User-Agent: curl/7.47.0
-> Accept: */*
->
-< HTTP/1.1 500 Internal Server Error
+< HTTP/1.1 503 Service Unavailable
 < Content-Type: text/plain
 < Content-Length: 98
 <
 * Connection #0 to host localhost left intact
-Upstream service unavailable. Requests to upstream service will be suspended for 5634 milliseconds
+Upstream service unavailable. Requests to upstream service will be suspended for 5398 milliseconds
 
 $ curl -v http://localhost:9090/cb
 *   Trying 127.0.0.1...
@@ -99,12 +84,12 @@ $ curl -v http://localhost:9090/cb
 > User-Agent: curl/7.47.0
 > Accept: */*
 >
-< HTTP/1.1 500 Internal Server Error
+< HTTP/1.1 503 Service Unavailable
 < Content-Type: text/plain
-< Content-Length: 97
+< Content-Length: 98
 <
 * Connection #0 to host localhost left intact
-Upstream service unavailable. Requests to upstream service will be suspended for 793 milliseconds
+Upstream service unavailable. Requests to upstream service will be suspended for 1753 milliseconds
 
 # The request sent immediately after the timeout period expires is the trial request, to see if the backend service is back to normal.
 # If this succeeds, the circuit is set to 'close' and normal functionality resumes.

--- a/samples/ballerina-by-example/examples/http-circuit-breaker/http-circuit-breaker.client.sh
+++ b/samples/ballerina-by-example/examples/http-circuit-breaker/http-circuit-breaker.client.sh
@@ -1,0 +1,140 @@
+# The first 2 requests complete without any issue.
+$ curl -v http://localhost:9090/cb
+*   Trying 127.0.0.1...
+* Connected to localhost (127.0.0.1) port 9090 (#0)
+> GET /cb HTTP/1.1
+> Host: localhost:9090
+> User-Agent: curl/7.47.0
+> Accept: */*
+>
+< HTTP/1.1 200 OK
+< Content-Length: 14
+< Content-Type: text/plain
+<
+* Connection #0 to host localhost left intact
+Hello World!!!
+
+$ curl -v http://localhost:9090/cb
+*   Trying 127.0.0.1...
+* Connected to localhost (127.0.0.1) port 9090 (#0)
+> GET /cb HTTP/1.1
+> Host: localhost:9090
+> User-Agent: curl/7.47.0
+> Accept: */*
+>
+< HTTP/1.1 200 OK
+< Content-Length: 14
+< Content-Type: text/plain
+<
+* Connection #0 to host localhost left intact
+Hello World!!!
+
+# The third one times out, since our mock service times out when responding to every third request.
+$ curl -v http://localhost:9090/cb
+*   Trying 127.0.0.1...
+* Connected to localhost (127.0.0.1) port 9090 (#0)
+> GET /cb HTTP/1.1
+> Host: localhost:9090
+> User-Agent: curl/7.47.0
+> Accept: */*
+>
+< HTTP/1.1 500 Internal Server Error
+< Content-Type: text/plain
+< Content-Length: 15
+<
+* Connection #0 to host localhost left intact
+Gateway Timeout
+
+# Subsequent requests fail immediately since the reset timeout period has not elapsed.
+$ curl -v http://localhost:9090/cb
+*   Trying 127.0.0.1...
+* Connected to localhost (127.0.0.1) port 9090 (#0)
+> GET /cb HTTP/1.1
+> Host: localhost:9090
+> User-Agent: curl/7.47.0
+> Accept: */*
+>
+< HTTP/1.1 500 Internal Server Error
+< Content-Type: text/plain
+< Content-Length: 99
+<
+* Connection #0 to host localhost left intact
+Upstream service unavailable. Requests to upstream service will be suspended for 18919 milliseconds
+
+$ curl -v http://localhost:9090/cb
+*   Trying 127.0.0.1...
+* Connected to localhost (127.0.0.1) port 9090 (#0)
+> GET /cb HTTP/1.1
+> Host: localhost:9090
+> User-Agent: curl/7.47.0
+> Accept: */*
+>
+< HTTP/1.1 500 Internal Server Error
+< Content-Type: text/plain
+< Content-Length: 99
+<
+* Connection #0 to host localhost left intact
+Upstream service unavailable. Requests to upstream service will be suspended for 13526 milliseconds
+
+$ curl -v http://localhost:9090/cb
+*   Trying 127.0.0.1...
+* Connected to localhost (127.0.0.1) port 9090 (#0)
+> GET /cb HTTP/1.1
+> Host: localhost:9090
+> User-Agent: curl/7.47.0
+> Accept: */*
+>
+< HTTP/1.1 500 Internal Server Error
+< Content-Type: text/plain
+< Content-Length: 98
+<
+* Connection #0 to host localhost left intact
+Upstream service unavailable. Requests to upstream service will be suspended for 5634 milliseconds
+
+$ curl -v http://localhost:9090/cb
+*   Trying 127.0.0.1...
+* Connected to localhost (127.0.0.1) port 9090 (#0)
+> GET /cb HTTP/1.1
+> Host: localhost:9090
+> User-Agent: curl/7.47.0
+> Accept: */*
+>
+< HTTP/1.1 500 Internal Server Error
+< Content-Type: text/plain
+< Content-Length: 97
+<
+* Connection #0 to host localhost left intact
+Upstream service unavailable. Requests to upstream service will be suspended for 793 milliseconds
+
+# The request sent immediately after the timeout period expires is the trial request, to see if the backend service is back to normal.
+# If this succeeds, the circuit is set to 'close' and normal functionality resumes.
+$ curl -v http://localhost:9090/cb
+*   Trying 127.0.0.1...
+* Connected to localhost (127.0.0.1) port 9090 (#0)
+> GET /cb HTTP/1.1
+> Host: localhost:9090
+> User-Agent: curl/7.47.0
+> Accept: */*
+>
+< HTTP/1.1 200 OK
+< Content-Length: 14
+< Content-Type: text/plain
+<
+* Connection #0 to host localhost left intact
+Hello World!!!
+
+# Since the immediate request after the timeout expired was successful, the requests after that complete normally.
+$ curl -v http://localhost:9090/cb
+*   Trying 127.0.0.1...
+* Connected to localhost (127.0.0.1) port 9090 (#0)
+> GET /cb HTTP/1.1
+> Host: localhost:9090
+> User-Agent: curl/7.47.0
+> Accept: */*
+>
+< HTTP/1.1 200 OK
+< Content-Length: 14
+< Content-Type: text/plain
+<
+* Connection #0 to host localhost left intact
+Hello World!!!

--- a/samples/ballerina-by-example/examples/http-circuit-breaker/http-circuit-breaker.description
+++ b/samples/ballerina-by-example/examples/http-circuit-breaker/http-circuit-breaker.description
@@ -1,0 +1,1 @@
+// The Circuit Breaker can be used to gracefully handle errors (network related) which occur when using the HTTP Client Connector.

--- a/samples/ballerina-by-example/examples/http-circuit-breaker/http-circuit-breaker.server.sh
+++ b/samples/ballerina-by-example/examples/http-circuit-breaker/http-circuit-breaker.server.sh
@@ -4,9 +4,8 @@ ballerina: started HTTP/WS server connector 0.0.0.0:9090
 Hello World!!!
 Hello World!!!
 {msg:"Gateway Timeout", cause:null, stackTrace:null, statusCode:504}
-Upstream service unavailable. Requests to upstream service will be suspended for 18919 milliseconds
-Upstream service unavailable. Requests to upstream service will be suspended for 13526 milliseconds
-Upstream service unavailable. Requests to upstream service will be suspended for 5634 milliseconds
-Upstream service unavailable. Requests to upstream service will be suspended for 793 milliseconds
+Upstream service unavailable. Requests to upstream service will be suspended for 14061 milliseconds
+Upstream service unavailable. Requests to upstream service will be suspended for 5398 milliseconds
+Upstream service unavailable. Requests to upstream service will be suspended for 1753 milliseconds
 Hello World!!!
 Hello World!!!

--- a/samples/ballerina-by-example/examples/http-circuit-breaker/http-circuit-breaker.server.sh
+++ b/samples/ballerina-by-example/examples/http-circuit-breaker/http-circuit-breaker.server.sh
@@ -1,0 +1,12 @@
+$ ballerina run http-circuit-breaker.bal
+ballerina: deploying service(s) in 'http-circuit-breaker.bal'
+ballerina: started HTTP/WS server connector 0.0.0.0:9090
+Hello World!!!
+Hello World!!!
+{msg:"Gateway Timeout", cause:null, stackTrace:null, statusCode:504}
+Upstream service unavailable. Requests to upstream service will be suspended for 18919 milliseconds
+Upstream service unavailable. Requests to upstream service will be suspended for 13526 milliseconds
+Upstream service unavailable. Requests to upstream service will be suspended for 5634 milliseconds
+Upstream service unavailable. Requests to upstream service will be suspended for 793 milliseconds
+Hello World!!!
+Hello World!!!


### PR DESCRIPTION
This PR adds a circuit breaker implementation for the HTTP Client Connector. The implementation was guided by [1] and PR #3224. 

The behaviour of the circuit breaker is as follows:

- The user can specify a `failureThreshold` and a `resetTimeout` when creating the Circuit Breaker. The `failureThreshold` is percentage value and as such, should be between 0 - 100. The `failureThreshold` is compared against the failure ratio. The failure ratio is calculated as the ratio between no. of requests made and the no. of failed requests while the Circuit Breaker is in the `CLOSE` state. The `resetTimeout` is the time period the Circuit Breaker waits for before setting the circuit state to `HALF_OPEN`.
- In normal usage, the Circuit Breaker behaviour is equivalent to the HTTP Client Connector behaviour. 
- If the specified ratio of requests fail in the `CLOSE` state, the circuit trips and the circuit state goes to `OPEN`. Subsequent requests made through the Circuit Breaker are immediately failed.
- When the reset timeout period expires, the Circuit Breaker goes from `OPEN` to `HALF_OPEN`. In this state, one request is allowed to go through. If that request fails as well, the circuit goes back to the `OPEN` state. 
- If the request does not fail, the circuit goes to `CLOSE` state and resumes to function normally. 

Usage:
```ballerina
endpoint<resiliency:CircuitBreaker> circuitBreakerEP {
        create resiliency:CircuitBreaker(create http:HttpClient("http://localhost:8080", {}), 30, 20000);
}
```
Fix #4025  

[1] - [https://martinfowler.com/bliki/CircuitBreaker.html](https://martinfowler.com/bliki/CircuitBreaker.html)