### PR TITLE
Handle failure scenario for HTTP sever/client connectors

### DIFF
--- a/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Delete.java
+++ b/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Delete.java
@@ -65,7 +65,7 @@ public class Delete extends AbstractHTTPAction {
         }
         try {
             // Execute the operation
-            return executeNonBlockingAction(context, createCarbonMsg(context));
+            return executeNonBlockingAction(context, createOutboundRequestMsg(context));
         } catch (ClientConnectorException clientConnectorException) {
             throw new BallerinaException("Failed to invoke 'delete' action in " + Constants.CONNECTOR_NAME
                     + ". " + clientConnectorException.getMessage(), context);
@@ -73,9 +73,9 @@ public class Delete extends AbstractHTTPAction {
     }
 
 
-    protected HTTPCarbonMessage createCarbonMsg(Context context) {
+    protected HTTPCarbonMessage createOutboundRequestMsg(Context context) {
         // Extract Argument values
-        HTTPCarbonMessage cMsg = super.createCarbonMsg(context);
+        HTTPCarbonMessage cMsg = super.createOutboundRequestMsg(context);
         cMsg.setProperty(Constants.HTTP_METHOD, Constants.HTTP_METHOD_DELETE);
         return cMsg;
     }

--- a/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Execute.java
+++ b/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Execute.java
@@ -71,14 +71,14 @@ public class Execute extends AbstractHTTPAction {
         }
         try {
             // Execute the operation
-            return executeNonBlockingAction(context, createCarbonMsg(context));
+            return executeNonBlockingAction(context, createOutboundRequestMsg(context));
         } catch (ClientConnectorException clientConnectorException) {
             throw new BallerinaException("Failed to invoke 'execute' action in " + Constants.CONNECTOR_NAME
                     + ". " + clientConnectorException.getMessage(), context);
         }
     }
 
-    protected HTTPCarbonMessage createCarbonMsg(Context context) {
+    protected HTTPCarbonMessage createOutboundRequestMsg(Context context) {
         // Extract Argument values
         BConnector bConnector = (BConnector) getRefArgument(context, 0);
         String httpVerb = getStringArgument(context, 0);
@@ -86,14 +86,14 @@ public class Execute extends AbstractHTTPAction {
         BStruct requestStruct = ((BStruct) getRefArgument(context, 1));
         //TODO check below line
         HTTPCarbonMessage defaultCarbonMsg = HttpUtil.createHttpCarbonMessage(true);
-        HTTPCarbonMessage cMsg = HttpUtil.getCarbonMsg(requestStruct, defaultCarbonMsg);
-        prepareRequest(bConnector, path, cMsg, requestStruct);
+        HTTPCarbonMessage outboundRequestMsg = HttpUtil.getCarbonMsg(requestStruct, defaultCarbonMsg);
+        prepareOutboundRequest(bConnector, path, outboundRequestMsg);
 
         // If the verb is not specified, use the verb in incoming message
         if (httpVerb == null || "".equals(httpVerb)) {
-            httpVerb = (String) cMsg.getProperty(Constants.HTTP_METHOD);
+            httpVerb = (String) outboundRequestMsg.getProperty(Constants.HTTP_METHOD);
         }
-        cMsg.setProperty(Constants.HTTP_METHOD, httpVerb.trim().toUpperCase(Locale.getDefault()));
-        return cMsg;
+        outboundRequestMsg.setProperty(Constants.HTTP_METHOD, httpVerb.trim().toUpperCase(Locale.getDefault()));
+        return outboundRequestMsg;
     }
 }

--- a/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Forward.java
+++ b/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Forward.java
@@ -71,14 +71,14 @@ public class Forward extends AbstractHTTPAction {
         }
         try {
             // Execute the operation
-            return executeNonBlockingAction(context, createCarbonMsg(context));
+            return executeNonBlockingAction(context, createOutboundRequestMsg(context));
         } catch (Throwable t) {
             throw new BallerinaException("Failed to invoke 'forward' action in " + Constants.CONNECTOR_NAME
                     + ". " + t.getMessage(), context);
         }
     }
 
-    protected HTTPCarbonMessage createCarbonMsg(Context context) {
+    protected HTTPCarbonMessage createOutboundRequestMsg(Context context) {
         BConnector bConnector = (BConnector) getRefArgument(context, 0);
         String path = getStringArgument(context, 0);
         BStruct requestStruct = ((BStruct) getRefArgument(context, 1));
@@ -89,7 +89,7 @@ public class Forward extends AbstractHTTPAction {
 
         HTTPCarbonMessage outboundRequestMsg = HttpUtil
                 .getCarbonMsg(requestStruct, HttpUtil.createHttpCarbonMessage(true));
-        prepareRequest(bConnector, path, outboundRequestMsg, requestStruct);
+        prepareOutboundRequest(bConnector, path, outboundRequestMsg);
 
         String httpVerb = (String) outboundRequestMsg.getProperty(Constants.HTTP_METHOD);
         outboundRequestMsg.setProperty(Constants.HTTP_METHOD, httpVerb.trim().toUpperCase(Locale.getDefault()));

--- a/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Get.java
+++ b/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Get.java
@@ -63,7 +63,7 @@ public class Get extends AbstractHTTPAction {
             logger.debug("Executing Native Action : {}", this.getName());
         }
         try {
-            return executeNonBlockingAction(context, createCarbonMsg(context));
+            return executeNonBlockingAction(context, createOutboundRequestMsg(context));
         } catch (ClientConnectorException clientConnectorException) {
             // This is should be a JavaError. Need to handle this properly.
             throw new BallerinaException("Failed to invoke 'get' action in " + Constants.CONNECTOR_NAME
@@ -71,10 +71,9 @@ public class Get extends AbstractHTTPAction {
         }
     }
 
-    protected HTTPCarbonMessage createCarbonMsg(Context context) {
-        HTTPCarbonMessage cMsg = super.createCarbonMsg(context);
-        cMsg.setProperty(Constants.HTTP_METHOD, Constants.HTTP_METHOD_GET);
-        return cMsg;
+    protected HTTPCarbonMessage createOutboundRequestMsg(Context context) {
+        HTTPCarbonMessage outboundReqMsg = super.createOutboundRequestMsg(context);
+        outboundReqMsg.setProperty(Constants.HTTP_METHOD, Constants.HTTP_METHOD_GET);
+        return outboundReqMsg;
     }
-
 }

--- a/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Head.java
+++ b/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Head.java
@@ -66,16 +66,16 @@ public class Head extends AbstractHTTPAction {
 
         try {
             // Execute the operation
-            return executeNonBlockingAction(context, createCarbonMsg(context));
+            return executeNonBlockingAction(context, createOutboundRequestMsg(context));
         } catch (ClientConnectorException clientConnectorException) {
             throw new BallerinaException("Failed to invoke 'head' action in " + Constants.CONNECTOR_NAME
                     + ". " + clientConnectorException.getMessage(), context);
         }
     }
 
-    protected HTTPCarbonMessage createCarbonMsg(Context context) {
-        HTTPCarbonMessage cMsg = super.createCarbonMsg(context);
-        cMsg.setProperty(Constants.HTTP_METHOD, Constants.HTTP_METHOD_HEAD);
-        return cMsg;
+    protected HTTPCarbonMessage createOutboundRequestMsg(Context context) {
+        HTTPCarbonMessage outboundReqMsg = super.createOutboundRequestMsg(context);
+        outboundReqMsg.setProperty(Constants.HTTP_METHOD, Constants.HTTP_METHOD_HEAD);
+        return outboundReqMsg;
     }
 }

--- a/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Options.java
+++ b/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Options.java
@@ -65,16 +65,16 @@ public class Options extends AbstractHTTPAction {
             logger.debug("Executing Native Action : {}", this.getName());
         }
         try {
-            return executeNonBlockingAction(context, createCarbonMsg(context));
+            return executeNonBlockingAction(context, createOutboundRequestMsg(context));
         } catch (ClientConnectorException clientConnectorException) {
             throw new BallerinaException("Failed to invoke 'options' action in " + Constants.CONNECTOR_NAME
                     + ". " + clientConnectorException.getMessage(), context);
         }
     }
 
-    protected HTTPCarbonMessage createCarbonMsg(Context context) {
-        HTTPCarbonMessage cMsg = super.createCarbonMsg(context);
-        cMsg.setProperty(Constants.HTTP_METHOD, Constants.HTTP_METHOD_OPTIONS);
-        return cMsg;
+    protected HTTPCarbonMessage createOutboundRequestMsg(Context context) {
+        HTTPCarbonMessage outboundRequestMsg = super.createOutboundRequestMsg(context);
+        outboundRequestMsg.setProperty(Constants.HTTP_METHOD, Constants.HTTP_METHOD_OPTIONS);
+        return outboundRequestMsg;
     }
 }

--- a/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Patch.java
+++ b/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Patch.java
@@ -66,17 +66,17 @@ public class Patch extends AbstractHTTPAction {
 
         try {
             // Execute the operation
-            return executeNonBlockingAction(context, createCarbonMsg(context));
+            return executeNonBlockingAction(context, createOutboundRequestMsg(context));
         } catch (ClientConnectorException clientConnectorException) {
             throw new BallerinaException("Failed to invoke 'patch' action in " + Constants.CONNECTOR_NAME
                     + ". " + clientConnectorException.getMessage(), context);
         }
     }
 
-    protected HTTPCarbonMessage createCarbonMsg(Context context) {
-        HTTPCarbonMessage cMsg = super.createCarbonMsg(context);
-        cMsg.setProperty(Constants.HTTP_METHOD, Constants.HTTP_METHOD_PATCH);
-        return cMsg;
+    protected HTTPCarbonMessage createOutboundRequestMsg(Context context) {
+        HTTPCarbonMessage outboundRequestMsg = super.createOutboundRequestMsg(context);
+        outboundRequestMsg.setProperty(Constants.HTTP_METHOD, Constants.HTTP_METHOD_PATCH);
+        return outboundRequestMsg;
     }
 
 }

--- a/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Post.java
+++ b/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Post.java
@@ -65,16 +65,16 @@ public class Post extends AbstractHTTPAction {
         }
         try {
             // Execute the operation
-            return executeNonBlockingAction(context, createCarbonMsg(context));
+            return executeNonBlockingAction(context, createOutboundRequestMsg(context));
         } catch (ClientConnectorException clientConnectorException) {
             throw new BallerinaException("Failed to invoke 'post' action in " + Constants.CONNECTOR_NAME
                     + ". " + clientConnectorException.getMessage(), context);
         }
     }
 
-    protected HTTPCarbonMessage createCarbonMsg(Context context) {
-        HTTPCarbonMessage cMsg = super.createCarbonMsg(context);
-        cMsg.setProperty(Constants.HTTP_METHOD, Constants.HTTP_METHOD_POST);
-        return cMsg;
+    protected HTTPCarbonMessage createOutboundRequestMsg(Context context) {
+        HTTPCarbonMessage outboundRequestMsg = super.createOutboundRequestMsg(context);
+        outboundRequestMsg.setProperty(Constants.HTTP_METHOD, Constants.HTTP_METHOD_POST);
+        return outboundRequestMsg;
     }
 }

--- a/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Put.java
+++ b/modules/ballerina-http/src/main/java/org/ballerinalang/net/http/actions/Put.java
@@ -66,17 +66,17 @@ public class Put extends AbstractHTTPAction {
 
         try {
             // Execute the operation
-            return executeNonBlockingAction(context, createCarbonMsg(context));
+            return executeNonBlockingAction(context, createOutboundRequestMsg(context));
         } catch (ClientConnectorException clientConnectorException) {
             throw new BallerinaException("Failed to invoke 'put' action in " + Constants.CONNECTOR_NAME
                     + ". " + clientConnectorException.getMessage(), context);
         }
     }
 
-    protected HTTPCarbonMessage createCarbonMsg(Context context) {
-        HTTPCarbonMessage cMsg = super.createCarbonMsg(context);
-        cMsg.setProperty(Constants.HTTP_METHOD, Constants.HTTP_METHOD_PUT);
-        return cMsg;
+    protected HTTPCarbonMessage createOutboundRequestMsg(Context context) {
+        HTTPCarbonMessage outboundRequestMsg = super.createOutboundRequestMsg(context);
+        outboundRequestMsg.setProperty(Constants.HTTP_METHOD, Constants.HTTP_METHOD_PUT);
+        return outboundRequestMsg;
     }
 
 }


### PR DESCRIPTION
We have done improvements in transport to notify relevant error messages when something goes wrong. These error messages are reflected in onError event. This PR uses that onError events to recover any blocked or running threads from failures. 

In addition to that, I have done some refactoring to make the code more readable and maintainable. 