### PR TITLE
Make Proxy, SSL, FollowRedirects and Retry structs public

### DIFF
--- a/modules/ballerina-http/src/main/ballerina/ballerina/net/http/natives.bal
+++ b/modules/ballerina-http/src/main/ballerina/ballerina/net/http/natives.bal
@@ -289,7 +289,7 @@ public struct HttpConnectorError {
 @Description { value:"Retry struct represents retry related options for HTTP client invocation" }
 @Field {value:"count: Number of retries"}
 @Field {value:"interval: Retry interval in millisecond"}
-struct Retry {
+public struct Retry {
     int count;
     int interval;
 }
@@ -302,7 +302,7 @@ struct Retry {
 @Field {value:"sslEnabledProtocols: SSL/TLS protocols to be enabled. eg: TLSv1,TLSv1.1,TLSv1.2"}
 @Field {value:"ciphers: List of ciphers to be used. eg: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"}
 @Field {value:"sslProtocol: SSL Protocol to be used. eg: TLS1.2"}
-struct SSL {
+public struct SSL {
     string trustStoreFile;
     string trustStorePassword;
     string keyStoreFile;
@@ -315,7 +315,7 @@ struct SSL {
 @Description { value:"FollowRedirects struct represents HTTP redirect related options to be used for HTTP client invocation" }
 @Field {value:"enabled: Enable redirect"}
 @Field {value:"maxCount: Maximun number of redirects to follow"}
-struct FollowRedirects {
+public struct FollowRedirects {
     boolean enabled = false;
     int maxCount = 5;
 }
@@ -325,7 +325,7 @@ struct FollowRedirects {
 @Field {value:"proxyPort: proxy server port"}
 @Field {value:"proxyUserName: Proxy server user name"}
 @Field {value:"proxyPassword: proxy server password"}
-struct Proxy {
+public struct Proxy {
     string host;
     int port;
     string userName;


### PR DESCRIPTION
Making these public due to the following reasons:
- Since the current behaviour makes it seem like we are exploiting a bug (#4454) 
- Having these as private structs makes it impossible to document these although they should be documented.

Fix #4453 