### PR TITLE
Ignore generated token file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ hs_err_pid*
 # generated files
 target
 /gen
+/docs/grammar/BallerinaLexer.tokens
 
 # mac
 .DS_Store
-/docs/grammar/BallerinaLexer.tokens

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ target
 
 # mac
 .DS_Store
+/docs/grammar/BallerinaLexer.tokens


### PR DESCRIPTION
This commit adds `docs/grammar/BallerinaLexer.tokens` file to `gitignore`.